### PR TITLE
Hotfix/126 apply signature

### DIFF
--- a/Vignettes/fileio/fileio.Rnw
+++ b/Vignettes/fileio/fileio.Rnw
@@ -322,7 +322,7 @@ tableend   <- c (tablestart [-1] - 2, length (file))
 tables <- list ()
 for (t in seq_along (tablestart)){
   tmp <- file [tablestart [t] : tableend [t]]
-  tables [[t]] <- read.fwf (textConnection (tmp), c (5, 8, 12, 15, 9))
+  tables [[t]] <- read.fwf (textConnection (tmp), c (5, 8, 12, 15, 9), stringsAsFactors = TRUE)
   colnames (tables [[t]]) <- c("Intensity", "persistent", "Wavelength", "Spectrum", "Ref. ")
   tables [[t]]$type <- gsub ("[[:space:]]", "", file [tablestart [t] - 1])
 }

--- a/hyperSpec/DESCRIPTION
+++ b/hyperSpec/DESCRIPTION
@@ -3,8 +3,8 @@ Encoding: UTF-8
 Type: Package
 Title: Work with Hyperspectral Data, i.e. Spectra + Meta Information (Spatial,
     Time, Concentration, ...)
-Version: 0.99-20200319
-Date: 2020-03-19
+Version: 0.99-20200521
+Date: 2020-05-21
 Maintainer: Claudia Beleites <Claudia.Beleites@chemometrix.gmbh>
 Authors@R: c(
     person("Claudia",   "Beleites",  role = c("aut","cre", "dtc"), email = "Claudia.Beleites@chemometrix.gmbh"),
@@ -180,4 +180,4 @@ Collate:
     'write.txt.wide.R'
     'y-pastenames.R'
     'zzz.R'
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/hyperSpec/R/apply.R
+++ b/hyperSpec/R/apply.R
@@ -86,6 +86,7 @@
 ##'   \code{FUN}, see also the examples.
 ##' @param FUN function to compute the summary statistics
 ##' @param ... further arguments passed to \code{FUN}
+##' @param simplify ignored: apply for hyperSpec results are always simplified
 ##' @param label.wl,label.spc new labels for wavelength and spectral intensity
 ##'   axes
 ##' @param new.wavelength for \code{MARGIN = 2}: numeric vector or name of the
@@ -118,7 +119,9 @@
 ##'
 setMethod ("apply", signature = signature (X = "hyperSpec"),
            function (X, MARGIN, FUN, ...,
-                     label.wl = NULL, label.spc = NULL, new.wavelength = NULL){
+                     label.wl = NULL, label.spc = NULL, new.wavelength = NULL,
+                     simplify
+           ){
   validObject (X)
 
   if (missing (MARGIN)){                # apply for functions that the complete spectra matrix


### PR DESCRIPTION
This should hotfix issue #126 

- [x] locally on linux, `R CMD check --as-cran` passed on the current release and r-devel (with two NOTEs, that is the usual state for **hyperSpec**)
- [x] on win-builder, I get 1 NOTE on 
  - [x] oldrelease and
  - [x] release, but 
  - [x] ~~no answer (not even an error) on r-devel!?~~ after almost a day, I got the results for r-devel, and that's also the 1 NOTE

- [ ] `rhub::check_for_cran()`
  - [x] 1 NOTE on Windows Server 2008 R2 SP1, R-devel, 32/64 bit
  - [ ] 1 WARNING (LaTeX package missing) and 4 NOTES (the 2 I get locally, some R packages not available on the server, and `plot()` examples executing slowly) Fedora Linux, R-devel, clang, gfortran
  - [ ] Failure (PREPERROR) on Ubuntu Linux 16.04 LTS, R-release, GCC: not all depndencies are available on the server.