### PR TITLE
Fix code sample alignment

### DIFF
--- a/Vignettes/chondro/chondro.Rnw
+++ b/Vignettes/chondro/chondro.Rnw
@@ -239,10 +239,10 @@ are put again into \Rclass{hyperSpec} objects by \Rfunction{decomposition}:
 pca <- prcomp (chondro, center = TRUE)
 
 scores <- decomposition (chondro, pca$x, label.wavelength = "PC",
-												 label.spc = "score / a.u.")
+                         label.spc = "score / a.u.")
 
 loadings <- decomposition (chondro, t(pca$rotation), scores = FALSE,
-													 label.spc = "loading I / a.u.")
+                           label.spc = "loading I / a.u.")
 @
 
 Plotting the scores of each PC against all other gives a good idea


### PR DESCRIPTION
Fix code sample alignment so that line continuation does not flow out of the page in 6 in [PDF](https://cran.r-project.org/web/packages/hyperSpec/vignettes/chondro.pdf)