### PR TITLE
Fix/116 Update package startup message

### DIFF
--- a/hyperSpec/R/zzz.R
+++ b/hyperSpec/R/zzz.R
@@ -9,9 +9,10 @@
     'Package ',  desc$Package, ' (version ', desc$Version, ')\n\n',
 
     'To get started, try: \n',
-    '   vignette("', desc$Package, '")',       '\n',
-    '   package?', desc$Package,               '\n',
-    '   vignette(package = "', desc$Package, '")\n',
+    '   vignette("', desc$Package, '")',              '\n',
+    '   package?', desc$Package,                      '\n',
+    '   browseVignettes(package = "', desc$Package, '")\n',
+    '   vignette(package = "', desc$Package, '")',    '\n',
     # '   browseURL("', first_url, '") # Online documentation \n',
     '\n',
 

--- a/hyperSpec/R/zzz.R
+++ b/hyperSpec/R/zzz.R
@@ -2,16 +2,24 @@
   unlockBinding(".options", asNamespace("hyperSpec"))
 
   desc <- utils::packageDescription("hyperSpec")
-  vers <- paste("V. ", desc$Version)
+  first_url <- sub(",.*$", "", desc$URL) # To use the first URL only
 
-  packageStartupMessage("Package ",  desc$Package, ", version ", desc$Version, "\n\n",
-    "To get started, try\n",
-    '   vignette ("hyperspec")\n',
-    "   package?hyperSpec \n",
-    '   vignette (package = "hyperSpec")\n\n',
-    "If you use this package please cite it appropriately.\n",
-    "   citation(\"hyperSpec\")\nwill give you the correct reference.", "\n\n",
-    "The project homepage is http://hyperspec.r-forge.r-project.org\n\n",
+  packageStartupMessage(
+    '\n\n',
+    'Package ',  desc$Package, ' (version ', desc$Version, ')\n\n',
+
+    'To get started, try: \n',
+    '   vignette("', desc$Package, '")',       '\n',
+    '   package?', desc$Package,               '\n',
+    '   vignette(package = "', desc$Package, '")\n',
+    # '   browseURL("', first_url, '") # Online documentation \n',
+    '\n',
+
+    'If you use this package, please cite it appropriately.\n',
+    'The correct reference is given by:\n',
+    '   citation("', desc$Package, '")\n\n',
+
+    "The project's website:\n   ", first_url, "\n\n",
     sep = ""
   )
 }

--- a/hyperSpec/R/zzz.R
+++ b/hyperSpec/R/zzz.R
@@ -9,7 +9,7 @@
     'Package ',  desc$Package, ' (version ', desc$Version, ')\n\n',
 
     'To get started, try: \n',
-    '   vignette("', desc$Package, '", package = "', desc$Package, '")', '\n',
+    '   vignette("', tolower(desc$Package), '", package = "', desc$Package, '")', '\n',
     '   package?', desc$Package,                      '\n',
     '   browseVignettes(package = "', desc$Package, '")\n',
     '   vignette(package = "', desc$Package, '")',    '\n',

--- a/hyperSpec/R/zzz.R
+++ b/hyperSpec/R/zzz.R
@@ -9,7 +9,7 @@
     'Package ',  desc$Package, ' (version ', desc$Version, ')\n\n',
 
     'To get started, try: \n',
-    '   vignette("', desc$Package, '")',              '\n',
+    '   vignette("', desc$Package, '", package = "', desc$Package, '")', '\n',
     '   package?', desc$Package,                      '\n',
     '   browseVignettes(package = "', desc$Package, '")\n',
     '   vignette(package = "', desc$Package, '")',    '\n',


### PR DESCRIPTION
All necessary pieces of information are taken from the fields of DESCRIPTION. So it's easier to maintain the message now.

```


Package hyperSpec (version 0.99-20200608)

To get started, try:
   vignette("hyperSpec")
   package?hyperSpec
   vignette(package = "hyperSpec")

If you use this package, please cite it appropriately.
The correct reference is given by:
   citation("hyperSpec")

The project's website:
   https://github.com/cbeleites/hyperSpec


```
On why only `first_url` is used. When #147 is merged and `pkgdown` website is published, the URL field in `DESCRIPTION` will look like this:

```
URL: 
    https://cbeleites.github.io/hyperSpec,
    https://github.com/cbeleites/hyperSpec
```
So in order not to give the users too much information, only the first URL is displayed in the message.

Closes #116.