### PR TITLE
Fix for name of documentation chapter "Initialize"

### DIFF
--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -119,6 +119,7 @@
 }
 
 ##' Creating a hyperSpec Object
+##' 
 ##' Like other S4 objects, a hyperSpec object can be created by \code{new}. The
 ##' hyperSpec object is then \code{initialize}d using the given parameters.
 ##'


### PR DESCRIPTION
Now documentation of "Initialize" looks like this:

![image](https://user-images.githubusercontent.com/12725868/43039253-1ba2451c-8d32-11e8-9a4c-7c6c8baf1968.png)

The highlighted part should be the name and the remaining part should be the description. This pull request should fix it. 