### PR TITLE
Closes bug #100. Building of chondro.pdf continues even without package 'akima'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -206,7 +206,6 @@ Vignettes/fileio/spe/manuals.txt filter=lfs diff=lfs merge=lfs -text
 Vignettes/fileio/spe/noise.spe filter=lfs diff=lfs merge=lfs -text
 Vignettes/fileio/spe/polystyrene.SPE filter=lfs diff=lfs merge=lfs -text
 Vignettes/fileio/spe/readspe.h filter=lfs diff=lfs merge=lfs -text
-Vignettes/fileio/spe/read.spe.R filter=lfs diff=lfs merge=lfs -text
 Vignettes/fileio/spe/winspec.pdf filter=lfs diff=lfs merge=lfs -text
 Vignettes/fileio/sp.PerkinElmer/A1701001.SP filter=lfs diff=lfs merge=lfs -text
 Vignettes/fileio/sp.PerkinElmer/A1702001.SP filter=lfs diff=lfs merge=lfs -text

--- a/Vignettes/chondro/chondro.Rnw
+++ b/Vignettes/chondro/chondro.Rnw
@@ -462,7 +462,8 @@ image (chondro.bilinear,
   xlab = labels (chondro, "x"), ylab = labels (chondro, "y"), 
   col = DNAcols)
 } else {
-  plot (NULL)
+  plot(NULL, xlim=c(0, 1), ylim=c(0, 1))
+  text(0.5, 0.5, 'Package "akima" is required to create this plot')
 }
 @
 \begin{figure}[tbh]

--- a/Vignettes/fileio/spe/manuals.txt
+++ b/Vignettes/fileio/spe/manuals.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7eef10b6649f5ff6ed181ade804ec52c389692b426614329fe5176b0f1384c45
-size 457
+oid sha256:02e7f153858099e6a00e4529ebbb6ab296b053044f1449948fce8e13fdae5d13
+size 338

--- a/Vignettes/fileio/spe/read.spe.R
+++ b/Vignettes/fileio/spe/read.spe.R
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f608ddbbb51a356181b1ee06e55378080c438231e078db120358d6a04faf5e7
-size 9794

--- a/hyperSpec/DESCRIPTION
+++ b/hyperSpec/DESCRIPTION
@@ -35,7 +35,8 @@ Depends:
     R (>= 3.6.0),
     lattice,
     grid,
-    ggplot2 (>= 2.2.0)
+    ggplot2 (>= 2.2.0),
+    xml2
 Suggests:
     R.matlab,
     tripack,
@@ -62,7 +63,6 @@ Imports:
     utils,
     latticeExtra,
     lazyeval,
-    XML,
     dplyr
 URL: https://github.com/cbeleites/hyperSpec
 BugReports: https://github.com/cbeleites/hyperSpec/issues


### PR DESCRIPTION
If package is missing, we create empty axes with a text label in the middle (see pics below). Previously the build crashed on command `plot(NULL)` with the message `Error in plot.window(...) : need finite 'xlim' values`.