### PR TITLE
Style documentation

### DIFF
--- a/hyperSpec/R/Arith.R
+++ b/hyperSpec/R/Arith.R
@@ -11,10 +11,12 @@
   validObject(e1)
   validObject(e2)
 
-  if (length(e2[[]]) > length(e1[[]]))
+  if (length(e2[[]]) > length(e1[[]])) {
     e1 <- .expand(e1, dim(e2) [c(1, 3)])
-  if (length(e1[[]]) > length(e2[[]]))
+  }
+  if (length(e1[[]]) > length(e2[[]])) {
     e2 <- .expand(e2, dim(e1) [c(1, 3)])
+  }
 
   e1[[]] <- callGeneric(e1[[]], e2[[]])
 
@@ -23,7 +25,7 @@
   e1
 }
 
-.test(.arith_hh) <- function(){
+.test(.arith_hh) <- function() {
   context("Arithmetic operators, 2 hyperSpec objects")
 
   tmp <- as.hyperSpec(matrix(1:length(flu[[]]), nrow = nrow(flu)))
@@ -32,7 +34,6 @@
 
   test_that("correct results for 2 equal-sized objects", {
     for (operator in c(`+`, `-`, `*`, `/`, `^`, `%%`, `%/%`)) {
-
       res <- operator(flu, tmp)
       expect_equal(res[[]], operator(flu[[]], tmp[[]]))
       expect_equal(res$.., cbind(flu$.., tmp$..))
@@ -49,7 +50,6 @@
 
   test_that("correct results with 1x1 object", {
   })
-
 }
 
 #' Arithmetical Operators: +, -, *, /, ^, %%, %/%, %*% for hyperSpec objects
@@ -128,13 +128,14 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .arith_hh)
 .arith_h_ <- function(e1, e2) {
   validObject(e1)
 
-  if (!missing(e2))
+  if (!missing(e2)) {
     stop("e2 must be missing")
+  }
 
   e1[[]] <- callGeneric(e1[[]])
   e1
 }
-.test(.arith_h_) <- function(){
+.test(.arith_h_) <- function() {
   context("Unary arithmetic operators")
 
   test_that("correct results", {
@@ -146,8 +147,9 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .arith_hh)
       expect_equal(wl(res), wl(flu))
     }
 
-    for (operator in c(`*`, `/`, `^`, `%%`, `%/%`))
+    for (operator in c(`*`, `/`, `^`, `%%`, `%/%`)) {
       expect_error(operator(flu))
+    }
   })
 
   test_that("unary -", {
@@ -167,17 +169,19 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
 .arith_hn <- function(e1, e2) {
   validObject(e1)
 
-  if (length(e2) > length(e1[[]]))
+  if (length(e2) > length(e1[[]])) {
     e1 <- .expand(e1, dim(e2))
-  if (length(e1[[]]) > length(e2))
+  }
+  if (length(e1[[]]) > length(e2)) {
     e2 <- .expand(e2, dim(e1) [c(1, 3)])
+  }
 
   e1[[]] <- callGeneric(e1[[]], e2)
 
   e1
 }
 
-.test(.arith_hn) <- function(){
+.test(.arith_hn) <- function() {
   context("Arithmetic operators, hyperSpec object x")
 
   test_that("correct results with scalar", {
@@ -200,7 +204,7 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
     }
   })
 
-    test_that("correct results with vector for rows", {
+  test_that("correct results with vector for rows", {
     v <- 1:nwl(flu)
 
     for (operator in c(`+`, `-`, `*`, `/`, `^`, `%%`, `%/%`)) {
@@ -255,7 +259,6 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
     expect_equal(as.matrix(flu + 1), as.matrix(flu) + 1)
     expect_equal(as.matrix(1 + flu), as.matrix(flu) + 1)
   })
-
 }
 
 
@@ -266,16 +269,18 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "matrix"), .arith_hn)
 
 ## arithmetic function called with second parameter hyperSpec
 .arith_nh <- function(e1, e2) {
-  #e1 <- as.matrix(e1)
+  # e1 <- as.matrix(e1)
   validObject(e2)
 
   ## called /only/ with e2 hyperSpec but e1 numeric
-  if (length(e2[[]]) > length(e1))
+  if (length(e2[[]]) > length(e1)) {
     e1 <- .expand(e1, dim(e2) [c(1, 3)])
-  if (length(e1) > length(e2[[]]))
+  }
+  if (length(e1) > length(e2[[]])) {
     e2 <- .expand(e2, dim(e1))
+  }
 
-  e2[[]] <- callGeneric(e1,e2[[]])
+  e2[[]] <- callGeneric(e1, e2[[]])
   e2
 }
 
@@ -298,9 +303,9 @@ setMethod("Arith", signature(e1 = "matrix", e2 = "hyperSpec"), .arith_nh)
   x
 }
 
-.test(.matmul_hh) <- function(){
+.test(.matmul_hh) <- function() {
   context("matrix multiplication: 2 hyperSpec objects")
-  h <- flu[,,1:nrow(flu), wl.index = TRUE]
+  h <- flu[, , 1:nrow(flu), wl.index = TRUE]
   h$filename <- NULL
 
   test_that("correct result", {
@@ -314,7 +319,7 @@ setMethod("Arith", signature(e1 = "matrix", e2 = "hyperSpec"), .arith_nh)
 
     expect_equal(res$.., h$..)
 
-        expect_equal(wl(res), wl(flu))
+    expect_equal(wl(res), wl(flu))
   })
 }
 
@@ -354,7 +359,6 @@ setMethod("%*%", signature(x = "hyperSpec", y = "hyperSpec"), .matmul_hh)
 
     expect_equal(res$.., flu$.., )
   })
-
 }
 
 #' @rdname Arith
@@ -367,7 +371,7 @@ setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
   new("hyperSpec", wavelength = y@wavelength, spc = x %*% y@data$spc)
 }
 
-.test(.matmul_mh) <- function(){
+.test(.matmul_mh) <- function() {
   context("matrix multiplication: matrix x hyperSpec")
 
   m <- matrix(1:(2 * nrow(flu)), ncol = nrow(flu))
@@ -384,4 +388,3 @@ setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
 
 #' @rdname Arith
 setMethod("%*%", signature(x = "matrix", y = "hyperSpec"), .matmul_mh)
-

--- a/hyperSpec/R/Arith.R
+++ b/hyperSpec/R/Arith.R
@@ -52,75 +52,75 @@
 
 }
 
-##' Arithmetical Operators: +, -, *, /, ^, %%, %/%, %*% for hyperSpec objects
-##'
-##' The arithmetical operators `+`, `-`, `*`, `/`, `^`, `%%`, `%/%`, and `%*%`
-##' hyperSpec objects.
-##'
-##' You can use these operators in different ways:
-##' \preformatted{
-##' e1 + e2
-##'
-##' `+`(e1, e2)
-##'
-##' x %*% y `%*%`(x, y)
-##'
-##' -x }
-##'
-##' The arithmetical operators `+`, `-`, `*`, `/`, `^`, `%%`, `%/%`, and
-##' `%*%` work on the  spectra matrix of the hyperSpec object. They have their
-##' usual meaning (see [base::Arithmetic]).  The operators work also with
-##' one hyperSpec object and a numeric object or a matrix of the same
-##' size as the spectra matrix of the hyperSpec object.
-##'
-##' With numeric vectors [sweep()] may be more explicit.
-##'
-##' If you want to calculate on the extra data as well, use the data.frame
-##' `hyperSpec@data` directly or [`as.data.frame(x)`][as.data.frame()].
-##' @author C. Beleites
-##' @md
-##' @rdname Arith
-##' @docType methods
-##' @param e1,e2 or
-##' @param x,y either two hyperSpec objects or
-##'
-##'   one hyperSpec object and  matrix of same size as `x[[]]` or
-##'
-##'   a vector which length equalling either the number of rows or the number of
-##'   wavelengths of the hyperSpec object, or
-##'
-##'   a scalar (numeric of length 1).
-##' @return hyperSpec object with the new spectra matrix.
-##'
-##' If
-##' If the `e2` is a hyperSpec objects, its extra data columns will silently be
-##' dropped silently.
-##'
-##' @export
-##' @keywords methods arith
-##' @include paste.row.R
-##' @include unittest.R
-##' @include hyperspec-class.R
-##' @concept hyperSpec arithmetic
-##' @concept hyperSpec arithmetical operators
-##' @concept hyperSpec plus
-##' @concept hyperSpec division
-##' @concept hyperSpec spectra conversion
-##' @seealso [sweep()] for calculations with a vector and the spectra matrix.
-##'
-##' [methods::S4groupGeneric] for group generic methods.
-##'
-##' [base::Arithmetic] for the base arithmetic functions.
-##'
-##' [hyperSpec::Comparison] for comparison operators,
-##' [hyperSpec::Math] for mathematical group generic functions (Math
-##' and Math2 groups) working on hyperSpec objects.
-##' @examples
-##' flu + flu
-##' 1 / flu
-##' all((flu + flu - 2 * flu)[[]] == 0)
-##' -flu
-##' flu / flu$c
+#' Arithmetical Operators: +, -, *, /, ^, %%, %/%, %*% for hyperSpec objects
+#'
+#' The arithmetical operators `+`, `-`, `*`, `/`, `^`, `%%`, `%/%`, and `%*%`
+#' hyperSpec objects.
+#'
+#' You can use these operators in different ways:
+#' \preformatted{
+#' e1 + e2
+#'
+#' `+`(e1, e2)
+#'
+#' x %*% y `%*%`(x, y)
+#'
+#' -x }
+#'
+#' The arithmetical operators `+`, `-`, `*`, `/`, `^`, `%%`, `%/%`, and
+#' `%*%` work on the  spectra matrix of the hyperSpec object. They have their
+#' usual meaning (see [base::Arithmetic]).  The operators work also with
+#' one hyperSpec object and a numeric object or a matrix of the same
+#' size as the spectra matrix of the hyperSpec object.
+#'
+#' With numeric vectors [sweep()] may be more explicit.
+#'
+#' If you want to calculate on the extra data as well, use the data.frame
+#' `hyperSpec@data` directly or [`as.data.frame(x)`][as.data.frame()].
+#' @author C. Beleites
+#' @md
+#' @rdname Arith
+#' @docType methods
+#' @param e1,e2 or
+#' @param x,y either two hyperSpec objects or
+#'
+#'   one hyperSpec object and  matrix of same size as `x[[]]` or
+#'
+#'   a vector which length equalling either the number of rows or the number of
+#'   wavelengths of the hyperSpec object, or
+#'
+#'   a scalar (numeric of length 1).
+#' @return hyperSpec object with the new spectra matrix.
+#'
+#' If
+#' If the `e2` is a hyperSpec objects, its extra data columns will silently be
+#' dropped silently.
+#'
+#' @export
+#' @keywords methods arith
+#' @include paste.row.R
+#' @include unittest.R
+#' @include hyperspec-class.R
+#' @concept hyperSpec arithmetic
+#' @concept hyperSpec arithmetical operators
+#' @concept hyperSpec plus
+#' @concept hyperSpec division
+#' @concept hyperSpec spectra conversion
+#' @seealso [sweep()] for calculations with a vector and the spectra matrix.
+#'
+#' [methods::S4groupGeneric] for group generic methods.
+#'
+#' [base::Arithmetic] for the base arithmetic functions.
+#'
+#' [hyperSpec::Comparison] for comparison operators,
+#' [hyperSpec::Math] for mathematical group generic functions (Math
+#' and Math2 groups) working on hyperSpec objects.
+#' @examples
+#' flu + flu
+#' 1 / flu
+#' all((flu + flu - 2 * flu)[[]] == 0)
+#' -flu
+#' flu / flu$c
 setMethod("Arith", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .arith_hh)
 
 ## unary operators
@@ -159,7 +159,7 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .arith_hh)
   })
 }
 
-##' @rdname Arith
+#' @rdname Arith
 setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
 
 
@@ -259,9 +259,9 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
 }
 
 
-##' @rdname Arith
+#' @rdname Arith
 setMethod("Arith", signature(e1 = "hyperSpec", e2 = "numeric"), .arith_hn)
-##' @rdname Arith
+#' @rdname Arith
 setMethod("Arith", signature(e1 = "hyperSpec", e2 = "matrix"), .arith_hn)
 
 ## arithmetic function called with second parameter hyperSpec
@@ -279,10 +279,10 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "matrix"), .arith_hn)
   e2
 }
 
-##' @rdname Arith
+#' @rdname Arith
 setMethod("Arith", signature(e1 = "numeric", e2 = "hyperSpec"), .arith_nh)
 
-##' @rdname Arith
+#' @rdname Arith
 setMethod("Arith", signature(e1 = "matrix", e2 = "hyperSpec"), .arith_nh)
 
 
@@ -319,11 +319,11 @@ setMethod("Arith", signature(e1 = "matrix", e2 = "hyperSpec"), .arith_nh)
 }
 
 
-##' @rdname Arith
-##' @concept hyperSpec matrix multiplication
-##' @export
-##' @md
-##' @seealso  [base::matmult] for matrix multiplications with `%*%`.
+#' @rdname Arith
+#' @concept hyperSpec matrix multiplication
+#' @export
+#' @md
+#' @seealso  [base::matmult] for matrix multiplications with `%*%`.
 setMethod("%*%", signature(x = "hyperSpec", y = "hyperSpec"), .matmul_hh)
 
 ## matrix multiplication hyperSpec object %*% matrix
@@ -357,7 +357,7 @@ setMethod("%*%", signature(x = "hyperSpec", y = "hyperSpec"), .matmul_hh)
 
 }
 
-##' @rdname Arith
+#' @rdname Arith
 setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
 
 ## matrix multiplication matrix %*% hyperSpec object
@@ -382,6 +382,6 @@ setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
 }
 
 
-##' @rdname Arith
+#' @rdname Arith
 setMethod("%*%", signature(x = "matrix", y = "hyperSpec"), .matmul_mh)
 

--- a/hyperSpec/R/Compare.R
+++ b/hyperSpec/R/Compare.R
@@ -47,11 +47,9 @@
 #' @export
 #' @examples
 #'
-#' flu [,,445 ~ 450] > 300
+#' flu [, , 445 ~ 450] > 300
 #'
-#' all (flu == flu[[]])
-#'
-
+#' all(flu == flu[[]])
 setMethod(
   "Compare", signature(e1 = "hyperSpec", e2 = "hyperSpec"),
   function(e1, e2) {

--- a/hyperSpec/R/Compare.R
+++ b/hyperSpec/R/Compare.R
@@ -62,12 +62,12 @@ setMethod(
 
 .compx <- function(e1, e2) {
   validObject(e1)
-  callGeneric(e1 [[]], e2)
+  callGeneric(e1[[]], e2)
 }
 
 .compy <- function(e1, e2) {
   validObject(e2)
-  callGeneric(e1, e2 [[]])
+  callGeneric(e1, e2[[]])
 }
 
 #' @rdname Comparison

--- a/hyperSpec/R/Compare.R
+++ b/hyperSpec/R/Compare.R
@@ -1,56 +1,56 @@
-##' The comparison operators \code{>}, \code{<}, \code{>=}, \code{<=},
-##' \code{==}, and \code{!=} for \code{hyperSpec} objects.
-##'
-##' \code{all.equal} checks the equality of two hyperSpec objects.
-##'
-##' The comparison operators \code{>}, \code{<}, \code{>=}, \code{<=},
-##' \code{==}, and \code{!=} work on the spectra matrix of the \code{hyperSpec}
-##' object. They have their usual meaning (see \code{\link[base]{Comparison}}).
-##' The operators work also with one \code{hyperSpec} object and a numeric
-##' (scalar) object or a matrices of the same size as the spectra matrix of the
-##' \code{hyperSpec} object.
-##'
-##' With numeric vectors \code{\link[hyperSpec]{sweep}} might be more
-##' appropriate.
-##'
-##' If you want to calculate on the \code{data.frame} \code{hyperSpec@@data},
-##' you have to do this directly on \code{hyperSpec@@data}.
-##'
-##' @author C. Beleites
-##' @title Comparison of hyperSpec objects
-##' @name Comparison
-##' @rdname Comparison
-##' @docType methods
-##' @aliases Comparison Operators Compare,hyperSpec-method
-##' Compare,hyperSpec,hyperSpec-method <,hyperSpec,hyperSpec-method >,hyperSpec,hyperSpec-method
-##' <=,hyperSpec,hyperSpec-method >=,hyperSpec,hyperSpec-method ==,hyperSpec,hyperSpec-method
-##' !=,hyperSpec,hyperSpec-method Compare,hyperSpec,matrix-method Compare,hyperSpec,numeric-method
-##' Compare,matrix,hyperSpec-method Compare,numeric,hyperSpec-method
-##' @param e1,e2 Either two \code{hyperSpec} objects or one \code{hyperSpec}
-##'   object and matrix of same size as \code{hyperSpec[[]]} or a scalar
-##'   (numeric of length 1).
-##'
-##' As \code{hyperSpec} objects must have numeric spectra matrices, the
-##'   resulting matrix of the comparison is returned directly.
-##' @return a logical matrix for the comparison operators.
-##' @seealso \code{\link[hyperSpec]{sweep-methods}} for calculations involving
-##'   a vector and the spectral matrix.
-##'
-##' \code{\link[methods]{S4groupGeneric}} for group generic methods.
-##'
-##' \code{\link[base]{Comparison}} for the base comparison functions.
-##'
-##' \code{\link[hyperSpec]{Arith}} for arithmetic operators,
-##'   \code{\link[hyperSpec]{Math}} for mathematical group generic functions
-##'   (groups Math and Math2) working on \code{hyperSpec} objects.
-##' @keywords methods arith
-##' @export
-##' @examples
-##'
-##' flu [,,445 ~ 450] > 300
-##'
-##' all (flu == flu[[]])
-##'
+#' The comparison operators \code{>}, \code{<}, \code{>=}, \code{<=},
+#' \code{==}, and \code{!=} for \code{hyperSpec} objects.
+#'
+#' \code{all.equal} checks the equality of two hyperSpec objects.
+#'
+#' The comparison operators \code{>}, \code{<}, \code{>=}, \code{<=},
+#' \code{==}, and \code{!=} work on the spectra matrix of the \code{hyperSpec}
+#' object. They have their usual meaning (see \code{\link[base]{Comparison}}).
+#' The operators work also with one \code{hyperSpec} object and a numeric
+#' (scalar) object or a matrices of the same size as the spectra matrix of the
+#' \code{hyperSpec} object.
+#'
+#' With numeric vectors \code{\link[hyperSpec]{sweep}} might be more
+#' appropriate.
+#'
+#' If you want to calculate on the \code{data.frame} \code{hyperSpec@@data},
+#' you have to do this directly on \code{hyperSpec@@data}.
+#'
+#' @author C. Beleites
+#' @title Comparison of hyperSpec objects
+#' @name Comparison
+#' @rdname Comparison
+#' @docType methods
+#' @aliases Comparison Operators Compare,hyperSpec-method
+#' Compare,hyperSpec,hyperSpec-method <,hyperSpec,hyperSpec-method >,hyperSpec,hyperSpec-method
+#' <=,hyperSpec,hyperSpec-method >=,hyperSpec,hyperSpec-method ==,hyperSpec,hyperSpec-method
+#' !=,hyperSpec,hyperSpec-method Compare,hyperSpec,matrix-method Compare,hyperSpec,numeric-method
+#' Compare,matrix,hyperSpec-method Compare,numeric,hyperSpec-method
+#' @param e1,e2 Either two \code{hyperSpec} objects or one \code{hyperSpec}
+#'   object and matrix of same size as \code{hyperSpec[[]]} or a scalar
+#'   (numeric of length 1).
+#'
+#' As \code{hyperSpec} objects must have numeric spectra matrices, the
+#'   resulting matrix of the comparison is returned directly.
+#' @return a logical matrix for the comparison operators.
+#' @seealso \code{\link[hyperSpec]{sweep-methods}} for calculations involving
+#'   a vector and the spectral matrix.
+#'
+#' \code{\link[methods]{S4groupGeneric}} for group generic methods.
+#'
+#' \code{\link[base]{Comparison}} for the base comparison functions.
+#'
+#' \code{\link[hyperSpec]{Arith}} for arithmetic operators,
+#'   \code{\link[hyperSpec]{Math}} for mathematical group generic functions
+#'   (groups Math and Math2) working on \code{hyperSpec} objects.
+#' @keywords methods arith
+#' @export
+#' @examples
+#'
+#' flu [,,445 ~ 450] > 300
+#'
+#' all (flu == flu[[]])
+#'
 
 setMethod(
   "Compare", signature(e1 = "hyperSpec", e2 = "hyperSpec"),
@@ -72,12 +72,12 @@ setMethod(
   callGeneric(e1, e2 [[]])
 }
 
-##' @rdname Comparison
+#' @rdname Comparison
 setMethod("Compare", signature(e1 = "hyperSpec", e2 = "numeric"), .compx)
-##' @rdname Comparison
+#' @rdname Comparison
 setMethod("Compare", signature(e1 = "hyperSpec", e2 = "matrix"), .compx)
 
-##' @rdname Comparison
+#' @rdname Comparison
 setMethod("Compare", signature(e1 = "numeric", e2 = "hyperSpec"), .compy)
-##' @rdname Comparison
+#' @rdname Comparison
 setMethod("Compare", signature(e1 = "matrix", e2 = "hyperSpec"), .compy)

--- a/hyperSpec/R/DollarNames.R
+++ b/hyperSpec/R/DollarNames.R
@@ -1,16 +1,16 @@
-##' command line completion for $
-##'
-##' @aliases .DollarNames .DollarNames,hyperSpec-method
-##' @author C. Beleites
-##' @seealso \code{\link[utils]{.DollarNames}}
-##' @export
-##' @rdname dollarnames
-##' @keywords utilities
-##' @title command line completion for $
-##' @param x the hyperSpecobject
-##' @param pattern pattern to look for
-##' @return the name of the extra data slot
-##' @importFrom utils .DollarNames
+#' command line completion for $
+#'
+#' @aliases .DollarNames .DollarNames,hyperSpec-method
+#' @author C. Beleites
+#' @seealso \code{\link[utils]{.DollarNames}}
+#' @export
+#' @rdname dollarnames
+#' @keywords utilities
+#' @title command line completion for $
+#' @param x the hyperSpecobject
+#' @param pattern pattern to look for
+#' @return the name of the extra data slot
+#' @importFrom utils .DollarNames
 .DollarNames.hyperSpec <- function(x, pattern = "") {
   grep(pattern, colnames(x@data), value = TRUE)
 }

--- a/hyperSpec/R/Math.R
+++ b/hyperSpec/R/Math.R
@@ -37,9 +37,7 @@
 #' @export
 #' @examples
 #'
-#' 	log (flu)
-#'
-
+#' log(flu)
 setMethod(
   "Math2", signature(x = "hyperSpec"),
   function(x, digits) {

--- a/hyperSpec/R/Math.R
+++ b/hyperSpec/R/Math.R
@@ -43,7 +43,7 @@ setMethod(
   function(x, digits) {
     validObject(x)
 
-    x [[]] <- callGeneric(x[[]], digits)
+    x[[]] <- callGeneric(x[[]], digits)
 
     x
   }
@@ -59,7 +59,7 @@ setMethod(
   function(x, base = exp(1), ...) {
     validObject(x)
 
-    x [[]] <- log(x[[]], base = base)
+    x[[]] <- log(x[[]], base = base)
     x
   }
 )
@@ -75,7 +75,7 @@ setMethod(
       warning(paste("Do you really want to use", .Generic, "on a hyperSpec object?"))
     }
 
-    x [[]] <- callGeneric(x[[]])
+    x[[]] <- callGeneric(x[[]])
     x
   }
 )

--- a/hyperSpec/R/Math.R
+++ b/hyperSpec/R/Math.R
@@ -1,44 +1,44 @@
-##' Math Functions for hyperSpec Objects
-##'
-##' Mathematical functions for hyperSpec Objects.
-##'
-##' The functions \code{abs}, \code{sign}, \code{sqrt}, \code{floor},
-##' \code{ceiling}, \code{trunc}, \code{round}, \code{signif}, \code{exp},
-##' \code{log}, \code{expm1}, \code{log1p}, \code{cos}, \code{sin}, \code{tan},
-##' \code{acos}, \code{asin}, \code{atan}, \code{cosh}, \code{sinh},
-##' \code{tanh}, \code{acosh}, \code{asinh}, \code{atanh}, \code{lgamma},
-##' \code{gamma}, \code{digamma}, \code{trigamma}, \code{cumsum},
-##' \code{cumprod}, \code{cummax}, \code{cummin} for \code{hyperSpec} objects.
-##'
-##' @aliases  Math Math2 Math,hyperSpec-method Math2,hyperSpec-method abs,hyperSpec-method
-##' sign,hyperSpec-method sqrt,hyperSpec-method floor,hyperSpec-method ceiling,hyperSpec-method
-##' trunc,hyperSpec-method round,hyperSpec-method signif,hyperSpec-method exp,hyperSpec-method
-##' log,hyperSpec-method expm1,hyperSpec-method log1p,hyperSpec-method cos,hyperSpec-method
-##' sin,hyperSpec-method tan,hyperSpec-method acos,hyperSpec-method asin,hyperSpec-method
-##' atan,hyperSpec-method cosh,hyperSpec-method sinh,hyperSpec-method tanh,hyperSpec-method
-##' acosh,hyperSpec-method asinh,hyperSpec-method atanh,hyperSpec-method lgamma,hyperSpec-method
-##' gamma,hyperSpec-method digamma,hyperSpec-method trigamma,hyperSpec-method cumsum,hyperSpec-method
-##' cumprod,hyperSpec-method cummax,hyperSpec-method cummin,hyperSpec-method round,hyperSpec-method
-##' signif,hyperSpec-method
-##' @param x the \code{hyperSpec} object
-##' @param digits integer stating the rounding precision
-##' @return a \code{hyperSpec} object
-##' @rdname math
-##' @author C. Beleites
-##' @seealso \code{\link[methods]{S4groupGeneric}} for group generic methods.
-##'
-##' \code{\link[base]{Math}} for the base math functions.
-##'
-##' \code{\link[hyperSpec]{Arith}} for arithmetic operators,
-##'   \code{\link[hyperSpec]{Comparison}} for comparison operators, and
-##'   \code{\link[hyperSpec]{Summary}} for group generic functions working on
-##'   \code{hyperSpec} objects.
-##' @keywords methods math
-##' @export
-##' @examples
-##'
-##' 	log (flu)
-##'
+#' Math Functions for hyperSpec Objects
+#'
+#' Mathematical functions for hyperSpec Objects.
+#'
+#' The functions \code{abs}, \code{sign}, \code{sqrt}, \code{floor},
+#' \code{ceiling}, \code{trunc}, \code{round}, \code{signif}, \code{exp},
+#' \code{log}, \code{expm1}, \code{log1p}, \code{cos}, \code{sin}, \code{tan},
+#' \code{acos}, \code{asin}, \code{atan}, \code{cosh}, \code{sinh},
+#' \code{tanh}, \code{acosh}, \code{asinh}, \code{atanh}, \code{lgamma},
+#' \code{gamma}, \code{digamma}, \code{trigamma}, \code{cumsum},
+#' \code{cumprod}, \code{cummax}, \code{cummin} for \code{hyperSpec} objects.
+#'
+#' @aliases  Math Math2 Math,hyperSpec-method Math2,hyperSpec-method abs,hyperSpec-method
+#' sign,hyperSpec-method sqrt,hyperSpec-method floor,hyperSpec-method ceiling,hyperSpec-method
+#' trunc,hyperSpec-method round,hyperSpec-method signif,hyperSpec-method exp,hyperSpec-method
+#' log,hyperSpec-method expm1,hyperSpec-method log1p,hyperSpec-method cos,hyperSpec-method
+#' sin,hyperSpec-method tan,hyperSpec-method acos,hyperSpec-method asin,hyperSpec-method
+#' atan,hyperSpec-method cosh,hyperSpec-method sinh,hyperSpec-method tanh,hyperSpec-method
+#' acosh,hyperSpec-method asinh,hyperSpec-method atanh,hyperSpec-method lgamma,hyperSpec-method
+#' gamma,hyperSpec-method digamma,hyperSpec-method trigamma,hyperSpec-method cumsum,hyperSpec-method
+#' cumprod,hyperSpec-method cummax,hyperSpec-method cummin,hyperSpec-method round,hyperSpec-method
+#' signif,hyperSpec-method
+#' @param x the \code{hyperSpec} object
+#' @param digits integer stating the rounding precision
+#' @return a \code{hyperSpec} object
+#' @rdname math
+#' @author C. Beleites
+#' @seealso \code{\link[methods]{S4groupGeneric}} for group generic methods.
+#'
+#' \code{\link[base]{Math}} for the base math functions.
+#'
+#' \code{\link[hyperSpec]{Arith}} for arithmetic operators,
+#'   \code{\link[hyperSpec]{Comparison}} for comparison operators, and
+#'   \code{\link[hyperSpec]{Summary}} for group generic functions working on
+#'   \code{hyperSpec} objects.
+#' @keywords methods math
+#' @export
+#' @examples
+#'
+#' 	log (flu)
+#'
 
 setMethod(
   "Math2", signature(x = "hyperSpec"),
@@ -51,11 +51,11 @@ setMethod(
   }
 )
 
-##' @rdname math
-##' @param ... ignored
-##' @param base base of logarithm
-##' @export
-##' @aliases log log,hyperSpec-method
+#' @rdname math
+#' @param ... ignored
+#' @param base base of logarithm
+#' @export
+#' @aliases log log,hyperSpec-method
 setMethod(
   "log", signature(x = "hyperSpec"),
   function(x, base = exp(1), ...) {
@@ -66,8 +66,8 @@ setMethod(
   }
 )
 
-##' @rdname math
-##' @export
+#' @rdname math
+#' @export
 setMethod(
   "Math", signature(x = "hyperSpec"),
   function(x) {

--- a/hyperSpec/R/Summary.R
+++ b/hyperSpec/R/Summary.R
@@ -28,8 +28,7 @@
 #' @export
 #' @examples
 #'
-#' 	range (flu)
-#'
+#' range(flu)
 setMethod(
   "Summary", signature(x = "hyperSpec"),
   function(x, ..., na.rm = FALSE) {
@@ -52,7 +51,7 @@ setMethod(
 #' @export
 #' @examples
 #'
-#' is.na (flu [,, 405 ~ 410]);
+#' is.na(flu [, , 405 ~ 410])
 setMethod(
   "is.na", signature(x = "hyperSpec"),
   function(x) {
@@ -70,7 +69,7 @@ setMethod(
 #' @export
 #' @examples
 #'
-#' all_wl (flu > 100)
+#' all_wl(flu > 100)
 all_wl <- function(expression, na.rm = FALSE) {
   res <- rowSums(!expression, na.rm = TRUE) == 0
 
@@ -122,8 +121,8 @@ all_wl <- function(expression, na.rm = FALSE) {
 #' @export
 #' @examples
 #'
-#' any_wl (flu > 300)
-#' ! any_wl (is.na (flu))
+#' any_wl(flu > 300)
+#' !any_wl(is.na(flu))
 any_wl <- function(expression, na.rm = FALSE) {
   res <- rowSums(expression, na.rm = TRUE) > 0
 

--- a/hyperSpec/R/Summary.R
+++ b/hyperSpec/R/Summary.R
@@ -100,7 +100,7 @@ all_wl <- function(expression, na.rm = FALSE) {
 
   test_that("na.rm", {
     tmp <- flu
-    tmp [[3:4, , 450 ~ 460]] <- NA
+    tmp[[3:4, , 450 ~ 460]] <- NA
 
     expect_equal(
       all_wl(tmp > 100),
@@ -153,7 +153,7 @@ any_wl <- function(expression, na.rm = FALSE) {
 
   test_that("na.rm", {
     tmp <- flu
-    tmp [[3:4, , 450 ~ 460]] <- NA
+    tmp[[3:4, , 450 ~ 460]] <- NA
 
     expect_equal(
       any_wl(tmp > 400),

--- a/hyperSpec/R/Summary.R
+++ b/hyperSpec/R/Summary.R
@@ -1,35 +1,35 @@
-##' The functions
-##'
-##' \code{all}, \code{any},
-##'
-##' \code{sum}, \code{prod},
-##'
-##' \code{min}, \code{max},
-##'
-##' \code{range}, and
-##'
-##' \code{is.na}
-##'
-##' for \code{hyperSpec} objects.
-##'
-##' All these functions work on the spectra matrix.
-##' @name Summary
-##' @docType methods
-##' @rdname summary
-##' @aliases Summary,hyperSpec-method Summary all,hyperSpec-method
-##'   any,hyperSpec-method sum,hyperSpec-method prod,hyperSpec-method
-##'   min,hyperSpec-method max,hyperSpec-method range,hyperSpec-method
-##' @param x hyperSpec object
-##' @param ... further objects
-##' @param na.rm logical indicating whether missing values should be removed
-##' @return \code{sum}, \code{prod}, \code{min}, \code{max}, and \code{range} return  a numeric,
-##' \code{all}, \code{any}, and \code{is.na} a logical.
-##' @seealso \code{\link[base]{Summary}} for the base summary functions.
-##' @export
-##' @examples
-##'
-##' 	range (flu)
-##'
+#' The functions
+#'
+#' \code{all}, \code{any},
+#'
+#' \code{sum}, \code{prod},
+#'
+#' \code{min}, \code{max},
+#'
+#' \code{range}, and
+#'
+#' \code{is.na}
+#'
+#' for \code{hyperSpec} objects.
+#'
+#' All these functions work on the spectra matrix.
+#' @name Summary
+#' @docType methods
+#' @rdname summary
+#' @aliases Summary,hyperSpec-method Summary all,hyperSpec-method
+#'   any,hyperSpec-method sum,hyperSpec-method prod,hyperSpec-method
+#'   min,hyperSpec-method max,hyperSpec-method range,hyperSpec-method
+#' @param x hyperSpec object
+#' @param ... further objects
+#' @param na.rm logical indicating whether missing values should be removed
+#' @return \code{sum}, \code{prod}, \code{min}, \code{max}, and \code{range} return  a numeric,
+#' \code{all}, \code{any}, and \code{is.na} a logical.
+#' @seealso \code{\link[base]{Summary}} for the base summary functions.
+#' @export
+#' @examples
+#'
+#' 	range (flu)
+#'
 setMethod(
   "Summary", signature(x = "hyperSpec"),
   function(x, ..., na.rm = FALSE) {
@@ -46,13 +46,13 @@ setMethod(
   }
 )
 
-##' @rdname summary
-##' @aliases is.na,hyperSpec-method
-##' @seealso \code{\link[base]{all.equal}} and \code{\link[base]{isTRUE}}
-##' @export
-##' @examples
-##'
-##' is.na (flu [,, 405 ~ 410]);
+#' @rdname summary
+#' @aliases is.na,hyperSpec-method
+#' @seealso \code{\link[base]{all.equal}} and \code{\link[base]{isTRUE}}
+#' @export
+#' @examples
+#'
+#' is.na (flu [,, 405 ~ 410]);
 setMethod(
   "is.na", signature(x = "hyperSpec"),
   function(x) {
@@ -60,17 +60,17 @@ setMethod(
   }
 )
 
-##' \code{all_wl} and \code{any_wl} are shortcut function to check whether
-##' any or all intensities fulfill the condition per spectrum.
-##' \code{na.rm} behaviour is like \code{\link[base]{all}} and \code{\link[base]{any}}.
-##'
-##' @param expression expression that evaluates to a logical matrix of the same size as the spectra matrix
-##'
-##' @rdname summary
-##' @export
-##' @examples
-##'
-##' all_wl (flu > 100)
+#' \code{all_wl} and \code{any_wl} are shortcut function to check whether
+#' any or all intensities fulfill the condition per spectrum.
+#' \code{na.rm} behaviour is like \code{\link[base]{all}} and \code{\link[base]{any}}.
+#'
+#' @param expression expression that evaluates to a logical matrix of the same size as the spectra matrix
+#'
+#' @rdname summary
+#' @export
+#' @examples
+#'
+#' all_wl (flu > 100)
 all_wl <- function(expression, na.rm = FALSE) {
   res <- rowSums(!expression, na.rm = TRUE) == 0
 
@@ -118,12 +118,12 @@ all_wl <- function(expression, na.rm = FALSE) {
   })
 }
 
-##' @rdname summary
-##' @export
-##' @examples
-##'
-##' any_wl (flu > 300)
-##' ! any_wl (is.na (flu))
+#' @rdname summary
+#' @export
+#' @examples
+#'
+#' any_wl (flu > 300)
+#' ! any_wl (is.na (flu))
 any_wl <- function(expression, na.rm = FALSE) {
   res <- rowSums(expression, na.rm = TRUE) > 0
 

--- a/hyperSpec/R/aggregate.R
+++ b/hyperSpec/R/aggregate.R
@@ -110,45 +110,52 @@
 #' @import stats
 #' @include hyperspec-class.R
 #' @examples
-#' region.means <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
-#' plot(region.means, stacked = ".aggregate", fill = ".aggregate",
-#'      col = matlab.dark.palette (3))
+#' region.means <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
+#' plot(region.means,
+#'   stacked = ".aggregate", fill = ".aggregate",
+#'   col = matlab.dark.palette(3)
+#' )
 #'
 #' ## make some "spectra"
-#' spc <- new ("hyperSpec", spc = sweep (matrix (rnorm (10*20), ncol = 20), 1, (1:10)*5, "+"))
+#' spc <- new("hyperSpec", spc = sweep(matrix(rnorm(10 * 20), ncol = 20), 1, (1:10) * 5, "+"))
 #'
 #' ## 3 groups
 #' color <- c("red", "blue", "black")
-#' by <- as.factor (c (1, 1, 1, 1, 1, 1, 5, 1, 2, 2))
+#' by <- as.factor(c(1, 1, 1, 1, 1, 1, 5, 1, 2, 2))
 #' by
-#' plot (spc, "spc", col = color[by])
+#' plot(spc, "spc", col = color[by])
 #'
 #' ## Example 1: plot the mean of the groups
-#' plot (aggregate (spc, by, mean), "spc", col = color, add = TRUE,
-#'       lines.args = list(lwd = 3, lty = 2))
+#' plot(aggregate(spc, by, mean), "spc",
+#'   col = color, add = TRUE,
+#'   lines.args = list(lwd = 3, lty = 2)
+#' )
 #'
 #' ## Example 2: FUN may return more than one value (here: 3)
-#' plot (aggregate (spc, by, mean_pm_sd), "spc",
-#'       col = rep(color, each = 3), lines.args = list(lwd = 3, lty = 2))
+#' plot(aggregate(spc, by, mean_pm_sd), "spc",
+#'   col = rep(color, each = 3), lines.args = list(lwd = 3, lty = 2)
+#' )
 #'
 #' ## Example 3: aggregate even takes FUN that return different numbers of
 #' ##            values for different groups
-#' plot (spc, "spc", col = color[by])
+#' plot(spc, "spc", col = color[by])
 #'
-#' weird.function <- function (x){
-#'    if (length (x) == 1)
-#'       x + 1 : 10
-#'    else if (length (x) == 2)
-#'       NULL
-#'    else
-#'       x [1]
+#' weird.function <- function(x) {
+#'   if (length(x) == 1) {
+#'     x + 1:10
+#'   } else if (length(x) == 2) {
+#'     NULL
+#'   } else {
+#'     x [1]
+#'   }
 #' }
 #'
-#' agg <- aggregate (spc, by, weird.function)
+#' agg <- aggregate(spc, by, weird.function)
 #' agg$.aggregate
-#' plot (agg, "spc",  add = TRUE, col = color[agg$.aggregate],
-#'       lines.args = list (lwd = 3, lty = 2))
-#'
+#' plot(agg, "spc",
+#'   add = TRUE, col = color[agg$.aggregate],
+#'   lines.args = list(lwd = 3, lty = 2)
+#' )
 setMethod("aggregate", signature = signature(x = "hyperSpec"), .aggregate)
 
 

--- a/hyperSpec/R/aggregate.R
+++ b/hyperSpec/R/aggregate.R
@@ -61,94 +61,94 @@
 }
 
 
-##' aggregate hyperSpec objects
-##'
-##' Compute summary statistics for subsets of a \code{hyperSpec} object.
-##'
-##' \code{aggregate} applies \code{FUN} to each of the subgroups given by
-##' \code{by}. It combines the functionality of \code{\link[stats]{aggregate}},
-##' \code{\link[base]{tapply}}, and \code{\link[stats]{ave}} for hyperSpec
-##' objects.
-##'
-##' \code{aggregate} avoids splitting \code{x@@data}.
-##'
-##' \code{FUN} does not need to return exactly one value.  The number of
-##' returned values needs to be the same for all wavelengths (otherwise the
-##' result could not be a matrix), see the examples.
-##'
-##' If the initially preallocated \code{data.frame} turns out to be too small,
-##' more rows are appended and a warning is issued.
-##'
-##' @include hyperspec-class.R
-##' @aliases aggregate,hyperSpec-method ave,hyperSpec-method
-##' @name aggregate
-##' @docType methods
-##' @param x a \code{hyperSpec} object
-##' @param by grouping for the rows of \code{x@@data}.
-##'
-##' Either a list containing an index vector for each of the subgroups or a
-##'   vector that can be \code{split} in such a list.
-##' @param FUN function to compute the summary statistics
-##' @param out.rows number of rows in the resulting \code{hyperSpec} object,
-##'   for memory preallocation.
-##' @param append.rows If more rows are needed, how many should be appended?
-##'
-##' Defaults to 100 or an estimate based on the percentage of groups that are
-##'   still to be done, whatever is larger.
-##' @param by.isindex If a list is given in \code{by}: does the list already
-##'   contain the row indices of the groups? If \code{FALSE}, the list in
-##'   \code{by} is computed first (as in \code{\link[stats]{aggregate}}).
-##' @param ... further arguments passed to \code{FUN}
-##' @return A \code{hyperSpec} object with an additional column
-##'   \code{@@data$.aggregate} tracing which group the rows belong to.
-##' @author C. Beleites
-##' @seealso \code{\link[base]{tapply}}, \code{\link[stats]{aggregate}},
-##'   \code{\link[stats]{ave}}
-##' @keywords methods category array
-##' @rdname aggregate
-##' @export
-##' @import stats
-##' @include hyperspec-class.R
-##' @examples
-##' region.means <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
-##' plot(region.means, stacked = ".aggregate", fill = ".aggregate",
-##'      col = matlab.dark.palette (3))
-##'
-##' ## make some "spectra"
-##' spc <- new ("hyperSpec", spc = sweep (matrix (rnorm (10*20), ncol = 20), 1, (1:10)*5, "+"))
-##'
-##' ## 3 groups
-##' color <- c("red", "blue", "black")
-##' by <- as.factor (c (1, 1, 1, 1, 1, 1, 5, 1, 2, 2))
-##' by
-##' plot (spc, "spc", col = color[by])
-##'
-##' ## Example 1: plot the mean of the groups
-##' plot (aggregate (spc, by, mean), "spc", col = color, add = TRUE,
-##'       lines.args = list(lwd = 3, lty = 2))
-##'
-##' ## Example 2: FUN may return more than one value (here: 3)
-##' plot (aggregate (spc, by, mean_pm_sd), "spc",
-##'       col = rep(color, each = 3), lines.args = list(lwd = 3, lty = 2))
-##'
-##' ## Example 3: aggregate even takes FUN that return different numbers of
-##' ##            values for different groups
-##' plot (spc, "spc", col = color[by])
-##'
-##' weird.function <- function (x){
-##'    if (length (x) == 1)
-##'       x + 1 : 10
-##'    else if (length (x) == 2)
-##'       NULL
-##'    else
-##'       x [1]
-##' }
-##'
-##' agg <- aggregate (spc, by, weird.function)
-##' agg$.aggregate
-##' plot (agg, "spc",  add = TRUE, col = color[agg$.aggregate],
-##'       lines.args = list (lwd = 3, lty = 2))
-##'
+#' aggregate hyperSpec objects
+#'
+#' Compute summary statistics for subsets of a \code{hyperSpec} object.
+#'
+#' \code{aggregate} applies \code{FUN} to each of the subgroups given by
+#' \code{by}. It combines the functionality of \code{\link[stats]{aggregate}},
+#' \code{\link[base]{tapply}}, and \code{\link[stats]{ave}} for hyperSpec
+#' objects.
+#'
+#' \code{aggregate} avoids splitting \code{x@@data}.
+#'
+#' \code{FUN} does not need to return exactly one value.  The number of
+#' returned values needs to be the same for all wavelengths (otherwise the
+#' result could not be a matrix), see the examples.
+#'
+#' If the initially preallocated \code{data.frame} turns out to be too small,
+#' more rows are appended and a warning is issued.
+#'
+#' @include hyperspec-class.R
+#' @aliases aggregate,hyperSpec-method ave,hyperSpec-method
+#' @name aggregate
+#' @docType methods
+#' @param x a \code{hyperSpec} object
+#' @param by grouping for the rows of \code{x@@data}.
+#'
+#' Either a list containing an index vector for each of the subgroups or a
+#'   vector that can be \code{split} in such a list.
+#' @param FUN function to compute the summary statistics
+#' @param out.rows number of rows in the resulting \code{hyperSpec} object,
+#'   for memory preallocation.
+#' @param append.rows If more rows are needed, how many should be appended?
+#'
+#' Defaults to 100 or an estimate based on the percentage of groups that are
+#'   still to be done, whatever is larger.
+#' @param by.isindex If a list is given in \code{by}: does the list already
+#'   contain the row indices of the groups? If \code{FALSE}, the list in
+#'   \code{by} is computed first (as in \code{\link[stats]{aggregate}}).
+#' @param ... further arguments passed to \code{FUN}
+#' @return A \code{hyperSpec} object with an additional column
+#'   \code{@@data$.aggregate} tracing which group the rows belong to.
+#' @author C. Beleites
+#' @seealso \code{\link[base]{tapply}}, \code{\link[stats]{aggregate}},
+#'   \code{\link[stats]{ave}}
+#' @keywords methods category array
+#' @rdname aggregate
+#' @export
+#' @import stats
+#' @include hyperspec-class.R
+#' @examples
+#' region.means <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
+#' plot(region.means, stacked = ".aggregate", fill = ".aggregate",
+#'      col = matlab.dark.palette (3))
+#'
+#' ## make some "spectra"
+#' spc <- new ("hyperSpec", spc = sweep (matrix (rnorm (10*20), ncol = 20), 1, (1:10)*5, "+"))
+#'
+#' ## 3 groups
+#' color <- c("red", "blue", "black")
+#' by <- as.factor (c (1, 1, 1, 1, 1, 1, 5, 1, 2, 2))
+#' by
+#' plot (spc, "spc", col = color[by])
+#'
+#' ## Example 1: plot the mean of the groups
+#' plot (aggregate (spc, by, mean), "spc", col = color, add = TRUE,
+#'       lines.args = list(lwd = 3, lty = 2))
+#'
+#' ## Example 2: FUN may return more than one value (here: 3)
+#' plot (aggregate (spc, by, mean_pm_sd), "spc",
+#'       col = rep(color, each = 3), lines.args = list(lwd = 3, lty = 2))
+#'
+#' ## Example 3: aggregate even takes FUN that return different numbers of
+#' ##            values for different groups
+#' plot (spc, "spc", col = color[by])
+#'
+#' weird.function <- function (x){
+#'    if (length (x) == 1)
+#'       x + 1 : 10
+#'    else if (length (x) == 2)
+#'       NULL
+#'    else
+#'       x [1]
+#' }
+#'
+#' agg <- aggregate (spc, by, weird.function)
+#' agg$.aggregate
+#' plot (agg, "spc",  add = TRUE, col = color[agg$.aggregate],
+#'       lines.args = list (lwd = 3, lty = 2))
+#'
 setMethod("aggregate", signature = signature(x = "hyperSpec"), .aggregate)
 
 

--- a/hyperSpec/R/aggregate.R
+++ b/hyperSpec/R/aggregate.R
@@ -12,7 +12,7 @@
 
   # try a guess how many rows the result will have
   if (is.null(out.rows)) {
-    tmp <- .apply(data = x@data[by [[1]], , drop = FALSE], MARGIN = 2, FUN = FUN, ...)
+    tmp <- .apply(data = x@data[by[[1]], , drop = FALSE], MARGIN = 2, FUN = FUN, ...)
 
     out.rows <- nrow(tmp) * length(by)
   }
@@ -24,7 +24,7 @@
   r <- 1 # keeping track of the actually filled rows
 
   for (i in seq(along = by)) {
-    tmp <- .apply(data = x@data[by [[i]], , drop = FALSE], MARGIN = 2, FUN = FUN, ...)
+    tmp <- .apply(data = x@data[by[[i]], , drop = FALSE], MARGIN = 2, FUN = FUN, ...)
 
     prows <- nrow(tmp) - 1
 
@@ -170,8 +170,8 @@ setMethod("aggregate", signature = signature(x = "hyperSpec"), .aggregate)
 
     for (region in levels(faux_cell$region)) {
       expect_equivalent(
-        region.means [[region.means$region == region, ]],
-        apply(faux_cell [[faux_cell$region == region, ]], 2, mean_pm_sd)
+        region.means[[region.means$region == region, ]],
+        apply(faux_cell[[faux_cell$region == region, ]], 2, mean_pm_sd)
       )
     }
   })

--- a/hyperSpec/R/all.equal.R
+++ b/hyperSpec/R/all.equal.R
@@ -49,7 +49,7 @@
   }
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.all.equal) <- function() {
   context(".all.equal")
 
@@ -83,23 +83,23 @@
 }
 
 
-##' @aliases all.equal  all.equal,hyperSpec,hyperSpec-method
-##' @rdname Comparison
-##' @param target,current two \code{hyperSpec} objects that are tested for
-##'   equality
-##' @param ... handed to \code{\link[base]{all.equal}} when testing the slots of the
-##'   \code{hyperSpec} objects
-##' @param check.column.order If two objects have the same data, but the order
-##'   of the columns (determined by the names) differs, should they be regarded
-##'   as different?
-##' @param check.label Should the slot \code{label} be checked? \cr If the
-##'   labels differ only in the order of their entries, they are conidered
-##'   equal.
-##' @param check.attributes,check.names see \code{\link[base]{all.equal}}
-##' @param tolerance,wl.tolerance tolerances for checking wavelengths and data, respectively
-##' @return \code{all.equal} returns either \code{TRUE}, or a character vector describing the
-##' differences. In conditions, the result must therefore be tested with
-##' \code{\link[base]{isTRUE}}.
-##' @seealso \code{\link[base]{all.equal}} and \code{\link[base]{isTRUE}}
-##' @export
+#' @aliases all.equal  all.equal,hyperSpec,hyperSpec-method
+#' @rdname Comparison
+#' @param target,current two \code{hyperSpec} objects that are tested for
+#'   equality
+#' @param ... handed to \code{\link[base]{all.equal}} when testing the slots of the
+#'   \code{hyperSpec} objects
+#' @param check.column.order If two objects have the same data, but the order
+#'   of the columns (determined by the names) differs, should they be regarded
+#'   as different?
+#' @param check.label Should the slot \code{label} be checked? \cr If the
+#'   labels differ only in the order of their entries, they are conidered
+#'   equal.
+#' @param check.attributes,check.names see \code{\link[base]{all.equal}}
+#' @param tolerance,wl.tolerance tolerances for checking wavelengths and data, respectively
+#' @return \code{all.equal} returns either \code{TRUE}, or a character vector describing the
+#' differences. In conditions, the result must therefore be tested with
+#' \code{\link[base]{isTRUE}}.
+#' @seealso \code{\link[base]{all.equal}} and \code{\link[base]{isTRUE}}
+#' @export
 setMethod("all.equal", signature(target = "hyperSpec", current = "hyperSpec"), .all.equal)

--- a/hyperSpec/R/apply.R
+++ b/hyperSpec/R/apply.R
@@ -52,74 +52,74 @@
 
 
 
-##' apply
-##' Computes summary statistics for the spectra of a \code{hyperSpec} object.
-##'
-##' \code{apply} gives the functionality of \code{\link[base]{apply}} for
-##' \code{hyperSpec} objects.
-##'
-##' The generic functions of group \code{\link[methods]{Math}} are not definded
-##' for \code{hyperSpec} objects. Instead, \code{apply} can be used. For
-##' functions like \code{log} that work on scalars, \code{MARGIN = 1 : 2} gives
-##' the appropriate behaviour.
-##'
-##' \code{spcapply} does the same as \code{apply} with \code{MARGIN = 1}, but
-##' additionally allows to set a new wavelength axis and adjust the labels.
-##'
-##' \code{wlapply} does the same as \code{apply} with \code{MARGIN = 2}, but
-##' additionally allows to set a new wavelength axis and adjust the labels.
-##'
-##' @name apply
-##' @rdname apply
-##' @aliases apply apply,hyperSpec-method
-##' @docType methods
-##' @param X,spc a \code{hyperSpec} object
-##' @param MARGIN The subscript which the function will be applied over.
-##'
-##' \code{1} indicates rows (\code{FUN} is applied to each spectrum),
-##'
-##' \code{2} indicates columns (\code{FUN} is applied to each wavelength),
-##'
-##' \code{1 : 2} indicates that \code{FUN} should be applied to each single
-##'   element of the spectra matrix. Note that many basic mathematical
-##'   functions are already defined for hyperSpec objects (see
-##'   \code{\link{Math}}).
-##'
-##' If \code{MARGIN} is missing, the whole spectra matrix is handed to
-##'   \code{FUN}, see also the examples.
-##' @param FUN function to compute the summary statistics
-##' @param ... further arguments passed to \code{FUN}
-##' @param simplify ignored: apply for hyperSpec results are always simplified
-##' @param label.wl,label.spc new labels for wavelength and spectral intensity
-##'   axes
-##' @param new.wavelength for \code{MARGIN = 2}: numeric vector or name of the
-##'   argument in \dots{} that is to be used (character) as wavelength axis of
-##'   the resulting object.
-##' @return A \code{hyperSpec} object
-##' @author C. Beleites
-##' @seealso \code{\link[base]{apply}}, for applying \code{FUN} to subgroups of
-##'   the \code{hyperSpec} object: \code{\link[hyperSpec]{aggregate}}.
-##' @keywords methods iteration
-##' @export
-##' @examples
-##'
-##'
-##' plotspc (apply (faux_cell, 2, range))
-##'
-##' avgflu <- apply (flu, 1, mean,
-##'                  label.spc = expression (bar (I)),
-##'                  new.wavelength = mean (wl (flu)))
-##' avgflu
-##'
-##' flu[[,,405:407]]
-##' apply (flu, 1:2, "*", -1)[[,,405:407]]
-##'
-##' ## without MARGIN the whole matrix is handed to FUN
-##' apply (flu [,,405:407], , print) [[]]
-##'
-##' ## whereas MARGIN = 1 : 2 leads to FUN being called for each element separately
-##' apply (flu [,,405:407], 1 : 2, print) [[]]
-##'
+#' apply
+#' Computes summary statistics for the spectra of a \code{hyperSpec} object.
+#'
+#' \code{apply} gives the functionality of \code{\link[base]{apply}} for
+#' \code{hyperSpec} objects.
+#'
+#' The generic functions of group \code{\link[methods]{Math}} are not definded
+#' for \code{hyperSpec} objects. Instead, \code{apply} can be used. For
+#' functions like \code{log} that work on scalars, \code{MARGIN = 1 : 2} gives
+#' the appropriate behaviour.
+#'
+#' \code{spcapply} does the same as \code{apply} with \code{MARGIN = 1}, but
+#' additionally allows to set a new wavelength axis and adjust the labels.
+#'
+#' \code{wlapply} does the same as \code{apply} with \code{MARGIN = 2}, but
+#' additionally allows to set a new wavelength axis and adjust the labels.
+#'
+#' @name apply
+#' @rdname apply
+#' @aliases apply apply,hyperSpec-method
+#' @docType methods
+#' @param X,spc a \code{hyperSpec} object
+#' @param MARGIN The subscript which the function will be applied over.
+#'
+#' \code{1} indicates rows (\code{FUN} is applied to each spectrum),
+#'
+#' \code{2} indicates columns (\code{FUN} is applied to each wavelength),
+#'
+#' \code{1 : 2} indicates that \code{FUN} should be applied to each single
+#'   element of the spectra matrix. Note that many basic mathematical
+#'   functions are already defined for hyperSpec objects (see
+#'   \code{\link{Math}}).
+#'
+#' If \code{MARGIN} is missing, the whole spectra matrix is handed to
+#'   \code{FUN}, see also the examples.
+#' @param FUN function to compute the summary statistics
+#' @param ... further arguments passed to \code{FUN}
+#' @param simplify ignored: apply for hyperSpec results are always simplified
+#' @param label.wl,label.spc new labels for wavelength and spectral intensity
+#'   axes
+#' @param new.wavelength for \code{MARGIN = 2}: numeric vector or name of the
+#'   argument in \dots{} that is to be used (character) as wavelength axis of
+#'   the resulting object.
+#' @return A \code{hyperSpec} object
+#' @author C. Beleites
+#' @seealso \code{\link[base]{apply}}, for applying \code{FUN} to subgroups of
+#'   the \code{hyperSpec} object: \code{\link[hyperSpec]{aggregate}}.
+#' @keywords methods iteration
+#' @export
+#' @examples
+#'
+#'
+#' plotspc (apply (faux_cell, 2, range))
+#'
+#' avgflu <- apply (flu, 1, mean,
+#'                  label.spc = expression (bar (I)),
+#'                  new.wavelength = mean (wl (flu)))
+#' avgflu
+#'
+#' flu[[,,405:407]]
+#' apply (flu, 1:2, "*", -1)[[,,405:407]]
+#'
+#' ## without MARGIN the whole matrix is handed to FUN
+#' apply (flu [,,405:407], , print) [[]]
+#'
+#' ## whereas MARGIN = 1 : 2 leads to FUN being called for each element separately
+#' apply (flu [,,405:407], 1 : 2, print) [[]]
+#'
 setMethod ("apply", signature = signature (X = "hyperSpec"),
            function (X, MARGIN, FUN, ...,
                      label.wl = NULL, label.spc = NULL, new.wavelength = NULL,
@@ -193,7 +193,7 @@ setMethod ("apply", signature = signature (X = "hyperSpec"),
   }
 )
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.apply) <- function() {
   context("apply")
 

--- a/hyperSpec/R/apply.R
+++ b/hyperSpec/R/apply.R
@@ -104,28 +104,28 @@
 #' @examples
 #'
 #'
-#' plotspc (apply (faux_cell, 2, range))
+#' plotspc(apply(faux_cell, 2, range))
 #'
-#' avgflu <- apply (flu, 1, mean,
-#'                  label.spc = expression (bar (I)),
-#'                  new.wavelength = mean (wl (flu)))
+#' avgflu <- apply(flu, 1, mean,
+#'   label.spc = expression(bar(I)),
+#'   new.wavelength = mean(wl(flu))
+#' )
 #' avgflu
 #'
-#' flu[[,,405:407]]
-#' apply (flu, 1:2, "*", -1)[[,,405:407]]
+#' flu[[, , 405:407]]
+#' apply(flu, 1:2, "*", -1)[[, , 405:407]]
 #'
 #' ## without MARGIN the whole matrix is handed to FUN
-#' apply (flu [,,405:407], , print) [[]]
+#' apply(flu [, , 405:407], , print) [[]]
 #'
 #' ## whereas MARGIN = 1 : 2 leads to FUN being called for each element separately
-#' apply (flu [,,405:407], 1 : 2, print) [[]]
-#'
-setMethod ("apply", signature = signature (X = "hyperSpec"),
-           function (X, MARGIN, FUN, ...,
-                     label.wl = NULL, label.spc = NULL, new.wavelength = NULL,
-                     simplify
-           ){
-  validObject (X)
+#' apply(flu [, , 405:407], 1:2, print) [[]]
+setMethod("apply",
+  signature = signature(X = "hyperSpec"),
+  function(X, MARGIN, FUN, ...,
+           label.wl = NULL, label.spc = NULL, new.wavelength = NULL,
+           simplify) {
+    validObject(X)
 
     if (missing(MARGIN)) { # apply for functions that the complete spectra matrix
       ## is easier: tmp <- apply (x, , FUN, ...)

--- a/hyperSpec/R/apply.R
+++ b/hyperSpec/R/apply.R
@@ -116,10 +116,10 @@
 #' apply(flu, 1:2, "*", -1)[[, , 405:407]]
 #'
 #' ## without MARGIN the whole matrix is handed to FUN
-#' apply(flu [, , 405:407], , print) [[]]
+#' apply(flu [, , 405:407], , print)[[]]
 #'
 #' ## whereas MARGIN = 1 : 2 leads to FUN being called for each element separately
-#' apply(flu [, , 405:407], 1:2, print) [[]]
+#' apply(flu [, , 405:407], 1:2, print)[[]]
 setMethod("apply",
   signature = signature(X = "hyperSpec"),
   function(X, MARGIN, FUN, ...,
@@ -131,7 +131,7 @@ setMethod("apply",
       ## is easier: tmp <- apply (x, , FUN, ...)
       ## does:
       ## tmp <- x
-      ## tmp [[]] <- FUN (x [[]], ...)
+      ## tmp[[]] <- FUN (x[[]], ...)
 
       X@data$spc <- do.call(FUN, list(X@data$spc, ...))
     } else if (all(MARGIN == 1:2)) { # apply for functions that take scalar arguments.
@@ -162,7 +162,7 @@ setMethod("apply",
               .wl(X) <- new.wavelength
             } else {
               dots <- list(...)
-              .wl(X) <- dots [[new.wavelength]] # or as name of the argument that becomes the new
+              .wl(X) <- dots[[new.wavelength]] # or as name of the argument that becomes the new
               # wavelength vector
             }
           } else if (ncol(X@data$spc) != length(X@wavelength)) {

--- a/hyperSpec/R/as.data.frame.R
+++ b/hyperSpec/R/as.data.frame.R
@@ -1,26 +1,26 @@
-##' Conversion of a hyperSpec object into a data.frame or matrix
-##' \code{as.data.frame} returns \code{x@@data} (as data.frame) \code{as.matrix}
-##' returns the spectra matrix \code{x@@data$spc} as matrix
-##'
-##' @rdname asdataframe
-##' @name as.data.frame
-##' @aliases as.data.frame as.data.frame,hyperSpec-method as.data.frame.hyperSpec
-##' @docType methods
-##' @param x a \code{hyperSpec} object
-##' @param row.names if \code{TRUE}, a column \code{.row} is created containing row names or row
-##' indices if no rownames are set. If character vector, the rownames are set accordingly.
-##' @param optional ignored
-##' @return \code{x@@data} and \code{x@@data$spc} (== \code{x$spc} == \code{x [[]]}), respectively.
-##' @author C. Beleites
-##' @method as.data.frame hyperSpec
-##' @export
-##' @seealso \code{\link[base]{as.data.frame}}
-##' @keywords methods
-##' @examples
-##'
-##' as.data.frame (faux_cell [1:3,, 600 ~ 620])
-##' as.matrix (faux_cell [1:3,, 600 ~ 620])
-##' lm (c ~ spc, data = flu [,,450])
+#' Conversion of a hyperSpec object into a data.frame or matrix
+#' \code{as.data.frame} returns \code{x@@data} (as data.frame) \code{as.matrix}
+#' returns the spectra matrix \code{x@@data$spc} as matrix
+#'
+#' @rdname asdataframe
+#' @name as.data.frame
+#' @aliases as.data.frame as.data.frame,hyperSpec-method as.data.frame.hyperSpec
+#' @docType methods
+#' @param x a \code{hyperSpec} object
+#' @param row.names if \code{TRUE}, a column \code{.row} is created containing row names or row
+#' indices if no rownames are set. If character vector, the rownames are set accordingly.
+#' @param optional ignored
+#' @return \code{x@@data} and \code{x@@data$spc} (== \code{x$spc} == \code{x [[]]}), respectively.
+#' @author C. Beleites
+#' @method as.data.frame hyperSpec
+#' @export
+#' @seealso \code{\link[base]{as.data.frame}}
+#' @keywords methods
+#' @examples
+#'
+#' as.data.frame (faux_cell [1:3,, 600 ~ 620])
+#' as.matrix (faux_cell [1:3,, 600 ~ 620])
+#' lm (c ~ spc, data = flu [,,450])
 
 as.data.frame.hyperSpec <- function(x, row.names = TRUE, optional = NULL, ...) {
   validObject(x)
@@ -41,15 +41,15 @@ as.data.frame.hyperSpec <- function(x, row.names = TRUE, optional = NULL, ...) {
 
   x
 }
-##' @method as.matrix hyperSpec
-##' @rdname asdataframe
-##' @param ... ignored
-##' @aliases as.matrix as.matrix,hyperSpec-method
-##' @export
-##' @md
-##' @seealso and [base::as.matrix()]
-##'
-##' [`[[`()] (`[[]]`) for a shortcut to `as.matrix`
+#' @method as.matrix hyperSpec
+#' @rdname asdataframe
+#' @param ... ignored
+#' @aliases as.matrix as.matrix,hyperSpec-method
+#' @export
+#' @md
+#' @seealso and [base::as.matrix()]
+#'
+#' [`[[`()] (`[[]]`) for a shortcut to `as.matrix`
 as.matrix.hyperSpec <- function(x, ...) {
   validObject(x)
 
@@ -57,24 +57,24 @@ as.matrix.hyperSpec <- function(x, ...) {
 }
 
 
-##' `as.wide.df` converts the spectra matrix to a data.frame. The extra
-##' data together with this data is returned. The column names of the spectra
-##' matrix are retained (if they are numbers, without preceeding letters).
-##'
-##' @param wl.prefix prefix to prepend wavelength column names
-##' @rdname asdataframe
-##' @aliases  as.wide.df
-##' @export
-##' @md
-##' @return
-##'
-##' `as.wide.df` returns a data.frame that consists of the extra data and
-##'   the spectra matrix converted to a data.frame. The spectra matrix is
-##'   expanded *in place*.
-##' @examples
-##'
-##' as.wide.df (faux_cell [1:5,, 600 ~ 610])
-##' summary (as.wide.df (faux_cell [1:5,, 600 ~ 610]))
+#' `as.wide.df` converts the spectra matrix to a data.frame. The extra
+#' data together with this data is returned. The column names of the spectra
+#' matrix are retained (if they are numbers, without preceeding letters).
+#'
+#' @param wl.prefix prefix to prepend wavelength column names
+#' @rdname asdataframe
+#' @aliases  as.wide.df
+#' @export
+#' @md
+#' @return
+#'
+#' `as.wide.df` returns a data.frame that consists of the extra data and
+#'   the spectra matrix converted to a data.frame. The spectra matrix is
+#'   expanded *in place*.
+#' @examples
+#'
+#' as.wide.df (faux_cell [1:5,, 600 ~ 610])
+#' summary (as.wide.df (faux_cell [1:5,, 600 ~ 610]))
 
 as.wide.df <- function(x, wl.prefix = "") {
   chk.hy(x)
@@ -135,33 +135,33 @@ as.wide.df <- function(x, wl.prefix = "") {
   })
 }
 
-##' \code{as.long.df} returns a long-format data.frame.
-##'
-##' The data.frame returned by \code{as.long.df} is guaranteed to have columns
-##' \code{spc} and \code{.wavelength}. If \code{nwl (x) == 0} these columns
-##' will be \code{NA}.
-##'
-##' @rdname asdataframe
-##' @aliases as.long.df
-##' @param rownames should the rownames be in column \code{.rownames} of the
-##'   long-format data.frame?
-##' @param wl.factor should the wavelengths be returned as a factor (instead of
-##'   numeric)?
-##' @param na.rm if \code{TRUE}, rows where spc is not \code{NA} are deleted.
-##' @export
-##' @return \code{as.long.df} returns the stacked or molten version of \code{x@@data}. The
-##'   wavelengths are in column \code{.wavelength}.
-##' @seealso
-##'
-##' \code{\link[utils]{stack}} and \code{\link[reshape]{melt}} or \code{\link[reshape2]{melt}} for
-##' other functions producing long-format data.frames.
-##' @examples
-##'
-##' as.long.df (flu [,, 405 ~ 410])
-##' summary (as.long.df (flu [,, 405 ~ 410]))
-##' summary (as.long.df (flu [,, 405 ~ 410], rownames = TRUE))
-##' summary (as.long.df (flu [,, 405 ~ 410], wl.factor = TRUE))
-##'
+#' \code{as.long.df} returns a long-format data.frame.
+#'
+#' The data.frame returned by \code{as.long.df} is guaranteed to have columns
+#' \code{spc} and \code{.wavelength}. If \code{nwl (x) == 0} these columns
+#' will be \code{NA}.
+#'
+#' @rdname asdataframe
+#' @aliases as.long.df
+#' @param rownames should the rownames be in column \code{.rownames} of the
+#'   long-format data.frame?
+#' @param wl.factor should the wavelengths be returned as a factor (instead of
+#'   numeric)?
+#' @param na.rm if \code{TRUE}, rows where spc is not \code{NA} are deleted.
+#' @export
+#' @return \code{as.long.df} returns the stacked or molten version of \code{x@@data}. The
+#'   wavelengths are in column \code{.wavelength}.
+#' @seealso
+#'
+#' \code{\link[utils]{stack}} and \code{\link[reshape]{melt}} or \code{\link[reshape2]{melt}} for
+#' other functions producing long-format data.frames.
+#' @examples
+#'
+#' as.long.df (flu [,, 405 ~ 410])
+#' summary (as.long.df (flu [,, 405 ~ 410]))
+#' summary (as.long.df (flu [,, 405 ~ 410], rownames = TRUE))
+#' summary (as.long.df (flu [,, 405 ~ 410], wl.factor = TRUE))
+#'
 as.long.df <- function(x, rownames = FALSE, wl.factor = FALSE, na.rm = TRUE) {
   chk.hy(x)
   validObject(x)
@@ -214,24 +214,24 @@ as.long.df <- function(x, rownames = FALSE, wl.factor = FALSE, na.rm = TRUE) {
   tmp
 }
 
-##'
-##' \code{as.t.df} produces a 'transposed' data.frame with columns containing the spectra.
-##' @rdname asdataframe
-##' @aliases as.t.df
-##' @return \code{as.t.df} returns a data.frame similar to \code{as.long.df}, but each
-##'   spectrum in its own column. This is useful for exporting summary spectra,
-##'   see the example.
-##' @export
-##' @examples
-##' df <- as.t.df (apply (faux_cell, 2, mean_pm_sd))
-##' head (df)
-##'
-##' if (require (ggplot2)){
-##'   ggplot (df, aes (x = .wavelength)) +
-##'     geom_ribbon (aes (ymin = mean.minus.sd, ymax = mean.plus.sd),
-##'       fill = "#00000040") +
-##'     geom_line (aes (y = mean))
-##' }
+#'
+#' \code{as.t.df} produces a 'transposed' data.frame with columns containing the spectra.
+#' @rdname asdataframe
+#' @aliases as.t.df
+#' @return \code{as.t.df} returns a data.frame similar to \code{as.long.df}, but each
+#'   spectrum in its own column. This is useful for exporting summary spectra,
+#'   see the example.
+#' @export
+#' @examples
+#' df <- as.t.df (apply (faux_cell, 2, mean_pm_sd))
+#' head (df)
+#'
+#' if (require (ggplot2)){
+#'   ggplot (df, aes (x = .wavelength)) +
+#'     geom_ribbon (aes (ymin = mean.minus.sd, ymax = mean.plus.sd),
+#'       fill = "#00000040") +
+#'     geom_line (aes (y = mean))
+#' }
 as.t.df <- function(x) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/as.data.frame.R
+++ b/hyperSpec/R/as.data.frame.R
@@ -18,10 +18,9 @@
 #' @keywords methods
 #' @examples
 #'
-#' as.data.frame (faux_cell [1:3,, 600 ~ 620])
-#' as.matrix (faux_cell [1:3,, 600 ~ 620])
-#' lm (c ~ spc, data = flu [,,450])
-
+#' as.data.frame(faux_cell [1:3, , 600 ~ 620])
+#' as.matrix(faux_cell [1:3, , 600 ~ 620])
+#' lm(c ~ spc, data = flu [, , 450])
 as.data.frame.hyperSpec <- function(x, row.names = TRUE, optional = NULL, ...) {
   validObject(x)
 
@@ -73,9 +72,8 @@ as.matrix.hyperSpec <- function(x, ...) {
 #'   expanded *in place*.
 #' @examples
 #'
-#' as.wide.df (faux_cell [1:5,, 600 ~ 610])
-#' summary (as.wide.df (faux_cell [1:5,, 600 ~ 610]))
-
+#' as.wide.df(faux_cell [1:5, , 600 ~ 610])
+#' summary(as.wide.df(faux_cell [1:5, , 600 ~ 610]))
 as.wide.df <- function(x, wl.prefix = "") {
   chk.hy(x)
   validObject(x)
@@ -157,11 +155,10 @@ as.wide.df <- function(x, wl.prefix = "") {
 #' other functions producing long-format data.frames.
 #' @examples
 #'
-#' as.long.df (flu [,, 405 ~ 410])
-#' summary (as.long.df (flu [,, 405 ~ 410]))
-#' summary (as.long.df (flu [,, 405 ~ 410], rownames = TRUE))
-#' summary (as.long.df (flu [,, 405 ~ 410], wl.factor = TRUE))
-#'
+#' as.long.df(flu [, , 405 ~ 410])
+#' summary(as.long.df(flu [, , 405 ~ 410]))
+#' summary(as.long.df(flu [, , 405 ~ 410], rownames = TRUE))
+#' summary(as.long.df(flu [, , 405 ~ 410], wl.factor = TRUE))
 as.long.df <- function(x, rownames = FALSE, wl.factor = FALSE, na.rm = TRUE) {
   chk.hy(x)
   validObject(x)
@@ -223,14 +220,15 @@ as.long.df <- function(x, rownames = FALSE, wl.factor = FALSE, na.rm = TRUE) {
 #'   see the example.
 #' @export
 #' @examples
-#' df <- as.t.df (apply (faux_cell, 2, mean_pm_sd))
-#' head (df)
+#' df <- as.t.df(apply(faux_cell, 2, mean_pm_sd))
+#' head(df)
 #'
-#' if (require (ggplot2)){
-#'   ggplot (df, aes (x = .wavelength)) +
-#'     geom_ribbon (aes (ymin = mean.minus.sd, ymax = mean.plus.sd),
-#'       fill = "#00000040") +
-#'     geom_line (aes (y = mean))
+#' if (require(ggplot2)) {
+#'   ggplot(df, aes(x = .wavelength)) +
+#'     geom_ribbon(aes(ymin = mean.minus.sd, ymax = mean.plus.sd),
+#'       fill = "#00000040"
+#'     ) +
+#'     geom_line(aes(y = mean))
 #' }
 as.t.df <- function(x) {
   chk.hy(x)

--- a/hyperSpec/R/as.data.frame.R
+++ b/hyperSpec/R/as.data.frame.R
@@ -10,7 +10,7 @@
 #' @param row.names if \code{TRUE}, a column \code{.row} is created containing row names or row
 #' indices if no rownames are set. If character vector, the rownames are set accordingly.
 #' @param optional ignored
-#' @return \code{x@@data} and \code{x@@data$spc} (== \code{x$spc} == \code{x [[]]}), respectively.
+#' @return \code{x@@data} and \code{x@@data$spc} (== \code{x$spc} == \code{x[[]]}), respectively.
 #' @author C. Beleites
 #' @method as.data.frame hyperSpec
 #' @export
@@ -107,7 +107,7 @@ as.wide.df <- function(x, wl.prefix = "") {
   test_that("faux_cell", {
     expect_equal(
       as.wide.df(faux_cell [1:5, , 600 ~ 610]),
-      cbind(faux_cell [1:5]$.., faux_cell [[1:5, , 600 ~ 610]])
+      cbind(faux_cell [1:5]$.., faux_cell[[1:5, , 600 ~ 610]])
     )
   })
 
@@ -122,7 +122,7 @@ as.wide.df <- function(x, wl.prefix = "") {
       c(grep("spc", colnames(faux_cell), value = TRUE, invert = TRUE), wl(faux_cell))
     )
 
-    expect_true(!any(is.na(colnames(as.wide.df(barbiturates [[1]])))))
+    expect_true(!any(is.na(colnames(as.wide.df(barbiturates[[1]])))))
   })
 
   test_that("column names with wl.prefix", {
@@ -179,7 +179,7 @@ as.long.df <- function(x, rownames = FALSE, wl.factor = FALSE, na.rm = TRUE) {
     tmp <- cbind(
       data.frame(
         .wavelength = rep(x@wavelength, each = nrow(x)),
-        spc = as.numeric(x [[]])
+        spc = as.numeric(x[[]])
       ),
       tmp
     )

--- a/hyperSpec/R/barbiturates.R
+++ b/hyperSpec/R/barbiturates.R
@@ -12,21 +12,25 @@
 #' @examples
 #'
 #' barbiturates [1:3]
-#' length (barbiturates)
+#' length(barbiturates)
 #'
-#' barb <- collapse (barbiturates, collapse.equal = FALSE)
-#' barb <- orderwl (barb)
+#' barb <- collapse(barbiturates, collapse.equal = FALSE)
+#' barb <- orderwl(barb)
 #'
-#' plot (barb [1:3], lines.args = list (type = "h"),
-#'       col = matlab.dark.palette (3), stacked = TRUE,
-#'       stacked.args = list (add.factor = .2))
+#' plot(barb [1:3],
+#'   lines.args = list(type = "h"),
+#'   col = matlab.dark.palette(3), stacked = TRUE,
+#'   stacked.args = list(add.factor = .2)
+#' )
 #'
-#' if (require (latticeExtra)){
-#' levelplot (spc ~ .wavelength * z, log (barb), panel = panel.levelplot.points,
-#'    cex = 0.3, col = "#00000000", col.regions = matlab.palette (20))
+#' if (require(latticeExtra)) {
+#'   levelplot(spc ~ .wavelength * z, log(barb),
+#'     panel = panel.levelplot.points,
+#'     cex = 0.3, col = "#00000000", col.regions = matlab.palette(20)
+#'   )
 #' }
 #'
-#' plotc (apply (barb [,, 42.9~43.2], 1, sum, na.rm = TRUE), spc ~ z,
-#'        panel = panel.lines, ylab = expression (I[m/z == 43] / "a.u."))
-#'
+#' plotc(apply(barb [, , 42.9 ~ 43.2], 1, sum, na.rm = TRUE), spc ~ z,
+#'   panel = panel.lines, ylab = expression(I[m / z == 43] / "a.u.")
+#' )
 NULL

--- a/hyperSpec/R/barbiturates.R
+++ b/hyperSpec/R/barbiturates.R
@@ -1,32 +1,32 @@
-##' Barbiturates Spectra from .spc example files
-##' A time series of mass spectra in a list of hyperSpec objects.
-##'
-##'
-##' @name barbiturates
-##' @docType data
-##' @format The data sets consists of 286 spectra. They are the result of importing the
-##' BARBITUATES.SPC example data from Thermo Galactic's spc file format specification.
-##' @author C. Beleites and Thermo Galactic
-##' @references The raw data is available at \url{http://hyperspec.r-forge.r-project.org/blob/fileio.zip}
-##' @keywords datasets
-##' @examples
-##'
-##' barbiturates [1:3]
-##' length (barbiturates)
-##'
-##' barb <- collapse (barbiturates, collapse.equal = FALSE)
-##' barb <- orderwl (barb)
-##'
-##' plot (barb [1:3], lines.args = list (type = "h"),
-##'       col = matlab.dark.palette (3), stacked = TRUE,
-##'       stacked.args = list (add.factor = .2))
-##'
-##' if (require (latticeExtra)){
-##' levelplot (spc ~ .wavelength * z, log (barb), panel = panel.levelplot.points,
-##'    cex = 0.3, col = "#00000000", col.regions = matlab.palette (20))
-##' }
-##'
-##' plotc (apply (barb [,, 42.9~43.2], 1, sum, na.rm = TRUE), spc ~ z,
-##'        panel = panel.lines, ylab = expression (I[m/z == 43] / "a.u."))
-##'
+#' Barbiturates Spectra from .spc example files
+#' A time series of mass spectra in a list of hyperSpec objects.
+#'
+#'
+#' @name barbiturates
+#' @docType data
+#' @format The data sets consists of 286 spectra. They are the result of importing the
+#' BARBITUATES.SPC example data from Thermo Galactic's spc file format specification.
+#' @author C. Beleites and Thermo Galactic
+#' @references The raw data is available at \url{http://hyperspec.r-forge.r-project.org/blob/fileio.zip}
+#' @keywords datasets
+#' @examples
+#'
+#' barbiturates [1:3]
+#' length (barbiturates)
+#'
+#' barb <- collapse (barbiturates, collapse.equal = FALSE)
+#' barb <- orderwl (barb)
+#'
+#' plot (barb [1:3], lines.args = list (type = "h"),
+#'       col = matlab.dark.palette (3), stacked = TRUE,
+#'       stacked.args = list (add.factor = .2))
+#'
+#' if (require (latticeExtra)){
+#' levelplot (spc ~ .wavelength * z, log (barb), panel = panel.levelplot.points,
+#'    cex = 0.3, col = "#00000000", col.regions = matlab.palette (20))
+#' }
+#'
+#' plotc (apply (barb [,, 42.9~43.2], 1, sum, na.rm = TRUE), spc ~ z,
+#'        panel = panel.lines, ylab = expression (I[m/z == 43] / "a.u."))
+#'
 NULL

--- a/hyperSpec/R/bind.R
+++ b/hyperSpec/R/bind.R
@@ -47,7 +47,7 @@
 #' x$a <- 1
 #' x@data <- x@data[, sample(ncol(x), ncol(x))] # reorder columns
 #'
-#' y <- faux_cell [nrow(faux_cell):1, , 1730:1750] # reorder rows
+#' y <- faux_cell[nrow(faux_cell):1, , 1730:1750] # reorder rows
 #' y$b <- 2
 #'
 #' cbind2(x, y) # works
@@ -65,7 +65,7 @@ bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
   wl.tolerance <- .checkpos(wl.tolerance, "wl.tolerance")
   dots <- list(...)
 
-  if ((length(dots) == 1) & is.list(dots [[1]])) {
+  if ((length(dots) == 1) & is.list(dots[[1]])) {
     dots <- dots[[1]]
   }
 
@@ -78,7 +78,7 @@ bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
     lapply(dots, chk.hy)
     lapply(dots, validObject)
 
-    for (i in seq_along(dots) [-1]) {
+    for (i in seq_along(dots)[-1]) {
       dots[[1]] <- switch(direction,
         c = cbind2(dots[[1]], dots[[i]]),
         r = rbind2(dots[[1]], dots[[i]], wl.tolerance = wl.tolerance),
@@ -89,7 +89,7 @@ bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
       )
     }
 
-    dots [[1]]
+    dots[[1]]
   }
 }
 
@@ -108,12 +108,12 @@ bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
 
     expect_error(bind("r", tmp.list))
     expect_true(all.equal(bind("r", tmp.list, wl.tolerance = 0.1),
-      flu [rep(row.seq(flu), 3)],
+      flu[rep(row.seq(flu), 3)],
       check.label = TRUE
     ))
 
     expect_true(all.equal(do.call("bind", list("r", tmp.list, wl.tolerance = 0.1)),
-      flu [rep(row.seq(flu), 3)],
+      flu[rep(row.seq(flu), 3)],
       check.label = TRUE
     ))
   })
@@ -155,19 +155,19 @@ rbind.hyperSpec <- function(...) bind("r", ...)
 
     tmp.list <- list(flu, tmp, flu)
     expect_true(all.equal(do.call("rbind", c(tmp.list, wl.tolerance = 0.1)),
-      flu [rep(row.seq(flu), 3)],
+      flu[rep(row.seq(flu), 3)],
       check.label = TRUE
     ))
   })
 
   test_that("correct rbinding", {
     expect_equal(nrow(rbind(flu, flu)), 2 * nrow(flu))
-    expect_error(rbind(flu, flu [, , min ~ min + 3i]))
+    expect_error(rbind(flu, flu[, , min ~ min + 3i]))
   })
 
   test_that("list of hyperSpec objects", {
     expect_equal(nrow(rbind(flu, flu)), 2 * nrow(flu))
-    expect_error(rbind(flu, flu [, , min ~ min + 3i]))
+    expect_error(rbind(flu, flu[, , min ~ min + 3i]))
   })
 }
 
@@ -177,9 +177,9 @@ rbind.hyperSpec <- function(...) bind("r", ...)
   validObject(y)
 
   cols <- match(colnames(x@data), colnames(y@data))
-  cols <- colnames(y@data) [cols]
-  cols <- cols [!is.na(cols)]
-  cols <- cols [-match("spc", cols)]
+  cols <- colnames(y@data)[cols]
+  cols <- cols[!is.na(cols)]
+  cols <- cols[-match("spc", cols)]
 
   if (length(cols) < 0) {
     ord <- do.call(order, x@data[, cols, drop = FALSE])
@@ -240,15 +240,15 @@ setMethod("cbind2", signature = signature(x = "hyperSpec", y = "missing"), funct
   context(".rbind2")
 
   test_that("flu", {
-    expect_equal(rbind(flu [1], flu [-1]), flu, check.attributes = FALSE)
-    expect_equal(rbind(flu [-1], flu [1]), flu [c(2:6, 1)], check.attributes = FALSE)
-    expect_equal(rbind(flu [1:2], flu [3:6]), flu, check.attributes = FALSE)
+    expect_equal(rbind(flu[1], flu[-1]), flu, check.attributes = FALSE)
+    expect_equal(rbind(flu[-1], flu[1]), flu[c(2:6, 1)], check.attributes = FALSE)
+    expect_equal(rbind(flu[1:2], flu[3:6]), flu, check.attributes = FALSE)
   })
 
   test_that("empty objects", {
-    expect_equal(rbind(flu [0], flu [0]), flu [0], check.attributes = FALSE)
-    expect_equal(rbind(flu [1], flu [0]), flu [1], check.attributes = FALSE)
-    expect_equal(rbind(flu [0], flu [1]), flu [1], check.attributes = FALSE)
+    expect_equal(rbind(flu[0], flu[0]), flu[0], check.attributes = FALSE)
+    expect_equal(rbind(flu[1], flu[0]), flu[1], check.attributes = FALSE)
+    expect_equal(rbind(flu[0], flu[1]), flu[1], check.attributes = FALSE)
   })
 
 

--- a/hyperSpec/R/bind.R
+++ b/hyperSpec/R/bind.R
@@ -38,28 +38,28 @@
 #' @examples
 #'
 #' faux_cell
-#' bind ("r", faux_cell, faux_cell)
-#' rbind (faux_cell, faux_cell)
-#' cbind (faux_cell, faux_cell)
-#' bind ("r", list (faux_cell, faux_cell, faux_cell))
+#' bind("r", faux_cell, faux_cell)
+#' rbind(faux_cell, faux_cell)
+#' cbind(faux_cell, faux_cell)
+#' bind("r", list(faux_cell, faux_cell, faux_cell))
 #'
-#' x <- faux_cell[,, 600 : 605]
+#' x <- faux_cell[, , 600:605]
 #' x$a <- 1
-#' x@@data <- x@@data[, sample (ncol (x), ncol (x))] # reorder columns
+#' x@data <- x@data[, sample(ncol(x), ncol(x))] # reorder columns
 #'
-#' y <- faux_cell [nrow (faux_cell) : 1,, 1730 : 1750] # reorder rows
+#' y <- faux_cell [nrow(faux_cell):1, , 1730:1750] # reorder rows
 #' y$b <- 2
 #'
-#' cbind2 (x, y) # works
+#' cbind2(x, y) # works
 #'
 #' y$y[3] <- 5
-#' try (cbind2 (x, y)) # error
+#' try(cbind2(x, y)) # error
 #'
 #' # list of hyperSpec objects
 #'
-#' lhy <- list (flu, flu)
-#' do.call ("rbind", lhy)
-#' bind ("r", lhy)
+#' lhy <- list(flu, flu)
+#' do.call("rbind", lhy)
+#' bind("r", lhy)
 bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
                  wl.tolerance = hy.getOption("wl.tolerance")) {
   wl.tolerance <- .checkpos(wl.tolerance, "wl.tolerance")

--- a/hyperSpec/R/bind.R
+++ b/hyperSpec/R/bind.R
@@ -1,65 +1,65 @@
-##' Binding hyperSpec Objects
-##'
-##' The former difficulties with binding S4 objects
-##' are resolved since R version 3.2.0 and \code{cbind} and \code{rbind} now work as intended and
-##' expected for hyperSpec objects.
-##'
-##' Therefore, calling \code{rbind.hyperSpec} and
-##' \code{cbind.hyperSpec} is now depecated: \code{cbind} and \code{rbind} should now be called
-##' directly.
-##'
-##' However, in consequence it is no longer possible to call \code{cbind} or \code{rbind} with a
-##' list of hyperSpec objects. In that case, use \code{bind} or \code{\link[base]{do.call}} (see example).
-##'
-##' \code{bind} does the common work for both column- and row-wise binding.
-##'
-##' @aliases bind
-##' @param ... The \code{hyperSpec} objects to be combined.
-##'
-##' Alternatively, \emph{one} list of \code{hyperSpec} objects can be given to
-##'   \code{bind}.
-##' @param wl.tolerance \code{rbind} and \code{rbind2} check for equal wavelengths
-##' with this tolerance.
-##' @include paste.row.R
-##' @param direction "r" or "c" to bind rows or columns
-##' @return a \code{hyperSpec} object, possibly with different row order (for
-##'   \code{bind ("c", \dots{})} and \code{cbind2}).
-##' @note You might have to make sure that the objects either all have or all
-##'   do not have rownames and/or colnames.
-##' @author C. Beleites
-##' @export
-##' @seealso
-##' \code{\link[methods]{rbind2}}, \code{\link[methods]{cbind2}}
-##' \code{\link[base]{rbind}}, \code{\link[base]{cbind}}
-##'
-##' \code{\link{merge}} and \code{\link{collapse}} for combining objects that do not share spectra
-##' or wavelengths, respectively.
-##' @keywords methods manip
-##' @examples
-##'
-##' faux_cell
-##' bind ("r", faux_cell, faux_cell)
-##' rbind (faux_cell, faux_cell)
-##' cbind (faux_cell, faux_cell)
-##' bind ("r", list (faux_cell, faux_cell, faux_cell))
-##'
-##' x <- faux_cell[,, 600 : 605]
-##' x$a <- 1
-##' x@@data <- x@@data[, sample (ncol (x), ncol (x))] # reorder columns
-##'
-##' y <- faux_cell [nrow (faux_cell) : 1,, 1730 : 1750] # reorder rows
-##' y$b <- 2
-##'
-##' cbind2 (x, y) # works
-##'
-##' y$y[3] <- 5
-##' try (cbind2 (x, y)) # error
-##'
-##' # list of hyperSpec objects
-##'
-##' lhy <- list (flu, flu)
-##' do.call ("rbind", lhy)
-##' bind ("r", lhy)
+#' Binding hyperSpec Objects
+#'
+#' The former difficulties with binding S4 objects
+#' are resolved since R version 3.2.0 and \code{cbind} and \code{rbind} now work as intended and
+#' expected for hyperSpec objects.
+#'
+#' Therefore, calling \code{rbind.hyperSpec} and
+#' \code{cbind.hyperSpec} is now depecated: \code{cbind} and \code{rbind} should now be called
+#' directly.
+#'
+#' However, in consequence it is no longer possible to call \code{cbind} or \code{rbind} with a
+#' list of hyperSpec objects. In that case, use \code{bind} or \code{\link[base]{do.call}} (see example).
+#'
+#' \code{bind} does the common work for both column- and row-wise binding.
+#'
+#' @aliases bind
+#' @param ... The \code{hyperSpec} objects to be combined.
+#'
+#' Alternatively, \emph{one} list of \code{hyperSpec} objects can be given to
+#'   \code{bind}.
+#' @param wl.tolerance \code{rbind} and \code{rbind2} check for equal wavelengths
+#' with this tolerance.
+#' @include paste.row.R
+#' @param direction "r" or "c" to bind rows or columns
+#' @return a \code{hyperSpec} object, possibly with different row order (for
+#'   \code{bind ("c", \dots{})} and \code{cbind2}).
+#' @note You might have to make sure that the objects either all have or all
+#'   do not have rownames and/or colnames.
+#' @author C. Beleites
+#' @export
+#' @seealso
+#' \code{\link[methods]{rbind2}}, \code{\link[methods]{cbind2}}
+#' \code{\link[base]{rbind}}, \code{\link[base]{cbind}}
+#'
+#' \code{\link{merge}} and \code{\link{collapse}} for combining objects that do not share spectra
+#' or wavelengths, respectively.
+#' @keywords methods manip
+#' @examples
+#'
+#' faux_cell
+#' bind ("r", faux_cell, faux_cell)
+#' rbind (faux_cell, faux_cell)
+#' cbind (faux_cell, faux_cell)
+#' bind ("r", list (faux_cell, faux_cell, faux_cell))
+#'
+#' x <- faux_cell[,, 600 : 605]
+#' x$a <- 1
+#' x@@data <- x@@data[, sample (ncol (x), ncol (x))] # reorder columns
+#'
+#' y <- faux_cell [nrow (faux_cell) : 1,, 1730 : 1750] # reorder rows
+#' y$b <- 2
+#'
+#' cbind2 (x, y) # works
+#'
+#' y$y[3] <- 5
+#' try (cbind2 (x, y)) # error
+#'
+#' # list of hyperSpec objects
+#'
+#' lhy <- list (flu, flu)
+#' do.call ("rbind", lhy)
+#' bind ("r", lhy)
 bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
                  wl.tolerance = hy.getOption("wl.tolerance")) {
   wl.tolerance <- .checkpos(wl.tolerance, "wl.tolerance")
@@ -93,7 +93,7 @@ bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
   }
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(bind) <- function() {
   context("bind")
 
@@ -120,28 +120,28 @@ bind <- function(direction = stop("direction ('c' or 'r') required"), ...,
 }
 
 
-##' @description  \code{cbind2} binds the spectral matrices of two \code{hyperSpec} objects by column. All columns
-##' besides \code{spc} with the same name in \code{x@@data} and \code{y@@data} must have the same
-##' elements.  Rows are ordered before checking.
-##' @aliases bind cbind.hyperSpec rbind.hyperSpec
-##'   cbind2,hyperSpec,hyperSpec-method rbind2,hyperSpec,hyperSpec-method
-##'   cbind2,hyperSpec,missing-method rbind2,hyperSpec,missing-method
-##' @param x,y \code{hyperSpec} objects
-##' @rdname bind
-##' @export
-##' @aliases cbind.hyperSpec
+#' @description  \code{cbind2} binds the spectral matrices of two \code{hyperSpec} objects by column. All columns
+#' besides \code{spc} with the same name in \code{x@@data} and \code{y@@data} must have the same
+#' elements.  Rows are ordered before checking.
+#' @aliases bind cbind.hyperSpec rbind.hyperSpec
+#'   cbind2,hyperSpec,hyperSpec-method rbind2,hyperSpec,hyperSpec-method
+#'   cbind2,hyperSpec,missing-method rbind2,hyperSpec,missing-method
+#' @param x,y \code{hyperSpec} objects
+#' @rdname bind
+#' @export
+#' @aliases cbind.hyperSpec
 
-##'
+#'
 cbind.hyperSpec <- function(...) bind("c", ...)
 
-##'
-##' \code{rbind2} binds two \code{hyperSpec} objects by row. They need to have
-##' the same columns.
-##'
-##' @aliases  rbind.hyperSpec
-##' @rdname bind
-##' @export
-##' @aliases rbind.hyperSpec
+#'
+#' \code{rbind2} binds two \code{hyperSpec} objects by row. They need to have
+#' the same columns.
+#'
+#' @aliases  rbind.hyperSpec
+#' @rdname bind
+#' @export
+#' @aliases rbind.hyperSpec
 rbind.hyperSpec <- function(...) bind("r", ...)
 
 .test(rbind.hyperSpec) <- function() {
@@ -209,14 +209,14 @@ rbind.hyperSpec <- function(...) bind("r", ...)
 
   x
 }
-##' @rdname bind
-##' @export
-##' @aliases cbind2,hyperSpec,hyperSpec-method
+#' @rdname bind
+#' @export
+#' @aliases cbind2,hyperSpec,hyperSpec-method
 setMethod("cbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .cbind2)
 
-##' @rdname bind
-##' @export
-##' @aliases cbind2,hyperSpec,missing-method
+#' @rdname bind
+#' @export
+#' @aliases cbind2,hyperSpec,missing-method
 setMethod("cbind2", signature = signature(x = "hyperSpec", y = "missing"), function(x, y) x)
 
 .rbind2 <- function(x, y, wl.tolerance = hy.getOption("wl.tolerance")) {
@@ -260,12 +260,12 @@ setMethod("cbind2", signature = signature(x = "hyperSpec", y = "missing"), funct
   })
 }
 
-##' @rdname bind
-##' @export
-##' @aliases  rbind2,hyperSpec,hyperSpec-method
+#' @rdname bind
+#' @export
+#' @aliases  rbind2,hyperSpec,hyperSpec-method
 setMethod("rbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .rbind2)
 
-##' @rdname bind
-##' @export
-##' @aliases rbind2,hyperSpec,missing-method
+#' @rdname bind
+#' @export
+#' @aliases rbind2,hyperSpec,missing-method
 setMethod("rbind2", signature = signature(x = "hyperSpec", y = "missing"), function(x, y, wl.tolerance) x)

--- a/hyperSpec/R/call.list.R
+++ b/hyperSpec/R/call.list.R
@@ -2,7 +2,7 @@
 ###
 ### generate a list of function arguments for the calling function
 ###
-##' @noRd
+#' @noRd
 .call.list <- function(x = NULL) {
   if (is.null(x)) {
     x <- sys.call(-1)

--- a/hyperSpec/R/chk.hy.R
+++ b/hyperSpec/R/chk.hy.R
@@ -1,17 +1,17 @@
-##' Check whether an object is a hyperSpec object and validate the object
-##'
-##' @title Validation of hyperSpec objects
-##' @aliases validObject validObject,hyperSpec-method chk.hy
-##' @author C. Beleites
-##' @seealso \code{\link[methods]{validObject}}
-##' @param object the object to check
-##' @return \code{TRUE} if the check passes, otherwise stop with an
-##' error.
-##' @keywords methods
-##' @export
-##' @examples
-##' chk.hy (faux_cell)
-##' validObject (faux_cell)
+#' Check whether an object is a hyperSpec object and validate the object
+#'
+#' @title Validation of hyperSpec objects
+#' @aliases validObject validObject,hyperSpec-method chk.hy
+#' @author C. Beleites
+#' @seealso \code{\link[methods]{validObject}}
+#' @param object the object to check
+#' @return \code{TRUE} if the check passes, otherwise stop with an
+#' error.
+#' @keywords methods
+#' @export
+#' @examples
+#' chk.hy (faux_cell)
+#' validObject (faux_cell)
 chk.hy <- function(object) {
   if (!is(object, "hyperSpec")) {
     stop("no hyperSpec object")

--- a/hyperSpec/R/chk.hy.R
+++ b/hyperSpec/R/chk.hy.R
@@ -10,8 +10,8 @@
 #' @keywords methods
 #' @export
 #' @examples
-#' chk.hy (faux_cell)
-#' validObject (faux_cell)
+#' chk.hy(faux_cell)
+#' validObject(faux_cell)
 chk.hy <- function(object) {
   if (!is(object, "hyperSpec")) {
     stop("no hyperSpec object")

--- a/hyperSpec/R/chondro.R
+++ b/hyperSpec/R/chondro.R
@@ -19,23 +19,23 @@
 #' chondro
 #'
 #' ## do baseline correction
-#' baselines <- spc.fit.poly.below (chondro)
+#' baselines <- spc.fit.poly.below(chondro)
 #' chondro <- chondro - baselines
 #'
 #' ## area normalization
-#' chondro <- chondro / colMeans (chondro)
+#' chondro <- chondro / colMeans(chondro)
 #'
 #' ## substact common composition
-#' chondro <- chondro - quantile (chondro, 0.05)
+#' chondro <- chondro - quantile(chondro, 0.05)
 #'
-#' cols <- c ("dark blue", "orange", "#C02020")
-#' plotmap (chondro, clusters ~ x * y, col.regions = cols)
+#' cols <- c("dark blue", "orange", "#C02020")
+#' plotmap(chondro, clusters ~ x * y, col.regions = cols)
 #'
-#' cluster.means <- aggregate (chondro, chondro$clusters, mean_pm_sd)
-#' plot (cluster.means, stacked = ".aggregate", fill = ".aggregate", col = cols)
+#' cluster.means <- aggregate(chondro, chondro$clusters, mean_pm_sd)
+#' plot(cluster.means, stacked = ".aggregate", fill = ".aggregate", col = cols)
 #'
 #' ## plot nucleic acid bands
-#' plotmap (chondro[, , c( 728, 782, 1098, 1240, 1482, 1577)],
-#'        col.regions = colorRampPalette (c ("white", "gold", "dark green"), space = "Lab") (20))
-#'
+#' plotmap(chondro[, , c(728, 782, 1098, 1240, 1482, 1577)],
+#'   col.regions = colorRampPalette(c("white", "gold", "dark green"), space = "Lab")(20)
+#' )
 NULL

--- a/hyperSpec/R/chondro.R
+++ b/hyperSpec/R/chondro.R
@@ -1,41 +1,41 @@
-##' Raman spectra of 2 Chondrocytes in Cartilage
-##' A Raman-map (laterally resolved Raman spectra) of chondrocytes in
-##' cartilage.
-##'
-##' See the vignette \code{vignette ("chondro", package = "hyperSpec")}.
-##'
-##' @name chondro
-##' @docType data
-##' @format The data set has 875 Raman spectra measured on a 25 \eqn{\times}{x}
-##'   35 grid with 1 micron step size. Spatial information is in
-##'   \code{chondro$x} and \code{chondro$y}. Each spectrum has 300 data points
-##'   in the range of ca. 600 - 1800 cm\eqn{^{-1}}{^-1}.
-##' @author A. Bonifacio and C. Beleites
-##' @keywords datasets
-##' @references The raw data is available at \url{http://hyperspec.r-forge.r-project.org/blob/chondro.zip}
-##' @examples
-##'
-##'
-##' chondro
-##'
-##' ## do baseline correction
-##' baselines <- spc.fit.poly.below (chondro)
-##' chondro <- chondro - baselines
-##'
-##' ## area normalization
-##' chondro <- chondro / colMeans (chondro)
-##'
-##' ## substact common composition
-##' chondro <- chondro - quantile (chondro, 0.05)
-##'
-##' cols <- c ("dark blue", "orange", "#C02020")
-##' plotmap (chondro, clusters ~ x * y, col.regions = cols)
-##'
-##' cluster.means <- aggregate (chondro, chondro$clusters, mean_pm_sd)
-##' plot (cluster.means, stacked = ".aggregate", fill = ".aggregate", col = cols)
-##'
-##' ## plot nucleic acid bands
-##' plotmap (chondro[, , c( 728, 782, 1098, 1240, 1482, 1577)],
-##'        col.regions = colorRampPalette (c ("white", "gold", "dark green"), space = "Lab") (20))
-##'
+#' Raman spectra of 2 Chondrocytes in Cartilage
+#' A Raman-map (laterally resolved Raman spectra) of chondrocytes in
+#' cartilage.
+#'
+#' See the vignette \code{vignette ("chondro", package = "hyperSpec")}.
+#'
+#' @name chondro
+#' @docType data
+#' @format The data set has 875 Raman spectra measured on a 25 \eqn{\times}{x}
+#'   35 grid with 1 micron step size. Spatial information is in
+#'   \code{chondro$x} and \code{chondro$y}. Each spectrum has 300 data points
+#'   in the range of ca. 600 - 1800 cm\eqn{^{-1}}{^-1}.
+#' @author A. Bonifacio and C. Beleites
+#' @keywords datasets
+#' @references The raw data is available at \url{http://hyperspec.r-forge.r-project.org/blob/chondro.zip}
+#' @examples
+#'
+#'
+#' chondro
+#'
+#' ## do baseline correction
+#' baselines <- spc.fit.poly.below (chondro)
+#' chondro <- chondro - baselines
+#'
+#' ## area normalization
+#' chondro <- chondro / colMeans (chondro)
+#'
+#' ## substact common composition
+#' chondro <- chondro - quantile (chondro, 0.05)
+#'
+#' cols <- c ("dark blue", "orange", "#C02020")
+#' plotmap (chondro, clusters ~ x * y, col.regions = cols)
+#'
+#' cluster.means <- aggregate (chondro, chondro$clusters, mean_pm_sd)
+#' plot (cluster.means, stacked = ".aggregate", fill = ".aggregate", col = cols)
+#'
+#' ## plot nucleic acid bands
+#' plotmap (chondro[, , c( 728, 782, 1098, 1240, 1482, 1577)],
+#'        col.regions = colorRampPalette (c ("white", "gold", "dark green"), space = "Lab") (20))
+#'
 NULL

--- a/hyperSpec/R/colMeans.R
+++ b/hyperSpec/R/colMeans.R
@@ -85,12 +85,12 @@ setMethod("rowSums", signature = signature(x = "hyperSpec"), function(x, na.rm =
     context(fun)
     f <- get(fun, mode = "function")
     test_that("basic operation", {
-      expect_equal(as.numeric(f(flu)                 [[]]), as.numeric(f(flu   [[]], na.rm = TRUE)), label = fun)
+      expect_equal(as.numeric(f(flu)                 [[]]), as.numeric(f(flu[[]],   na.rm = TRUE)), label = fun)
     })
 
     test_that("behaviour with NAs", {
-      expect_equal(as.numeric(f(fluNA)               [[]]), as.numeric(f(fluNA [[]], na.rm = TRUE)), label = fun)
-      expect_equal(as.numeric(f(fluNA, na.rm = FALSE)[[]]), as.numeric(f(fluNA [[]], na.rm = FALSE)), label = fun)
+      expect_equal(as.numeric(f(fluNA)               [[]]), as.numeric(f(fluNA[[]], na.rm = TRUE)), label = fun)
+      expect_equal(as.numeric(f(fluNA, na.rm = FALSE)[[]]), as.numeric(f(fluNA[[]], na.rm = FALSE)), label = fun)
     })
   }
 }

--- a/hyperSpec/R/colMeans.R
+++ b/hyperSpec/R/colMeans.R
@@ -20,7 +20,7 @@ setGeneric("colMeans") # , package = 'matrixStats')
 #' @rdname colSums
 #' @export
 #' @examples
-#' colMeans (flu)
+#' colMeans(flu)
 setMethod("colMeans", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.spc) {
   result <- colMeans(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && ncol(result) != nwl(x) && nrow(result) == nwl(x)) {
@@ -36,7 +36,7 @@ setGeneric("colSums") # , package = 'matrixStats')
 #' @rdname colSums
 #' @export
 #' @examples
-#' colSums (flu)
+#' colSums(flu)
 setMethod("colSums", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.spc) {
   result <- colSums(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && ncol(result) != nwl(x) && nrow(result) == nwl(x)) {
@@ -53,7 +53,7 @@ setGeneric("rowMeans") # , package = 'matrixStats')
 #' @rdname colSums
 #' @export
 #' @examples
-#' colSums (flu)
+#' colSums(flu)
 setMethod("rowMeans", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.wavelength) {
   result <- rowMeans(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && nrow(result) != nrow(x) && ncol(result) == nrow(x)) {
@@ -69,7 +69,7 @@ setGeneric("rowSums") # , package = 'matrixStats')
 #' @rdname colSums
 #' @export
 #' @examples
-#' rowSums (flu)
+#' rowSums(flu)
 setMethod("rowSums", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.wavelength) {
   result <- rowSums(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && nrow(result) != nrow(x) && ncol(result) == nrow(x)) {

--- a/hyperSpec/R/colMeans.R
+++ b/hyperSpec/R/colMeans.R
@@ -1,26 +1,26 @@
-##' colSums, colMeans, rowSums and rowMeans functions for hyperSpec objects
-##'
-##' hyperSpec objects can use the base functions \code{\link[base]{colMeans}},
-##' \code{\link[base]{colSums}}, \code{\link[base]{rowMeans}} and \code{\link[base]{rowSums}}.
-##'
-##' @param x hyperSpec object
-##' @param label.spc labels for the intensity axis for loadings-like (col) statistics
-##' @param label.wavelength labels for the wavelength axis for scores-like (row) statistics
-##' @param na.rm,... further parameters to the base functions
-##'
-##' \code{na.rm} defaults to \code{TRUE} for hyperSpec objects.
-##' @seealso \link[base]{colSums}
-##' @rdname colSums
-##' @name colSums
+#' colSums, colMeans, rowSums and rowMeans functions for hyperSpec objects
+#'
+#' hyperSpec objects can use the base functions \code{\link[base]{colMeans}},
+#' \code{\link[base]{colSums}}, \code{\link[base]{rowMeans}} and \code{\link[base]{rowSums}}.
+#'
+#' @param x hyperSpec object
+#' @param label.spc labels for the intensity axis for loadings-like (col) statistics
+#' @param label.wavelength labels for the wavelength axis for scores-like (row) statistics
+#' @param na.rm,... further parameters to the base functions
+#'
+#' \code{na.rm} defaults to \code{TRUE} for hyperSpec objects.
+#' @seealso \link[base]{colSums}
+#' @rdname colSums
+#' @name colSums
 NULL
 
-##' @noRd
+#' @noRd
 setGeneric("colMeans") # , package = 'matrixStats')
 
-##' @rdname colSums
-##' @export
-##' @examples
-##' colMeans (flu)
+#' @rdname colSums
+#' @export
+#' @examples
+#' colMeans (flu)
 setMethod("colMeans", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.spc) {
   result <- colMeans(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && ncol(result) != nwl(x) && nrow(result) == nwl(x)) {
@@ -30,13 +30,13 @@ setMethod("colMeans", signature = signature(x = "hyperSpec"), function(x, na.rm 
   decomposition(x, result, scores = FALSE, label.spc = label.spc)
 })
 
-##' @noRd
+#' @noRd
 setGeneric("colSums") # , package = 'matrixStats')
 
-##' @rdname colSums
-##' @export
-##' @examples
-##' colSums (flu)
+#' @rdname colSums
+#' @export
+#' @examples
+#' colSums (flu)
 setMethod("colSums", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.spc) {
   result <- colSums(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && ncol(result) != nwl(x) && nrow(result) == nwl(x)) {
@@ -47,13 +47,13 @@ setMethod("colSums", signature = signature(x = "hyperSpec"), function(x, na.rm =
 })
 
 
-##' @noRd
+#' @noRd
 setGeneric("rowMeans") # , package = 'matrixStats')
 
-##' @rdname colSums
-##' @export
-##' @examples
-##' colSums (flu)
+#' @rdname colSums
+#' @export
+#' @examples
+#' colSums (flu)
 setMethod("rowMeans", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.wavelength) {
   result <- rowMeans(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && nrow(result) != nrow(x) && ncol(result) == nrow(x)) {
@@ -63,13 +63,13 @@ setMethod("rowMeans", signature = signature(x = "hyperSpec"), function(x, na.rm 
   decomposition(x, result, scores = TRUE, label.wavelength = label.wavelength)
 })
 
-##' @noRd
+#' @noRd
 setGeneric("rowSums") # , package = 'matrixStats')
 
-##' @rdname colSums
-##' @export
-##' @examples
-##' rowSums (flu)
+#' @rdname colSums
+#' @export
+#' @examples
+#' rowSums (flu)
 setMethod("rowSums", signature = signature(x = "hyperSpec"), function(x, na.rm = TRUE, ..., label.wavelength) {
   result <- rowSums(x@data$spc, na.rm = na.rm, ...)
   if (is.matrix(result) && nrow(result) != nrow(x) && ncol(result) == nrow(x)) {
@@ -79,7 +79,7 @@ setMethod("rowSums", signature = signature(x = "hyperSpec"), function(x, na.rm =
   decomposition(x, result, scores = TRUE, label.wavelength = label.wavelength)
 })
 
-##' @include unittest.R
+#' @include unittest.R
 .test(colMeans) <- function() {
   for (fun in c("colMeans", "colSums", "rowMeans", "rowSums")) {
     context(fun)

--- a/hyperSpec/R/collapse.R
+++ b/hyperSpec/R/collapse.R
@@ -42,9 +42,9 @@
 #' barbiturates [1:3]
 #' collapse(barbiturates [1:3])
 #'
-#' a <- barbiturates [[1]]
-#' b <- barbiturates [[2]]
-#' c <- barbiturates [[3]]
+#' a <- barbiturates[[1]]
+#' b <- barbiturates[[2]]
+#' c <- barbiturates[[3]]
 #'
 #' a
 #' b
@@ -57,8 +57,8 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
   dots <- list(...)
 
   ## accept also a list of hyperSpec objects
-  if (length(dots) == 1 && is.list(dots [[1]])) {
-    dots <- dots [[1]]
+  if (length(dots) == 1 && is.list(dots[[1]])) {
+    dots <- dots[[1]]
   }
 
   ## check the arguments
@@ -89,7 +89,7 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
     dots <- .collapse.equal(dots, wl.tolerance)
 
     if (length(dots) == 1L) {
-      return(dots [[1]])
+      return(dots[[1]])
     }
   }
 
@@ -106,7 +106,7 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
   ## assign cluster number to columns
   # wl.df is ordered by wavelength, each object in dots is ordered by wavelength, so
   for (i in seq_along(dots)) {
-    colnames(dots [[i]]@data$spc) <- wl.df$wlcluster [wl.df$iobj == i]
+    colnames(dots[[i]]@data$spc) <- wl.df$wlcluster [wl.df$iobj == i]
   }
 
   ## now we're ready for the  actual work of collapsing the objects
@@ -147,9 +147,9 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
     )
 
     for (s in 1:3) {
-      expect_equal(as.numeric(new [[s, , wl(barbiturates [[s]])]]),
-        as.numeric(barbiturates [[s]][[]]),
-        label = paste0("barbiturates [[", s, "]]")
+      expect_equal(as.numeric(new[[s, , wl(barbiturates[[s]])]]),
+        as.numeric(barbiturates[[s]][[]]),
+        label = paste0("barbiturates[[", s, "]]")
       )
     }
   })
@@ -217,8 +217,8 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
   })
 
   test_that("collapsing objects with equal wavelength axes", {
-    expect_equivalent(collapse(barbiturates [[1]], barbiturates [[1]]),
-      barbiturates [[1]][c(1, 1)],
+    expect_equivalent(collapse(barbiturates[[1]], barbiturates[[1]]),
+      barbiturates[[1]][c(1, 1)],
       check.label = TRUE
     )
   })
@@ -276,8 +276,8 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
     )
 
     tmp <- flu [rep(1:nrow(flu), 2)]
-    tmp [[7:12]] <- NA
-    tmp [[7:12, , 450]] <- flu [[, , 450]]
+    tmp[[7:12]] <- NA
+    tmp[[7:12, , 450]] <- flu[[, , 450]]
     expect_equivalent(collapse(flu [, , 450], flu),
       tmp,
       check.labels = TRUE
@@ -358,30 +358,30 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
 
   while (i < length(dots)) {
     bind_directly <- sapply(tail(dots, -i), function(x) {
-      (nwl(x) == nwl(dots [[i]])) && all(abs(wl(x) - wl(dots [[i]])) < wl.tolerance)
+      (nwl(x) == nwl(dots[[i]])) && all(abs(wl(x) - wl(dots[[i]])) < wl.tolerance)
     })
     bind_directly <- which(bind_directly)
 
     if (length(bind_directly) > 0L) {
       n <- 0
-      wl <- rep(0, nwl(dots [[i]]))
+      wl <- rep(0, nwl(dots[[i]]))
 
       for (j in c(i, i + bind_directly)) {
-        wl <- wl + nrow(dots [[j]]) * wl(dots [[j]])
-        n <- n + nrow(dots [[j]])
+        wl <- wl + nrow(dots[[j]]) * wl(dots[[j]])
+        n <- n + nrow(dots[[j]])
 
         # also ensure same column names within spc.
-        colnames(dots [[j]]@data$spc) <- colnames(dots [[i]]@data$spc)
+        colnames(dots[[j]]@data$spc) <- colnames(dots[[i]]@data$spc)
       }
       wl <- wl / n
 
-      dots [[i]]@data <- rbind.fill(lapply(dots [c(i, i + bind_directly)], slot, "data"))
-      .wl(dots [[i]]) <- structure(wl, names = names(wl(dots [[i]])))
+      dots[[i]]@data <- rbind.fill(lapply(dots [c(i, i + bind_directly)], slot, "data"))
+      .wl(dots[[i]]) <- structure(wl, names = names(wl(dots[[i]])))
 
       labels <- unlist(lapply(dots [c(i, i + bind_directly)], labels))
       labels <- lapply(labels, function(l) if (is.language(l)) l <- as.expression(l) else l)
 
-      labels(dots [[i]]) <- labels [!duplicated(names(labels))]
+      labels(dots[[i]]) <- labels [!duplicated(names(labels))]
 
       dots <- dots [-(i + bind_directly)]
     }
@@ -403,15 +403,15 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
 
   # set up data.frame to hold relevant information
   wl.df <- lapply(seq_along(dots), function(i) {
-    if (nwl(dots [[i]]) == 0L) {
+    if (nwl(dots[[i]]) == 0L) {
       return(data.frame())
     }
 
     data.frame(
-      wl = wl(dots [[i]]),
+      wl = wl(dots[[i]]),
       iobj = i,
-      nspc = nrow(dots [[i]]),
-      wlcol = seq_len(nwl(dots [[i]])),
+      nspc = nrow(dots[[i]]),
+      wlcol = seq_len(nwl(dots[[i]])),
       wlcluster = NA
     )
   })
@@ -421,7 +421,7 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
   wl.df$old.wlnames <- NA
 
   for (i in seq_along(dots)) {
-    wln <- names(dots [[i]]@wavelength)
+    wln <- names(dots[[i]]@wavelength)
     if (!is.null(wln)) wl.df$old.wlnames [wl.df$iobj == i] <- wln
   }
 
@@ -491,8 +491,8 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
   })
 
   test_that("new wavelengths are weighted mean of wavelength bin", {
-    a <- barbiturates [[1]][, , min ~ 30]
-    b <- barbiturates [[2]][, , min ~ 30]
+    a <- barbiturates[[1]][, , min ~ 30]
+    b <- barbiturates[[2]][, , min ~ 30]
     wl(b) <- wl(b) + 0.03 / 2
 
     expect_equal(

--- a/hyperSpec/R/collapse.R
+++ b/hyperSpec/R/collapse.R
@@ -40,7 +40,7 @@
 #' @keywords manip
 #' @examples
 #' barbiturates [1:3]
-#' collapse (barbiturates [1:3])
+#' collapse(barbiturates [1:3])
 #'
 #' a <- barbiturates [[1]]
 #' b <- barbiturates [[2]]
@@ -49,11 +49,9 @@
 #' a
 #' b
 #' c
-#' collapse (a, b, c)
+#' collapse(a, b, c)
 #'
-#' collapse (barbiturates [1:3], collapse.equal = FALSE)
-#'
-
+#' collapse(barbiturates [1:3], collapse.equal = FALSE)
 collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.equal = TRUE) {
   wl.tolerance <- .checkpos(wl.tolerance, "wl.tolerance")
   dots <- list(...)

--- a/hyperSpec/R/collapse.R
+++ b/hyperSpec/R/collapse.R
@@ -1,58 +1,58 @@
-##' collapse/bind several hyperSpec objects into one object
-##'
-##' The spectra from all objects will be put into one object.
-##' The resulting object has all wavelengths that occur in any of the input objects,
-##' `wl.tolerance` is used to determine which difference in the wavelengths is
-##' tolerated as equal: clusters of approximately equal wavelengths will span at most `2 * wl.tolerance`.
-##' Differences up to +/- `wl.tolerance` are considered equal.
-##'
-##' The returned object has wavelengths that are the weighted average
-##' (by number of spectra) of the wavelengths within any such cluster of approximately
-##' equal wavelengths.
-##'
-##' Labels will be taken from the first object where they are encountered. However,
-##' the order of processing objects is not necessarily the same as the order of objects
-##' in the input: `collapse` first processes groups of input objects that share all
-##' wavelengths (within `wl.tolerance`).
-##'
-##' Data points corresponding to wavelengths not in the original spectrum will be set to NA.
-##' Extra data is combined in the same manner.
-##'
-##' If the objects are named, the names will be preserved in extra data column `$.name`.
-##' If the wavelengths are names, names are preserved and taken from the first object where they were encountered,
-##' the same applies to possible column names of the spectra matrix.
-##'
-##' @author C. Beleites
-##' @md
-##' @title Collapse hyperSpec objects
-##' @export
-##' @param ... hyperSpec objects to be collapsed into one object. Instead of giving several
-##' arguments, a list with all objects to be collapsed may be given.
-##' @param wl.tolerance tolerance to decide which wavelengths are considered equal.
-##' @param collapse.equal logical indicating whether to try first finding groups of spectra
-##' with (approximately) equal wavelength axes. If the data is known to contain few or no
-##' such groups, `collapse()` will be faster with this first pass being turned off.
-##' @aliases collapse collapse.hyperSpec
-##' @seealso [merge()],  [rbind()], and [plyr::rbind.fill()]
-##' @return a hyperSpec object
-##' @importFrom dplyr group_by
-##' @importFrom dplyr summarise
-##' @keywords manip
-##' @examples
-##' barbiturates [1:3]
-##' collapse (barbiturates [1:3])
-##'
-##' a <- barbiturates [[1]]
-##' b <- barbiturates [[2]]
-##' c <- barbiturates [[3]]
-##'
-##' a
-##' b
-##' c
-##' collapse (a, b, c)
-##'
-##' collapse (barbiturates [1:3], collapse.equal = FALSE)
-##'
+#' collapse/bind several hyperSpec objects into one object
+#'
+#' The spectra from all objects will be put into one object.
+#' The resulting object has all wavelengths that occur in any of the input objects,
+#' `wl.tolerance` is used to determine which difference in the wavelengths is
+#' tolerated as equal: clusters of approximately equal wavelengths will span at most `2 * wl.tolerance`.
+#' Differences up to +/- `wl.tolerance` are considered equal.
+#'
+#' The returned object has wavelengths that are the weighted average
+#' (by number of spectra) of the wavelengths within any such cluster of approximately
+#' equal wavelengths.
+#'
+#' Labels will be taken from the first object where they are encountered. However,
+#' the order of processing objects is not necessarily the same as the order of objects
+#' in the input: `collapse` first processes groups of input objects that share all
+#' wavelengths (within `wl.tolerance`).
+#'
+#' Data points corresponding to wavelengths not in the original spectrum will be set to NA.
+#' Extra data is combined in the same manner.
+#'
+#' If the objects are named, the names will be preserved in extra data column `$.name`.
+#' If the wavelengths are names, names are preserved and taken from the first object where they were encountered,
+#' the same applies to possible column names of the spectra matrix.
+#'
+#' @author C. Beleites
+#' @md
+#' @title Collapse hyperSpec objects
+#' @export
+#' @param ... hyperSpec objects to be collapsed into one object. Instead of giving several
+#' arguments, a list with all objects to be collapsed may be given.
+#' @param wl.tolerance tolerance to decide which wavelengths are considered equal.
+#' @param collapse.equal logical indicating whether to try first finding groups of spectra
+#' with (approximately) equal wavelength axes. If the data is known to contain few or no
+#' such groups, `collapse()` will be faster with this first pass being turned off.
+#' @aliases collapse collapse.hyperSpec
+#' @seealso [merge()],  [rbind()], and [plyr::rbind.fill()]
+#' @return a hyperSpec object
+#' @importFrom dplyr group_by
+#' @importFrom dplyr summarise
+#' @keywords manip
+#' @examples
+#' barbiturates [1:3]
+#' collapse (barbiturates [1:3])
+#'
+#' a <- barbiturates [[1]]
+#' b <- barbiturates [[2]]
+#' c <- barbiturates [[3]]
+#'
+#' a
+#' b
+#' c
+#' collapse (a, b, c)
+#'
+#' collapse (barbiturates [1:3], collapse.equal = FALSE)
+#'
 
 collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.equal = TRUE) {
   wl.tolerance <- .checkpos(wl.tolerance, "wl.tolerance")
@@ -136,7 +136,7 @@ collapse <- function(..., wl.tolerance = hy.getOption("wl.tolerance"), collapse.
   new("hyperSpec", wavelength = wl, data = dots, labels = labels)
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(collapse) <- function() {
   context("collapse")
 

--- a/hyperSpec/R/count_lines.R
+++ b/hyperSpec/R/count_lines.R
@@ -1,11 +1,11 @@
-##' count lines (of an ASCII file)
-##'
-##' @param file the file name or connection
-##' @param chunksize `file` is read in chunks of `chunksize` lines.
-##' @return number of lines in file
-##' @export
-##' @md
-##' @author C. Beleites
+#' count lines (of an ASCII file)
+#'
+#' @param file the file name or connection
+#' @param chunksize `file` is read in chunks of `chunksize` lines.
+#' @return number of lines in file
+#' @export
+#' @md
+#' @author C. Beleites
 count_lines <- function(file, chunksize = 1e4) {
   nlines <- 0
 

--- a/hyperSpec/R/cov.R
+++ b/hyperSpec/R/cov.R
@@ -1,16 +1,16 @@
-##' Covariance matrices for hyperSpec objects
-##'
-##'
-##' @param x hyperSpec object
-##' @param y not supported
-##' @param use,method handed to  \code{\link[stats]{cov}}
-##' @return covariance matrix of size \code{nwl (x)} x  \code{nwl (x)}
-##' @seealso \code{\link[stats]{cov}}
-##' @author C. Beleites
-##' @rdname cov
-##' @export
-##' @examples
-##' image (cov (faux_cell))
+#' Covariance matrices for hyperSpec objects
+#'
+#'
+#' @param x hyperSpec object
+#' @param y not supported
+#' @param use,method handed to  \code{\link[stats]{cov}}
+#' @return covariance matrix of size \code{nwl (x)} x  \code{nwl (x)}
+#' @seealso \code{\link[stats]{cov}}
+#' @author C. Beleites
+#' @rdname cov
+#' @export
+#' @examples
+#' image (cov (faux_cell))
 setMethod("cov", signature = signature(x = "hyperSpec", y = "missing"), function(x, y, use, method) {
   validObject(x)
 
@@ -18,18 +18,18 @@ setMethod("cov", signature = signature(x = "hyperSpec", y = "missing"), function
 })
 
 
-##' @param ... ignored
-##' @param regularize regularization of the covariance matrix. Set \code{0} to switch off
-##'
-##' \code{pooled.cov} calculates pooled covariance like e.g. in LDA.
-##' @param groups factor indicating the groups
-##' @rdname cov
-##' @export
-##' @examples
-##' pcov <-  pooled.cov (faux_cell, faux_cell$region)
-##' plot (pcov$means)
-##' image (pcov$COV)
-##'
+#' @param ... ignored
+#' @param regularize regularization of the covariance matrix. Set \code{0} to switch off
+#'
+#' \code{pooled.cov} calculates pooled covariance like e.g. in LDA.
+#' @param groups factor indicating the groups
+#' @rdname cov
+#' @export
+#' @examples
+#' pcov <-  pooled.cov (faux_cell, faux_cell$region)
+#' plot (pcov$means)
+#' image (pcov$COV)
+#'
 pooled.cov <- function(x, groups, ..., regularize = 1e-5 * max(abs(COV))) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/cov.R
+++ b/hyperSpec/R/cov.R
@@ -10,7 +10,7 @@
 #' @rdname cov
 #' @export
 #' @examples
-#' image (cov (faux_cell))
+#' image(cov(faux_cell))
 setMethod("cov", signature = signature(x = "hyperSpec", y = "missing"), function(x, y, use, method) {
   validObject(x)
 
@@ -26,10 +26,9 @@ setMethod("cov", signature = signature(x = "hyperSpec", y = "missing"), function
 #' @rdname cov
 #' @export
 #' @examples
-#' pcov <-  pooled.cov (faux_cell, faux_cell$region)
-#' plot (pcov$means)
-#' image (pcov$COV)
-#'
+#' pcov <- pooled.cov(faux_cell, faux_cell$region)
+#' plot(pcov$means)
+#' image(pcov$COV)
 pooled.cov <- function(x, groups, ..., regularize = 1e-5 * max(abs(COV))) {
   chk.hy(x)
   validObject(x)
@@ -38,7 +37,7 @@ pooled.cov <- function(x, groups, ..., regularize = 1e-5 * max(abs(COV))) {
     stop("groups must be a factor")
   }
 
-  x      <- x      [!is.na(groups)]
+  x <- x      [!is.na(groups)]
   groups <- groups [!is.na(groups)]
 
   means <- aggregate(x, groups, "mean") # TODO: speed up?

--- a/hyperSpec/R/decomposition.R
+++ b/hyperSpec/R/decomposition.R
@@ -1,78 +1,78 @@
-##' Convert Principal Component Decomposition or the like into a hyperSpec
-##' Object
-##'
-##' Decomposition of the spectra matrix is a common procedure in chemometric
-##' data analysis. \code{scores} and \code{loadings} convert the result matrices
-##' into new \code{hyperSpec} objects.
-##'
-##' Multivariate data are frequently decomposed by methods like principal
-##' component analysis, partial least squares, linear discriminant analysis, and
-##' the like.  These methods yield latent spectra (or latent variables,
-##' loadings, components, \dots{}) that are linear combination coefficients
-##' along the wavelength axis and scores for each spectrum and loading.
-##'
-##' The loadings matrix gives a coordinate transformation, and the scores are
-##' values in that new coordinate system.
-##'
-##' The obtained latent variables are spectra-like objects: a latent variable
-##' has a coefficient for each wavelength. If such a matrix (with the same
-##' number of columns as \code{object} has wavelengths) is given to
-##' \code{decomposition} (also setting \code{scores = FALSE}), the spectra
-##' matrix is replaced by \code{x}. Moreover, all columns of \code{object@@data}
-##' that did not contain the same value for all spectra are set to \code{NA}.
-##' Thus, for the resulting \code{hyperSpec} object, \code{\link{plotspc}} and
-##' related functions are meaningful. \code{\link[hyperSpec]{plotmap}} cannot be
-##' applied as the loadings are not laterally resolved.
-##'
-##' The scores matrix needs to have the same number of rows as \code{object} has
-##' spectra. If such a matrix is given, \code{decomposition} will replace the
-##' spectra matrix is replaced by \code{x} and \code{object@@wavelength} by
-##' \code{wavelength}. The information related to each of the spectra is
-##' retained. For such a \code{hyperSpec} object, \code{\link{plotmap}} and
-##' \code{\link{plotc}} and the like can be applied. It is also possible to use
-##' the spectra plotting, but the interpretation is not that of the spectrum any
-##' longer.
-##'
-##' @param object A \code{hyperSpec} object.
-##' @param x matrix with the new content for \code{object@@data$spc}.
-##'
-##'   Its size must correspond to rows (for \code{scores}) and to either columns
-##'   or rows (for \code{loadings}) of \code{object}.
-##' @param wavelength for a scores-like \code{x}: the new
-##'   \code{object@@wavelength}.
-##' @param label.wavelength The new label for the wavelength axis (if \code{x}
-##'   is scores-like). If not given, the label of \code{object} is kept.
-##' @param label.spc The new label for the spectra matrix. If not given, the
-##'   label of \code{object} is kept.
-##' @param scores is \code{x} a scores-like matrix?
-##' @param retain.columns for loading-like decompostition (i.e. \code{x} holds
-##'   loadings, pure component spectra or the like), the data columns need
-##'   special attention.
-##'
-##'   Columns with different values across the rows will be set to \code{NA} if
-##'   \code{retain.columns} is \code{TRUE}, otherwise they will be deleted.
-##' @param ... ignored.
-##' @return A \code{hyperSpec} object, updated according to \code{x}
-##' @author C. Beleites
-##' @seealso See \code{\link{\%*\%}} for matrix multiplication of
-##'   \code{hyperSpec} objects.
-##'
-##'   See e.g. \code{\link[stats]{prcomp}} and \code{\link[stats]{princomp}} for
-##'   principal component analysis, and package \code{pls} for Partial Least
-##'   Squares Regression.
-##' @keywords methods manip
-##' @include apply.R
-##' @examples
-##' pca <- prcomp (flu)
-##'
-##' pca.loadings <- decomposition (flu, t (pca$rotation), scores = FALSE)
-##' pca.center <- decomposition (flu, pca$center, scores = FALSE)
-##' pca.scores <- decomposition (flu, pca$x)
-##'
-##' plot (pca.center)
-##' plot (pca.loadings, col = c ("red", "gray50"))
-##' plotc (pca.scores, groups = .wavelength)
-##' @export
+#' Convert Principal Component Decomposition or the like into a hyperSpec
+#' Object
+#'
+#' Decomposition of the spectra matrix is a common procedure in chemometric
+#' data analysis. \code{scores} and \code{loadings} convert the result matrices
+#' into new \code{hyperSpec} objects.
+#'
+#' Multivariate data are frequently decomposed by methods like principal
+#' component analysis, partial least squares, linear discriminant analysis, and
+#' the like.  These methods yield latent spectra (or latent variables,
+#' loadings, components, \dots{}) that are linear combination coefficients
+#' along the wavelength axis and scores for each spectrum and loading.
+#'
+#' The loadings matrix gives a coordinate transformation, and the scores are
+#' values in that new coordinate system.
+#'
+#' The obtained latent variables are spectra-like objects: a latent variable
+#' has a coefficient for each wavelength. If such a matrix (with the same
+#' number of columns as \code{object} has wavelengths) is given to
+#' \code{decomposition} (also setting \code{scores = FALSE}), the spectra
+#' matrix is replaced by \code{x}. Moreover, all columns of \code{object@@data}
+#' that did not contain the same value for all spectra are set to \code{NA}.
+#' Thus, for the resulting \code{hyperSpec} object, \code{\link{plotspc}} and
+#' related functions are meaningful. \code{\link[hyperSpec]{plotmap}} cannot be
+#' applied as the loadings are not laterally resolved.
+#'
+#' The scores matrix needs to have the same number of rows as \code{object} has
+#' spectra. If such a matrix is given, \code{decomposition} will replace the
+#' spectra matrix is replaced by \code{x} and \code{object@@wavelength} by
+#' \code{wavelength}. The information related to each of the spectra is
+#' retained. For such a \code{hyperSpec} object, \code{\link{plotmap}} and
+#' \code{\link{plotc}} and the like can be applied. It is also possible to use
+#' the spectra plotting, but the interpretation is not that of the spectrum any
+#' longer.
+#'
+#' @param object A \code{hyperSpec} object.
+#' @param x matrix with the new content for \code{object@@data$spc}.
+#'
+#'   Its size must correspond to rows (for \code{scores}) and to either columns
+#'   or rows (for \code{loadings}) of \code{object}.
+#' @param wavelength for a scores-like \code{x}: the new
+#'   \code{object@@wavelength}.
+#' @param label.wavelength The new label for the wavelength axis (if \code{x}
+#'   is scores-like). If not given, the label of \code{object} is kept.
+#' @param label.spc The new label for the spectra matrix. If not given, the
+#'   label of \code{object} is kept.
+#' @param scores is \code{x} a scores-like matrix?
+#' @param retain.columns for loading-like decompostition (i.e. \code{x} holds
+#'   loadings, pure component spectra or the like), the data columns need
+#'   special attention.
+#'
+#'   Columns with different values across the rows will be set to \code{NA} if
+#'   \code{retain.columns} is \code{TRUE}, otherwise they will be deleted.
+#' @param ... ignored.
+#' @return A \code{hyperSpec} object, updated according to \code{x}
+#' @author C. Beleites
+#' @seealso See \code{\link{\%*\%}} for matrix multiplication of
+#'   \code{hyperSpec} objects.
+#'
+#'   See e.g. \code{\link[stats]{prcomp}} and \code{\link[stats]{princomp}} for
+#'   principal component analysis, and package \code{pls} for Partial Least
+#'   Squares Regression.
+#' @keywords methods manip
+#' @include apply.R
+#' @examples
+#' pca <- prcomp (flu)
+#'
+#' pca.loadings <- decomposition (flu, t (pca$rotation), scores = FALSE)
+#' pca.center <- decomposition (flu, pca$center, scores = FALSE)
+#' pca.scores <- decomposition (flu, pca$x)
+#'
+#' plot (pca.center)
+#' plot (pca.loadings, col = c ("red", "gray50"))
+#' plotc (pca.scores, groups = .wavelength)
+#' @export
 decomposition <- function(object, x, wavelength = seq_len(ncol(x)),
                           label.wavelength, label.spc,
                           scores = TRUE, retain.columns = FALSE,
@@ -145,7 +145,7 @@ decomposition <- function(object, x, wavelength = seq_len(ncol(x)),
   object
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(decomposition) <- function() {
   context("decomposition")
 

--- a/hyperSpec/R/decomposition.R
+++ b/hyperSpec/R/decomposition.R
@@ -157,43 +157,43 @@ decomposition <- function(object, x, wavelength = seq_len(ncol(x)),
     tmp@wavelength <- seq_len(nwl(tmp))
     colnames(tmp@data$spc) <- seq_len(nwl(tmp))
 
-    scores <- decomposition(flu, flu [[, , 405 ~ 410]])
+    scores <- decomposition(flu, flu[[, , 405 ~ 410]])
     expect_equal(scores, tmp)
   })
 
   test_that("spc labels", {
-    scores <- decomposition(flu, flu [[, , 405 ~ 410]], label.spc = "bla")
+    scores <- decomposition(flu, flu[[, , 405 ~ 410]], label.spc = "bla")
     expect_equal(labels(scores, "spc"), "bla")
   })
 
   test_that("wl labels", {
-    scores <- decomposition(flu, flu [[, , 405 ~ 410]], label.wavelength = "bla")
+    scores <- decomposition(flu, flu[[, , 405 ~ 410]], label.wavelength = "bla")
     expect_equal(labels(scores, ".wavelength"), "bla")
   })
 
   test_that("check loadings-like", {
     tmp <- flu [1, c("spc"), ]
-    loadings <- decomposition(flu, flu [[1, , ]])
+    loadings <- decomposition(flu, flu[[1, , ]])
     expect_equal(loadings, tmp)
   })
 
   test_that("POSIXct", {
     flu$ct <- as.POSIXct(Sys.time())
-    expect_equal(decomposition(flu, flu [[]], scores = FALSE)$ct, flu$ct)
+    expect_equal(decomposition(flu, flu[[]], scores = FALSE)$ct, flu$ct)
   })
 
   test_that("POSIXlt", {
     flu$lt <- as.POSIXlt(Sys.time())
-    expect_equal(decomposition(flu, flu [[]], scores = FALSE)$lt, flu$lt)
+    expect_equal(decomposition(flu, flu[[]], scores = FALSE)$lt, flu$lt)
   })
 
   test_that("spc labels", {
-    tmp <- decomposition(flu, flu [[]], scores = FALSE, label.spc = "bla")
+    tmp <- decomposition(flu, flu[[]], scores = FALSE, label.spc = "bla")
     expect_equal(labels(tmp, "spc"), "bla")
   })
 
   test_that("wl labels: should *not* be changed for loadings-like decomposition", {
-    tmp <- decomposition(flu, flu [[]], scores = FALSE, label.wavelength = "bla")
+    tmp <- decomposition(flu, flu[[]], scores = FALSE, label.wavelength = "bla")
     expect_equal(labels(tmp, ".wavelength"), labels(flu, ".wavelength"))
   })
 }

--- a/hyperSpec/R/decomposition.R
+++ b/hyperSpec/R/decomposition.R
@@ -63,15 +63,15 @@
 #' @keywords methods manip
 #' @include apply.R
 #' @examples
-#' pca <- prcomp (flu)
+#' pca <- prcomp(flu)
 #'
-#' pca.loadings <- decomposition (flu, t (pca$rotation), scores = FALSE)
-#' pca.center <- decomposition (flu, pca$center, scores = FALSE)
-#' pca.scores <- decomposition (flu, pca$x)
+#' pca.loadings <- decomposition(flu, t(pca$rotation), scores = FALSE)
+#' pca.center <- decomposition(flu, pca$center, scores = FALSE)
+#' pca.scores <- decomposition(flu, pca$x)
 #'
-#' plot (pca.center)
-#' plot (pca.loadings, col = c ("red", "gray50"))
-#' plotc (pca.scores, groups = .wavelength)
+#' plot(pca.center)
+#' plot(pca.loadings, col = c("red", "gray50"))
+#' plotc(pca.scores, groups = .wavelength)
 #' @export
 decomposition <- function(object, x, wavelength = seq_len(ncol(x)),
                           label.wavelength, label.spc,

--- a/hyperSpec/R/deprecated.R
+++ b/hyperSpec/R/deprecated.R
@@ -1,48 +1,48 @@
 
 
-##' @rdname read.asc.Andor
-##' @export
-##' @keywords internal
+#' @rdname read.asc.Andor
+#' @export
+#' @keywords internal
 scan.asc.Andor <- function(...) {
   .Deprecated("read.asc.Andor")
   read.asc.Andor(...)
 }
 
-##' @rdname read.txt.Renishaw
-##' @export
-##' @keywords internal
+#' @rdname read.txt.Renishaw
+#' @export
+#' @keywords internal
 scan.txt.Renishaw <- function(...) {
   .Deprecated("read.txt.Renishaw()")
   read.txt.Renishaw(...)
 }
 
-##' @rdname read.txt.Renishaw
-##' @export
-##' @keywords internal
+#' @rdname read.txt.Renishaw
+#' @export
+#' @keywords internal
 scan.zip.Renishaw <- function(...) {
   .Deprecated("read.(zip.Renishaw)")
   read.zip.Renishaw(...)
 }
 
-##' @rdname read.txt.Witec
-##' @export
-##' @keywords internal
+#' @rdname read.txt.Witec
+#' @export
+#' @keywords internal
 scan.txt.Witec <- function(...) {
   .Deprecated("read.txt.Witec()")
   read.txt.Witec(...)
 }
 
-##' @rdname read.txt.Witec
-##' @export
-##' @keywords internal
+#' @rdname read.txt.Witec
+#' @export
+#' @keywords internal
 scan.dat.Witec <- function(...) {
   .Deprecated("read.(dat.Witec)")
   read.dat.Witec(...)
 }
 
-##' @rdname read.txt.Witec
-##' @export
-##' @keywords internal
+#' @rdname read.txt.Witec
+#' @export
+#' @keywords internal
 scan.txt.Witec.Graph <- function(...) {
   .Deprecated("read.txt.Witec.Graph()")
   read.txt.Witec.Graph(...)
@@ -51,8 +51,8 @@ scan.txt.Witec.Graph <- function(...) {
 
 #### DEFUNCT ##################################################################################################
 
-##' @export
-##' @rdname read.mat.Cytospec
+#' @export
+#' @rdname read.mat.Cytospec
 read.cytomat <- function(...) {
   .Defunct("read.mat.Cytospec",
     package = "hyperSpec",

--- a/hyperSpec/R/dim.R
+++ b/hyperSpec/R/dim.R
@@ -15,7 +15,7 @@
 #' @export
 #' @examples
 #'
-#' ncol (faux_cell)
+#' ncol(faux_cell)
 setMethod("ncol", signature = signature("hyperSpec"), function(x) {
   validObject(x)
 
@@ -30,7 +30,7 @@ setMethod("ncol", signature = signature("hyperSpec"), function(x) {
 #' @seealso \code{\link[base]{nrow}}
 #' @export
 #' @examples
-#' nrow (faux_cell)
+#' nrow(faux_cell)
 setMethod("nrow", signature = signature("hyperSpec"), function(x) {
   validObject(x)
 
@@ -46,7 +46,7 @@ setMethod("nrow", signature = signature("hyperSpec"), function(x) {
 #' @export
 #' @examples
 #'
-#' nwl  (faux_cell)
+#' nwl(faux_cell)
 nwl <- function(x) {
   chk.hy(x)
   validObject(x)
@@ -68,7 +68,7 @@ nwl <- function(x) {
 #' @keywords methods
 #' @export
 #' @examples
-#' dim (faux_cell)
+#' dim(faux_cell)
 setMethod("dim", signature = signature("hyperSpec"), function(x) {
   validObject(x)
   c(nrow = nrow(x@data), ncol = ncol(x@data), nwl = ncol(x@data$spc))
@@ -81,7 +81,7 @@ setMethod("dim", signature = signature("hyperSpec"), function(x) {
 #' @seealso \code{\link[base]{length}}
 #' @export
 #' @examples
-#' length (faux_cell)
+#' length(faux_cell)
 setMethod("length", signature = signature("hyperSpec"), function(x) {
   validObject(x)
   nrow(x@data)

--- a/hyperSpec/R/dim.R
+++ b/hyperSpec/R/dim.R
@@ -1,52 +1,52 @@
-##' The Number of Rows (Spectra), Columns, and Data Points per Spectrum of an
-##' hyperSpec Object)
-##'
-##' \code{ncol} returns the number of columns in \code{x@@data}. I.e. the number
-##' of columns with additional information to each spectrum (e.g. "x", "y",
-##' \dots{}) + 1 (for column \code{spc} containing the spectra).
-##' @rdname dim
-##' @docType methods
-##' @param x a \code{hyperSpec} object
-##' @author C. Beleites
-##' @seealso \code{\link[base]{ncol}}
-##'
-##' @return \code{nrow}, \code{ncol}, \code{nwl}, and \code{length}, return an
-##'   \code{integer}.
-##' @export
-##' @examples
-##'
-##' ncol (faux_cell)
+#' The Number of Rows (Spectra), Columns, and Data Points per Spectrum of an
+#' hyperSpec Object)
+#'
+#' \code{ncol} returns the number of columns in \code{x@@data}. I.e. the number
+#' of columns with additional information to each spectrum (e.g. "x", "y",
+#' \dots{}) + 1 (for column \code{spc} containing the spectra).
+#' @rdname dim
+#' @docType methods
+#' @param x a \code{hyperSpec} object
+#' @author C. Beleites
+#' @seealso \code{\link[base]{ncol}}
+#'
+#' @return \code{nrow}, \code{ncol}, \code{nwl}, and \code{length}, return an
+#'   \code{integer}.
+#' @export
+#' @examples
+#'
+#' ncol (faux_cell)
 setMethod("ncol", signature = signature("hyperSpec"), function(x) {
   validObject(x)
 
   ncol(x@data)
 })
 
-##'
-##' \code{nrow} yields the number of rows in \code{x@@data}, i.e. the number of
-##' spectra in the \code{hyperSpec} object.
-##'
-##' @rdname dim
-##' @seealso \code{\link[base]{nrow}}
-##' @export
-##' @examples
-##' nrow (faux_cell)
+#'
+#' \code{nrow} yields the number of rows in \code{x@@data}, i.e. the number of
+#' spectra in the \code{hyperSpec} object.
+#'
+#' @rdname dim
+#' @seealso \code{\link[base]{nrow}}
+#' @export
+#' @examples
+#' nrow (faux_cell)
 setMethod("nrow", signature = signature("hyperSpec"), function(x) {
   validObject(x)
 
   nrow(x@data)
 })
 
-##'
-##' \code{nwl} returns the number of columns in \code{x@@data$spc}, i.e. the
-##' length of each spectrum.
-##'
-##' @rdname dim
-##' @aliases nwl
-##' @export
-##' @examples
-##'
-##' nwl  (faux_cell)
+#'
+#' \code{nwl} returns the number of columns in \code{x@@data$spc}, i.e. the
+#' length of each spectrum.
+#'
+#' @rdname dim
+#' @aliases nwl
+#' @export
+#' @examples
+#'
+#' nwl  (faux_cell)
 nwl <- function(x) {
   chk.hy(x)
   validObject(x)
@@ -56,32 +56,32 @@ nwl <- function(x) {
 
 
 
-##'
-##' \code{dim} returns all three values in a vector.
-##'
-##'
-##' @rdname dim
-##' @return
-##'
-##' \code{dim} returns a vector of length 3.
-##' @seealso \code{\link[base]{dim}}
-##' @keywords methods
-##' @export
-##' @examples
-##' dim (faux_cell)
+#'
+#' \code{dim} returns all three values in a vector.
+#'
+#'
+#' @rdname dim
+#' @return
+#'
+#' \code{dim} returns a vector of length 3.
+#' @seealso \code{\link[base]{dim}}
+#' @keywords methods
+#' @export
+#' @examples
+#' dim (faux_cell)
 setMethod("dim", signature = signature("hyperSpec"), function(x) {
   validObject(x)
   c(nrow = nrow(x@data), ncol = ncol(x@data), nwl = ncol(x@data$spc))
 })
 
-##'
-##' \code{length} is a synonym for \code{nrow}. It is supplied so that
-##' \code{seq_along (x)} returns a sequence to index each spectrum.
-##' @rdname dim
-##' @seealso \code{\link[base]{length}}
-##' @export
-##' @examples
-##' length (faux_cell)
+#'
+#' \code{length} is a synonym for \code{nrow}. It is supplied so that
+#' \code{seq_along (x)} returns a sequence to index each spectrum.
+#' @rdname dim
+#' @seealso \code{\link[base]{length}}
+#' @export
+#' @examples
+#' length (faux_cell)
 setMethod("length", signature = signature("hyperSpec"), function(x) {
   validObject(x)
   nrow(x@data)

--- a/hyperSpec/R/dimnames.R
+++ b/hyperSpec/R/dimnames.R
@@ -14,7 +14,7 @@
 #' \code{\link[base]{dimnames}}
 #' @export
 #' @examples
-#' dimnames (flu)
+#' dimnames(flu)
 setMethod("dimnames", signature = signature(x = "hyperSpec"), function(x) {
   validObject(x)
 
@@ -32,7 +32,7 @@ setMethod("dimnames", signature = signature(x = "hyperSpec"), function(x) {
 #' @seealso \code{\link[base]{rownames}}
 #' @export
 #' @examples
-#' rownames (flu)
+#' rownames(flu)
 setMethod("rownames", signature = signature(x = "hyperSpec"), function(x, do.NULL = TRUE, prefix = "row") {
   validObject(x)
 
@@ -58,8 +58,7 @@ setReplaceMethod("rownames", signature = signature(x = "hyperSpec"), function(x,
 #' @seealso \code{\link[base]{colnames}}
 #' @export
 #' @examples
-#' colnames (faux_cell)
-
+#' colnames(faux_cell)
 setMethod("colnames",
   signature = signature(x = "hyperSpec"),
   function(x, do.NULL = TRUE, prefix = "col") {

--- a/hyperSpec/R/dimnames.R
+++ b/hyperSpec/R/dimnames.R
@@ -1,20 +1,20 @@
-##' dimnames for hyperSpec objects
-##'
-##' hyperSpec objects can have row- and column names like data.frames. The "names" of the wavelengths
-##' are treated separately: see \code{\link{wl}}
-##'
-##' @param x the hyperSpec object
-##' @aliases dimnames
-##' @keywords methods
-##' @rdname dimnames
-##' @docType methods
-##' @author C. Beleites
-##' @seealso \code{\link{wl}} for the wavelength dimension
-##'
-##' \code{\link[base]{dimnames}}
-##' @export
-##' @examples
-##' dimnames (flu)
+#' dimnames for hyperSpec objects
+#'
+#' hyperSpec objects can have row- and column names like data.frames. The "names" of the wavelengths
+#' are treated separately: see \code{\link{wl}}
+#'
+#' @param x the hyperSpec object
+#' @aliases dimnames
+#' @keywords methods
+#' @rdname dimnames
+#' @docType methods
+#' @author C. Beleites
+#' @seealso \code{\link{wl}} for the wavelength dimension
+#'
+#' \code{\link[base]{dimnames}}
+#' @export
+#' @examples
+#' dimnames (flu)
 setMethod("dimnames", signature = signature(x = "hyperSpec"), function(x) {
   validObject(x)
 
@@ -24,28 +24,28 @@ setMethod("dimnames", signature = signature(x = "hyperSpec"), function(x) {
   )
 })
 
-##' @rdname dimnames
-##' @aliases rownames
-##' @param do.NULL handed to \code{\link[base]{rownames}} or \code{\link[base]{colnames}}: logical.
-##' Should this create names if they are \code{NULL}?
-##' @param prefix handed to \code{\link[base]{rownames}} or \code{\link[base]{colnames}}
-##' @seealso \code{\link[base]{rownames}}
-##' @export
-##' @examples
-##' rownames (flu)
+#' @rdname dimnames
+#' @aliases rownames
+#' @param do.NULL handed to \code{\link[base]{rownames}} or \code{\link[base]{colnames}}: logical.
+#' Should this create names if they are \code{NULL}?
+#' @param prefix handed to \code{\link[base]{rownames}} or \code{\link[base]{colnames}}
+#' @seealso \code{\link[base]{rownames}}
+#' @export
+#' @examples
+#' rownames (flu)
 setMethod("rownames", signature = signature(x = "hyperSpec"), function(x, do.NULL = TRUE, prefix = "row") {
   validObject(x)
 
   rownames(x@data, do.NULL = do.NULL, prefix = prefix)
 })
 
-##' @param value the new names
-##' @usage
-##' \S4method{rownames}{hyperSpec} (x) <- value
-##' @aliases rownames<-,hyperSpec-method
-##' @rdname dimnames
-##' @name rownames<-
-##' @export "rownames<-"
+#' @param value the new names
+#' @usage
+#' \S4method{rownames}{hyperSpec} (x) <- value
+#' @aliases rownames<-,hyperSpec-method
+#' @rdname dimnames
+#' @name rownames<-
+#' @export "rownames<-"
 setReplaceMethod("rownames", signature = signature(x = "hyperSpec"), function(x, value) {
   validObject(x)
 
@@ -53,12 +53,12 @@ setReplaceMethod("rownames", signature = signature(x = "hyperSpec"), function(x,
   x
 })
 
-##' @rdname dimnames
-##' @aliases colnames
-##' @seealso \code{\link[base]{colnames}}
-##' @export
-##' @examples
-##' colnames (faux_cell)
+#' @rdname dimnames
+#' @aliases colnames
+#' @seealso \code{\link[base]{colnames}}
+#' @export
+#' @examples
+#' colnames (faux_cell)
 
 setMethod("colnames",
   signature = signature(x = "hyperSpec"),
@@ -68,12 +68,12 @@ setMethod("colnames",
   }
 )
 
-##' @rdname dimnames
-##' @usage
-##' \S4method{colnames}{hyperSpec} (x) <- value
-##' @aliases colnames<-,hyperSpec-method
-##' @name colnames<-
-##' @export "colnames<-"
+#' @rdname dimnames
+#' @usage
+#' \S4method{colnames}{hyperSpec} (x) <- value
+#' @aliases colnames<-,hyperSpec-method
+#' @name colnames<-
+#' @export "colnames<-"
 setReplaceMethod("colnames",
   signature = signature(x = "hyperSpec"),
   function(x, value) {

--- a/hyperSpec/R/empty.R
+++ b/hyperSpec/R/empty.R
@@ -1,19 +1,19 @@
-##' Empty hyperSpec object
-##'
-##' Empty produces an hyperSpec object with the same columns and wavelengths as \code{x}.  The new
-##' object will either contain no rows at all (default), or the given number of rows with all data
-##' initialized to \code{spc} and \code{extra}, respectively.
-##'
-##' @aliases empty
-##' @author C. Beleites
-##' @keywords manip
-##' @export
-##' @examples
-##' empty (faux_cell, nrow = 2, spc = 0)
-##' @param x hyperSpec object
-##' @param nrow number of rows the new object should have
-##' @param spc value to initialize the new spectra matrix with
-##' @param extra value to initialize the new extra data with
+#' Empty hyperSpec object
+#'
+#' Empty produces an hyperSpec object with the same columns and wavelengths as \code{x}.  The new
+#' object will either contain no rows at all (default), or the given number of rows with all data
+#' initialized to \code{spc} and \code{extra}, respectively.
+#'
+#' @aliases empty
+#' @author C. Beleites
+#' @keywords manip
+#' @export
+#' @examples
+#' empty (faux_cell, nrow = 2, spc = 0)
+#' @param x hyperSpec object
+#' @param nrow number of rows the new object should have
+#' @param spc value to initialize the new spectra matrix with
+#' @param extra value to initialize the new extra data with
 empty <- function(x, nrow = 0, spc = NA, extra = NA) {
   if (nrow(x@data) == 0 && nrow > 0) {
     stop("Empty is not implemented for empty (0 row) objects")

--- a/hyperSpec/R/empty.R
+++ b/hyperSpec/R/empty.R
@@ -9,7 +9,7 @@
 #' @keywords manip
 #' @export
 #' @examples
-#' empty (faux_cell, nrow = 2, spc = 0)
+#' empty(faux_cell, nrow = 2, spc = 0)
 #' @param x hyperSpec object
 #' @param nrow number of rows the new object should have
 #' @param spc value to initialize the new spectra matrix with

--- a/hyperSpec/R/expand.R
+++ b/hyperSpec/R/expand.R
@@ -24,22 +24,26 @@
   }
 
   ## vector corresponding to whole matrix
-  if (is.vector(m) & length(m) == prod(target.dim))
+  if (is.vector(m) & length(m) == prod(target.dim)) {
     m <- matrix(m, nrow = target.dim[1])
+  }
 
   ## remaining type of vector: column vector
-  if (is.vector(m))
+  if (is.vector(m)) {
     m <- as.matrix(m)
+  }
 
   m.dim <- dim(m)
 
   # hyperSpec objects have columns of spectra matrix in 3rd dimension
-  if (is(m, "hyperSpec"))
+  if (is(m, "hyperSpec")) {
     m.dim <- m.dim[c(1, 3)]
+  }
 
   # check for mismatch
-  if (any(m.dim > 1L & m.dim != target.dim))
+  if (any(m.dim > 1L & m.dim != target.dim)) {
     stop("Dimension mismatch.")
+  }
 
 
   if (m.dim[1] == 1L & target.dim[1] > 1L) {
@@ -59,13 +63,13 @@
   m
 }
 
-.test(.expand) <- function(){
+.test(.expand) <- function() {
   context(".expand helper function for sweep shortcut operators")
 
   test_that("scalar", {
     expect_equal(.expand(1, c(1, 3)), matrix(rep(1, 3), nrow = 1, ncol = 3))
     expect_equal(.expand(1, c(3, 1)), matrix(rep(1, 3), nrow = 3, ncol = 1))
-    expect_equal(.expand(1, c(3, 5)), matrix(rep(1, 3*5), nrow = 3, ncol = 5))
+    expect_equal(.expand(1, c(3, 5)), matrix(rep(1, 3 * 5), nrow = 3, ncol = 5))
     expect_equal(.expand(1, c(1, 1)), matrix(1))
   })
 
@@ -73,7 +77,7 @@
     v <- 1:5
 
     expect_equal(.expand(v, c(1, 5)), t(v))
-    expect_equal(.expand(v, c(3, 5)), t(v)[rep(1, 3),])
+    expect_equal(.expand(v, c(3, 5)), t(v)[rep(1, 3), ])
 
     expect_error(.expand(v, c(1, 3)), "Dimension mismatch")
     expect_error(.expand(v, c(6, 3)), "Dimension mismatch")
@@ -100,7 +104,7 @@
     m <- matrix(1:5, ncol = 5)
 
     expect_equal(.expand(m, c(1, 5)), m)
-    expect_equal(.expand(m, c(3, 5)), m[rep(1, 3),])
+    expect_equal(.expand(m, c(3, 5)), m[rep(1, 3), ])
 
     expect_error(.expand(m, c(1, 3)), "Dimension mismatch")
     expect_error(.expand(m, c(6, 3)), "Dimension mismatch")
@@ -110,7 +114,7 @@
     m <- matrix(1:5, nrow = 5)
 
     expect_equal(.expand(m, c(5, 1)), m)
-    expect_equal(.expand(m, c(5, 3)), m[,rep(1, 3)])
+    expect_equal(.expand(m, c(5, 3)), m[, rep(1, 3)])
 
     expect_error(.expand(m, c(3, 1)), "Dimension mismatch")
     expect_error(.expand(m, c(3, 6)), "Dimension mismatch")
@@ -128,10 +132,12 @@
   })
 
   test_that("1 x 1 hyperSpec spectra matrix ('scalar')", {
-    h  <- new("hyperSpec", spc = matrix(1), data = data.frame(c = 3))
+    h <- new("hyperSpec", spc = matrix(1), data = data.frame(c = 3))
 
-    h3 <- new("hyperSpec", spc = t(rep(1, 3)), data = data.frame(c = 3),
-              wavelength = rep(1, 3))
+    h3 <- new("hyperSpec",
+      spc = t(rep(1, 3)), data = data.frame(c = 3),
+      wavelength = rep(1, 3)
+    )
 
     expect_equal(.expand(h, c(1, 1)), h)
     expect_equal(.expand(h, c(1, 3)), h3)
@@ -143,15 +149,15 @@
     v <- flu[1]
 
     expect_equal(.expand(v, c(1, 181)), v)
-    expect_equal(.expand(v, c(3, 181)), v[rep(1, 3),])
+    expect_equal(.expand(v, c(3, 181)), v[rep(1, 3), ])
 
     expect_error(.expand(v, c(1, 3)), "Dimension mismatch")
     expect_error(.expand(v, c(6, 3)), "Dimension mismatch")
   })
 
   test_that("n x 1 hyperSpec spectra matrix (column matrix)", {
-    v  <- flu[,,450]
-    v3 <- flu[,,rep(450,3)]
+    v <- flu[, , 450]
+    v3 <- flu[, , rep(450, 3)]
 
     expect_equal(.expand(v, c(6, 1)), v)
     expect_equal(.expand(v, c(6, 3)), v3)
@@ -161,7 +167,6 @@
   })
 
   test_that("hyperSpec spectra matrix with > 1 row & > 1 column: leave unchanged", {
-
     expect_equal(.expand(flu, c(6, 181)), flu)
 
     expect_error(.expand(flu, c(1, 181)), "Dimension mismatch")
@@ -169,4 +174,3 @@
     expect_error(.expand(flu, c(5, 6)), "Dimension mismatch")
   })
 }
-

--- a/hyperSpec/R/expand.R
+++ b/hyperSpec/R/expand.R
@@ -1,17 +1,17 @@
-##' Expand scalar, vector, matrix or similarly shaped hyperSpec objec to matrix
-##'
-##' Helper function for hyperSpec arithmetics.
-##'
-##' A row- or column vector or
-##' a matrix of size 1 x n or n x 1 or
-##' a hyperSpec object with 1 row or 1 wavelength will be expanded
-##' along the size-1-dimension.
-##'
-##' Dimensions that have size > 1 lead to an error if the size does not match.
-##'
-##' @param m matrix, vector or scalar
-##' @param target.dim target size to expand the vector to for the sweep-shortcuts
-##' @noRd
+#' Expand scalar, vector, matrix or similarly shaped hyperSpec objec to matrix
+#'
+#' Helper function for hyperSpec arithmetics.
+#'
+#' A row- or column vector or
+#' a matrix of size 1 x n or n x 1 or
+#' a hyperSpec object with 1 row or 1 wavelength will be expanded
+#' along the size-1-dimension.
+#'
+#' Dimensions that have size > 1 lead to an error if the size does not match.
+#'
+#' @param m matrix, vector or scalar
+#' @param target.dim target size to expand the vector to for the sweep-shortcuts
+#' @noRd
 .expand <- function(m, target.dim) {
 
   ## vector corresponding to a single row

--- a/hyperSpec/R/extract.R
+++ b/hyperSpec/R/extract.R
@@ -3,8 +3,8 @@
 ### .extract - internal function doing the work for extracting with [] and [[]]
 ###
 
-##' @include wl2i.R
-##' @noRd
+#' @include wl2i.R
+#' @noRd
 .extract <- function(x, i, j, l,
                      ...,
                      wl.index = FALSE) {
@@ -33,169 +33,169 @@
   x
 }
 
-##' These Methods allow to extract and replace parts of the \code{hyperSpec} object.
-##'
-##' They work with respect to the spectra (rows of \code{x}), the columns of the data matrix, and the
-##' wavelengths (columns of the spectra matrix).
-##'
-##' Thus, they can be used for selecting/deleting spectra, cutting the spectral range, and extracting
-##' or setting the data belonging to the spectra.
-##'
-##' Convenient shortcuts for access of the spectra matrix and the \code{data.frame} in slot
-##' \code{data} are provided.
-##'
-##' \emph{Extracting: \code{[}, \code{[[}, and \code{$}}.
-##'
-##' The version with single square brackets (\code{[}) returns the resulting \code{hyperSpec} object.
-##'
-##' \code{[[} yields \code{data.frame} of slot \code{@@data} of that corresponding \code{hyperSpec}
-##' object returned with the same arguments by \code{[} if columns were selected (i.e. \code{j} is
-##' given), otherwise the spectra \code{matrix} \code{x@@data$spc}.
-##'
-##' \code{$} returns the selected column of the \code{data.frame} in slot \code{@@data}.
-##'
-##' \emph{Shortcuts.} Three shortcuts to conveniently extract much needed parts of the object are
-##' defined:
-##'
-##' \code{x[[]]} returns the spectra matrix.
-##'
-##' \code{x$.} returns the complete slot \code{@@data}, including the spectra matrix in column
-##' \code{$spc}, as a \code{data.frame}.
-##'
-##' \code{x$..} returns a \code{data.frame} like \code{x$.} but without the spectra matrix.
-##'
-##' \emph{Replacing: \code{[<-}, \code{[[<-}, and \code{$<-}}.
-##' \preformatted{
-##' ## S4 method for signature 'hyperSpec':
-##' x [i, j, l, \dots] <- value
-##'
-##' ## S4 method for signature 'hyperSpec':
-##' x [[i, j, l, wl.index = FALSE, \dots]] <- value
-##'
-##' ## S4 method for signature 'hyperSpec':
-##' x$name <- value
-##' }
-##'
-##' \code{value} gives the values to be assigned.\cr
-##'
-##' For \code{$}, this can also be a list of the form \code{list (value =
-##' value, label = label)}, with \code{label} containing the label for data
-##' column \code{name}.
-##'
-##' \code{[[<-} replaces parts of the spectra matrix.
-##'
-##' \code{[<-} replaces parts of the \code{data.frame} in slot \code{x@@data}.
-##'
-##' \code{$<-} replaces a column of the \code{data.frame} in slot
-##' \code{x@@data}.  The \code{value} may be a list with two elements,
-##' \code{value} and \code{label}.  In this case the label of the data column
-##' is changed accordingly.
-##'
-##' \code{$..<-} is again an abbreviation for the data.frame without the
-##' spectra matrix.
-##'
+#' These Methods allow to extract and replace parts of the \code{hyperSpec} object.
+#'
+#' They work with respect to the spectra (rows of \code{x}), the columns of the data matrix, and the
+#' wavelengths (columns of the spectra matrix).
+#'
+#' Thus, they can be used for selecting/deleting spectra, cutting the spectral range, and extracting
+#' or setting the data belonging to the spectra.
+#'
+#' Convenient shortcuts for access of the spectra matrix and the \code{data.frame} in slot
+#' \code{data} are provided.
+#'
+#' \emph{Extracting: \code{[}, \code{[[}, and \code{$}}.
+#'
+#' The version with single square brackets (\code{[}) returns the resulting \code{hyperSpec} object.
+#'
+#' \code{[[} yields \code{data.frame} of slot \code{@@data} of that corresponding \code{hyperSpec}
+#' object returned with the same arguments by \code{[} if columns were selected (i.e. \code{j} is
+#' given), otherwise the spectra \code{matrix} \code{x@@data$spc}.
+#'
+#' \code{$} returns the selected column of the \code{data.frame} in slot \code{@@data}.
+#'
+#' \emph{Shortcuts.} Three shortcuts to conveniently extract much needed parts of the object are
+#' defined:
+#'
+#' \code{x[[]]} returns the spectra matrix.
+#'
+#' \code{x$.} returns the complete slot \code{@@data}, including the spectra matrix in column
+#' \code{$spc}, as a \code{data.frame}.
+#'
+#' \code{x$..} returns a \code{data.frame} like \code{x$.} but without the spectra matrix.
+#'
+#' \emph{Replacing: \code{[<-}, \code{[[<-}, and \code{$<-}}.
+#' \preformatted{
+#' ## S4 method for signature 'hyperSpec':
+#' x [i, j, l, \dots] <- value
+#'
+#' ## S4 method for signature 'hyperSpec':
+#' x [[i, j, l, wl.index = FALSE, \dots]] <- value
+#'
+#' ## S4 method for signature 'hyperSpec':
+#' x$name <- value
+#' }
+#'
+#' \code{value} gives the values to be assigned.\cr
+#'
+#' For \code{$}, this can also be a list of the form \code{list (value =
+#' value, label = label)}, with \code{label} containing the label for data
+#' column \code{name}.
+#'
+#' \code{[[<-} replaces parts of the spectra matrix.
+#'
+#' \code{[<-} replaces parts of the \code{data.frame} in slot \code{x@@data}.
+#'
+#' \code{$<-} replaces a column of the \code{data.frame} in slot
+#' \code{x@@data}.  The \code{value} may be a list with two elements,
+#' \code{value} and \code{label}.  In this case the label of the data column
+#' is changed accordingly.
+#'
+#' \code{$..<-} is again an abbreviation for the data.frame without the
+#' spectra matrix.
+#'
 
-##' @title Extract and Replace parts of hyperSpec objects
-##' @rdname extractreplace
-##' @docType methods
-##' @aliases [ [,hyperSpec-method
-##' @param x a \code{hyperSpec} Object
-##' @param i row index: selects spectra
-##'
-##' \code{[[} and code{[[<-} accept indexing with logical matrix or a n by 2
-##'   integer index matrix. In this case the indexing is done inside the
-##'   spectra matrix. See the examples below.
-##' @param j selecting columns of \code{x@@data}
-##' @param l selecting columns of the spectra matrix. If \code{l} is numeric,
-##'   the default behaviour is treating \code{l} as wavelengths, \emph{not} as
-##'   indices.
-##' @param wl.index If \code{TRUE} (default), the value(s) in \code{l} are
-##'   treated as column indices for the spectral matrix. Otherwise, the numbers
-##'   in \code{l} are treated as wavelengths and the corresponding column
-##'   indices are looked up first via \code{\link{wl2i}}.
-##' @param drop For \code{[[}: drop unnecessary dimensions, see
-##'   \code{\link[base]{drop}} and \code{\link[base]{Extract}}. Ignored for
-##'   \code{[}, as otherwise invalid \code{hyperSpec} objects might result.
-##' @param ... ignored
-##' @return For \code{[}, \code{[<-}, \code{[[<-}, and \code{$<-} a \code{hyperSpec} object,
-##'
-##' for \code{[[} a matrix or \code{data.frame}, and
-##'
-##' for \code{$} the column of the \code{data.frame} \code{@@data}.
-##'
-##' \code{x[[]]} returns the complete spectra matrix.
-##'
-##' \code{x$.} returns the complete slot \code{@@data},
-##'
-##' \code{x$..} returns the \code{data.frame} in \code{@@data} but without the column
-##' \code{@@data$spc} containing the spectra matrix.
-##' @seealso \code{\link{wl2i}} on conversion of wavelength ranges to indices.
-##'
-##' \code{\link[base]{drop}} and \code{\link[base]{Extract}} on \code{drop}.
-##' @keywords methods manip
-##' @examples
-##'
-##' ## index into the rows (spectra) -------------------------------------
-##' ## make some "spectra"
-##'
-##' ## numeric index
-##' plot (flu, "spc", lines.args = list (lty = 2))
-##' plot (flu[1:3], "spc", add = TRUE, col = "red")     # select spectra
-##' plot (flu[-(1:3)], "spc", add = TRUE, col = "blue") # delete spectra
-##'
-##' ## logic index
-##' plot (flu, "spc", lines.args = list (lty = 2))
-##' index <- rnorm (6) > 0
-##' index
-##' plot (flu[index], "spc", add = TRUE, col = "red")   # select spectra
-##' plot (flu[!index], "spc", add = TRUE, col = "blue") # select spectra
-##'
-##' ## index into the data columns ---------------------------------------
-##' range (faux_cell[[,"x"]])
-##' colnames (faux_cell[[,1]])
-##' dim (faux_cell[[,c(TRUE, FALSE, FALSE)]])
-##' faux_cell$x
-##'
-##'
-##' ## the shortcut functions --------------------------------------------
-##'
-##' ## extract the spectra matrix
-##' flu[[]]
-##'
-##' ## indexing via logical matrix
-##' summary (flu [[flu < 125]])
-##'
-##' ## indexing the spectra matrix with index matrix n by 2
-##' ind <- matrix (c (1, 2, 4, 406, 405.5, 409), ncol = 2)
-##' ind
-##' flu [[ind]]
-##'
-##' ind <- matrix (c (1, 2, 4, 4:6), ncol = 2)
-##' ind
-##' flu [[ind, wl.index = TRUE]]
-##'
-##' pca <- prcomp (flu[[]])
-##'
-##' ## result is data.frame, if j is given:
-##' result <- flu [[, 1:2, 405 ~ 410]]
-##' result
-##' class (result)
-##' colnames (result)
-##'
-##' ## extract the data.frame including the spectra matrix
-##' flu$.
-##' dim(flu$.)
-##' colnames (flu$.)
-##' flu$.$spc
-##'
-##' calibration <- lm (spc ~ c, data = flu[,,450]$.)
-##' calibration
-##'
-##' flu$..
-##' colnames (flu$..)
-##'
-##' @include call.list.R
-##' @export
+#' @title Extract and Replace parts of hyperSpec objects
+#' @rdname extractreplace
+#' @docType methods
+#' @aliases [ [,hyperSpec-method
+#' @param x a \code{hyperSpec} Object
+#' @param i row index: selects spectra
+#'
+#' \code{[[} and code{[[<-} accept indexing with logical matrix or a n by 2
+#'   integer index matrix. In this case the indexing is done inside the
+#'   spectra matrix. See the examples below.
+#' @param j selecting columns of \code{x@@data}
+#' @param l selecting columns of the spectra matrix. If \code{l} is numeric,
+#'   the default behaviour is treating \code{l} as wavelengths, \emph{not} as
+#'   indices.
+#' @param wl.index If \code{TRUE} (default), the value(s) in \code{l} are
+#'   treated as column indices for the spectral matrix. Otherwise, the numbers
+#'   in \code{l} are treated as wavelengths and the corresponding column
+#'   indices are looked up first via \code{\link{wl2i}}.
+#' @param drop For \code{[[}: drop unnecessary dimensions, see
+#'   \code{\link[base]{drop}} and \code{\link[base]{Extract}}. Ignored for
+#'   \code{[}, as otherwise invalid \code{hyperSpec} objects might result.
+#' @param ... ignored
+#' @return For \code{[}, \code{[<-}, \code{[[<-}, and \code{$<-} a \code{hyperSpec} object,
+#'
+#' for \code{[[} a matrix or \code{data.frame}, and
+#'
+#' for \code{$} the column of the \code{data.frame} \code{@@data}.
+#'
+#' \code{x[[]]} returns the complete spectra matrix.
+#'
+#' \code{x$.} returns the complete slot \code{@@data},
+#'
+#' \code{x$..} returns the \code{data.frame} in \code{@@data} but without the column
+#' \code{@@data$spc} containing the spectra matrix.
+#' @seealso \code{\link{wl2i}} on conversion of wavelength ranges to indices.
+#'
+#' \code{\link[base]{drop}} and \code{\link[base]{Extract}} on \code{drop}.
+#' @keywords methods manip
+#' @examples
+#'
+#' ## index into the rows (spectra) -------------------------------------
+#' ## make some "spectra"
+#'
+#' ## numeric index
+#' plot (flu, "spc", lines.args = list (lty = 2))
+#' plot (flu[1:3], "spc", add = TRUE, col = "red")     # select spectra
+#' plot (flu[-(1:3)], "spc", add = TRUE, col = "blue") # delete spectra
+#'
+#' ## logic index
+#' plot (flu, "spc", lines.args = list (lty = 2))
+#' index <- rnorm (6) > 0
+#' index
+#' plot (flu[index], "spc", add = TRUE, col = "red")   # select spectra
+#' plot (flu[!index], "spc", add = TRUE, col = "blue") # select spectra
+#'
+#' ## index into the data columns ---------------------------------------
+#' range (faux_cell[[,"x"]])
+#' colnames (faux_cell[[,1]])
+#' dim (faux_cell[[,c(TRUE, FALSE, FALSE)]])
+#' faux_cell$x
+#'
+#'
+#' ## the shortcut functions --------------------------------------------
+#'
+#' ## extract the spectra matrix
+#' flu[[]]
+#'
+#' ## indexing via logical matrix
+#' summary (flu [[flu < 125]])
+#'
+#' ## indexing the spectra matrix with index matrix n by 2
+#' ind <- matrix (c (1, 2, 4, 406, 405.5, 409), ncol = 2)
+#' ind
+#' flu [[ind]]
+#'
+#' ind <- matrix (c (1, 2, 4, 4:6), ncol = 2)
+#' ind
+#' flu [[ind, wl.index = TRUE]]
+#'
+#' pca <- prcomp (flu[[]])
+#'
+#' ## result is data.frame, if j is given:
+#' result <- flu [[, 1:2, 405 ~ 410]]
+#' result
+#' class (result)
+#' colnames (result)
+#'
+#' ## extract the data.frame including the spectra matrix
+#' flu$.
+#' dim(flu$.)
+#' colnames (flu$.)
+#' flu$.$spc
+#'
+#' calibration <- lm (spc ~ c, data = flu[,,450]$.)
+#' calibration
+#'
+#' flu$..
+#' colnames (flu$..)
+#'
+#' @include call.list.R
+#' @export
 setMethod("[",
   signature = signature(x = "hyperSpec"),
   function(x, i, j, l, ...,
@@ -224,9 +224,9 @@ setMethod("[",
   }
 )
 
-##' @rdname extractreplace
-##' @export
-##' @aliases [[ [[,hyperSpec-method
+#' @rdname extractreplace
+#' @export
+#' @aliases [[ [[,hyperSpec-method
 ## ' @name [[
 setMethod("[[",
   signature = signature(x = "hyperSpec"),
@@ -266,10 +266,10 @@ setMethod("[[",
   }
 )
 
-##' @rdname extractreplace
-##' @param name name of the data column to extract. \code{$spc} yields the spectra matrix.
-##' @aliases $ $,hyperSpec-method
-##' @export
+#' @rdname extractreplace
+#' @param name name of the data column to extract. \code{$spc} yields the spectra matrix.
+#' @aliases $ $,hyperSpec-method
+#' @export
 setMethod("$",
   signature = signature(x = "hyperSpec"),
   function(x, name) {

--- a/hyperSpec/R/extract.R
+++ b/hyperSpec/R/extract.R
@@ -70,7 +70,7 @@
 #' x [i, j, l, \dots] <- value
 #'
 #' ## S4 method for signature 'hyperSpec':
-#' x [[i, j, l, wl.index = FALSE, \dots]] <- value
+#' x[[i, j, l, wl.index = FALSE, \dots]] <- value
 #'
 #' ## S4 method for signature 'hyperSpec':
 #' x$name <- value
@@ -163,21 +163,21 @@
 #' flu[[]]
 #'
 #' ## indexing via logical matrix
-#' summary(flu [[flu < 125]])
+#' summary(flu[[flu < 125]])
 #'
 #' ## indexing the spectra matrix with index matrix n by 2
 #' ind <- matrix(c(1, 2, 4, 406, 405.5, 409), ncol = 2)
 #' ind
-#' flu [[ind]]
+#' flu[[ind]]
 #'
 #' ind <- matrix(c(1, 2, 4, 4:6), ncol = 2)
 #' ind
-#' flu [[ind, wl.index = TRUE]]
+#' flu[[ind, wl.index = TRUE]]
 #'
 #' pca <- prcomp(flu[[]])
 #'
 #' ## result is data.frame, if j is given:
-#' result <- flu [[, 1:2, 405 ~ 410]]
+#' result <- flu[[, 1:2, 405 ~ 410]]
 #' result
 #' class(result)
 #' colnames(result)

--- a/hyperSpec/R/extract.R
+++ b/hyperSpec/R/extract.R
@@ -139,21 +139,21 @@
 #' ## make some "spectra"
 #'
 #' ## numeric index
-#' plot (flu, "spc", lines.args = list (lty = 2))
-#' plot (flu[1:3], "spc", add = TRUE, col = "red")     # select spectra
-#' plot (flu[-(1:3)], "spc", add = TRUE, col = "blue") # delete spectra
+#' plot(flu, "spc", lines.args = list(lty = 2))
+#' plot(flu[1:3], "spc", add = TRUE, col = "red") # select spectra
+#' plot(flu[-(1:3)], "spc", add = TRUE, col = "blue") # delete spectra
 #'
 #' ## logic index
-#' plot (flu, "spc", lines.args = list (lty = 2))
-#' index <- rnorm (6) > 0
+#' plot(flu, "spc", lines.args = list(lty = 2))
+#' index <- rnorm(6) > 0
 #' index
-#' plot (flu[index], "spc", add = TRUE, col = "red")   # select spectra
-#' plot (flu[!index], "spc", add = TRUE, col = "blue") # select spectra
+#' plot(flu[index], "spc", add = TRUE, col = "red") # select spectra
+#' plot(flu[!index], "spc", add = TRUE, col = "blue") # select spectra
 #'
 #' ## index into the data columns ---------------------------------------
-#' range (faux_cell[[,"x"]])
-#' colnames (faux_cell[[,1]])
-#' dim (faux_cell[[,c(TRUE, FALSE, FALSE)]])
+#' range(faux_cell[[, "x"]])
+#' colnames(faux_cell[[, 1]])
+#' dim(faux_cell[[, c(TRUE, FALSE, FALSE)]])
 #' faux_cell$x
 #'
 #'
@@ -163,37 +163,36 @@
 #' flu[[]]
 #'
 #' ## indexing via logical matrix
-#' summary (flu [[flu < 125]])
+#' summary(flu [[flu < 125]])
 #'
 #' ## indexing the spectra matrix with index matrix n by 2
-#' ind <- matrix (c (1, 2, 4, 406, 405.5, 409), ncol = 2)
+#' ind <- matrix(c(1, 2, 4, 406, 405.5, 409), ncol = 2)
 #' ind
 #' flu [[ind]]
 #'
-#' ind <- matrix (c (1, 2, 4, 4:6), ncol = 2)
+#' ind <- matrix(c(1, 2, 4, 4:6), ncol = 2)
 #' ind
 #' flu [[ind, wl.index = TRUE]]
 #'
-#' pca <- prcomp (flu[[]])
+#' pca <- prcomp(flu[[]])
 #'
 #' ## result is data.frame, if j is given:
 #' result <- flu [[, 1:2, 405 ~ 410]]
 #' result
-#' class (result)
-#' colnames (result)
+#' class(result)
+#' colnames(result)
 #'
 #' ## extract the data.frame including the spectra matrix
 #' flu$.
 #' dim(flu$.)
-#' colnames (flu$.)
+#' colnames(flu$.)
 #' flu$.$spc
 #'
-#' calibration <- lm (spc ~ c, data = flu[,,450]$.)
+#' calibration <- lm(spc ~ c, data = flu[, , 450]$.)
 #' calibration
 #'
 #' flu$..
-#' colnames (flu$..)
-#'
+#' colnames(flu$..)
 #' @include call.list.R
 #' @export
 setMethod("[",

--- a/hyperSpec/R/faux_cell.R
+++ b/hyperSpec/R/faux_cell.R
@@ -12,8 +12,7 @@
   # @param rot rotation angle
   # @return logical indicating points inside the ellipse
   in_ellipse <- function(xy, center = c(0, 0), scale = c(1, 1), a = 0,
-                         debuglevel = 0L
-  ) {
+                         debuglevel = 0L) {
     xy <- as.matrix(xy)
     xy <- scale(xy, center = center, scale = FALSE)
     xy <- xy %*% matrix(c(cos(a), -sin(a), sin(a), cos(a)), ncol = 2)
@@ -21,8 +20,9 @@
 
     pt_in <- rowSums(xy^2) <= 1
 
-    if (debuglevel >= 1L)
+    if (debuglevel >= 1L) {
       plot(xy[, 1], xy[, 2], asp = 1, pch = 19, col = pt_in + 1)
+    }
 
     ## backtransformed points within unit circle?
     pt_in
@@ -44,14 +44,16 @@
   xy$region <- "matrix"
 
   pts_in_cell <- in_ellipse(xy[c("x", "y")],
-                            center = c(10, 10),
-                            scale = c(6, 10), a = -pi / 8)
+    center = c(10, 10),
+    scale = c(6, 10), a = -pi / 8
+  )
   xy$region[pts_in_cell] <- "cell"
 
 
   pts_in_nucleus <- in_ellipse(xy[c("x", "y")],
-                               center = c(12.5, 8),
-                               scale = c(3, 4), a = pi / 6)
+    center = c(12.5, 8),
+    scale = c(3, 4), a = pi / 6
+  )
   xy$region[pts_in_nucleus] <- "nucleus"
 
   xy$region <- as.factor(xy$region)
@@ -64,10 +66,12 @@
     wavelength = wavelength,
     data = xy,
     spc = matrix(0, nrow = nrow(xy), ncol = length(wavelength)),
-    label = list(spc = "intensity (arbitrary units)",
-                 .wavelength = expression(Delta * tilde(nu) / cm^-1),
-                 x = "x position",
-                 y = "y position")
+    label = list(
+      spc = "intensity (arbitrary units)",
+      .wavelength = expression(Delta * tilde(nu) / cm^-1),
+      x = "x position",
+      y = "y position"
+    )
   )
 
   ## 3. generate fake spectra
@@ -79,7 +83,7 @@
   tmp <- 7000 * dnorm(wavelength, mean = 1200, sd = 15)
   spc[[spc$region == "cell", , ]] <- rep(tmp, each = sum(spc$region == "cell"))
 
-  tmp <- 3000 * dnorm(wavelength, mean = 1500, sd =  5)
+  tmp <- 3000 * dnorm(wavelength, mean = 1500, sd = 5)
   spc[[spc$region == "nucleus", , ]] <- rep(tmp, each = sum(spc$region == "nucleus"))
 
   # add baselines
@@ -116,12 +120,14 @@
 #'
 #' faux_cell
 #'
-#' plot (sample (faux_cell, 10), stacked = TRUE)
+#' plot(sample(faux_cell, 10), stacked = TRUE)
 #'
 #' # Plot mean spectra
 #' FCgrps <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
-#' plotspc(FCgrps, stacked = ".aggregate",
-#'         col = c("red", "green", "blue"), fill = ".aggregate")
+#' plotspc(FCgrps,
+#'   stacked = ".aggregate",
+#'   col = c("red", "green", "blue"), fill = ".aggregate"
+#' )
 #'
 #' mapcols <- c(cell = "aquamarine", matrix = "aliceblue", nucleus = "dodgerblue")
 #' plotmap(faux_cell, region ~ x * y, col.regions = mapcols)
@@ -131,9 +137,10 @@
 #' plot(pca)
 #'
 #' loadings <- decomposition(faux_cell, t(pca$rotation), scores = FALSE)
-#' plot(loadings[1 : 5], stacked = TRUE)
+#' plot(loadings[1:5], stacked = TRUE)
 #'
-#' plot(pca$x[,2], pca$x[,3], xlab = "PC 1", ylab = "PC 2",
-#'   bg = mapcols[faux_cell$region], col = "black", pch = 21)
-#'
+#' plot(pca$x[, 2], pca$x[, 3],
+#'   xlab = "PC 1", ylab = "PC 2",
+#'   bg = mapcols[faux_cell$region], col = "black", pch = 21
+#' )
 delayedAssign("faux_cell", .faux_cell())

--- a/hyperSpec/R/fileio.optional.R
+++ b/hyperSpec/R/fileio.optional.R
@@ -40,9 +40,9 @@
 
   test_that("removing of zero/NA spectra", {
     tmp <- fluNA # spectrum 2 is all NA
-    tmp [[3]] <- 0
-    tmp [[5]] <- runif(nwl(tmp), min = -hy.getOption("tolerance") / 2, max = hy.getOption("tolerance") / 2)
-    tmp [[, , 450 ~ 455]] <- NA
+    tmp[[3]] <- 0
+    tmp[[5]] <- runif(nwl(tmp), min = -hy.getOption("tolerance") / 2, max = hy.getOption("tolerance") / 2)
+    tmp[[, , 450 ~ 455]] <- NA
 
     expect_equivalent(
       .fileio.optional(tmp, file.remove.emptyspc = TRUE, file.keep.name = FALSE),

--- a/hyperSpec/R/fileio.optional.R
+++ b/hyperSpec/R/fileio.optional.R
@@ -34,7 +34,7 @@
   spc
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.fileio.optional) <- function() {
   context(".fileio.optional")
 

--- a/hyperSpec/R/flu.R
+++ b/hyperSpec/R/flu.R
@@ -16,8 +16,7 @@
 #'
 #' flu
 #'
-#' plot (flu)
+#' plot(flu)
 #'
-#' plotc (flu)
-#'
+#' plotc(flu)
 NULL

--- a/hyperSpec/R/flu.R
+++ b/hyperSpec/R/flu.R
@@ -1,23 +1,23 @@
-##' Quinine Fluorescence Spectra
-##' Fluorescence spectra of different dilutions of quinine forming a
-##' calibration set.
-##'
-##' See the vignette: \code{vignette ("flu", package = "hyperSpec")}
-##'
-##' @name flu
-##' @docType data
-##' @format The data set has 6 fluorescence emission spectra measured on
-##'   quinine concentrations between 0.05 mg/l and 0.30 mg/l.  Each spectrum
-##'   consists of 181 data points in the range of 405 nm to 495 nm.
-##' @author M. Kammer and C. Beleites
-##' @keywords datasets
-##' @include wl2i.R
-##' @examples
-##'
-##' flu
-##'
-##' plot (flu)
-##'
-##' plotc (flu)
-##'
+#' Quinine Fluorescence Spectra
+#' Fluorescence spectra of different dilutions of quinine forming a
+#' calibration set.
+#'
+#' See the vignette: \code{vignette ("flu", package = "hyperSpec")}
+#'
+#' @name flu
+#' @docType data
+#' @format The data set has 6 fluorescence emission spectra measured on
+#'   quinine concentrations between 0.05 mg/l and 0.30 mg/l.  Each spectrum
+#'   consists of 181 data points in the range of 405 nm to 495 nm.
+#' @author M. Kammer and C. Beleites
+#' @keywords datasets
+#' @include wl2i.R
+#' @examples
+#'
+#' flu
+#'
+#' plot (flu)
+#'
+#' plotc (flu)
+#'
 NULL

--- a/hyperSpec/R/guesswavelength.R
+++ b/hyperSpec/R/guesswavelength.R
@@ -14,7 +14,7 @@
 #' @export
 #'
 #' @examples
-#' tmp <- data.frame(flu [[, , 400 ~ 410]])
+#' tmp <- data.frame(flu[[, , 400 ~ 410]])
 #' (wl <- colnames(tmp))
 #' guess.wavelength(wl)
 guess.wavelength <- function(X) {

--- a/hyperSpec/R/guesswavelength.R
+++ b/hyperSpec/R/guesswavelength.R
@@ -31,8 +31,8 @@ guess.wavelength <- function(X) {
   wl
 }
 
-##' @include regexps.R
-##' @include options.R
+#' @include regexps.R
+#' @include options.R
 .test(guess.wavelength) <- function() {
   context("guess.wavelength")
 

--- a/hyperSpec/R/hyperspec-class.R
+++ b/hyperSpec/R/hyperspec-class.R
@@ -31,7 +31,9 @@
 #' @examples
 #'
 #' showClass("hyperSpec")
-#' \dontrun{vignette ("hyperspec")}
+#' \dontrun{
+#' vignette("hyperspec")
+#' }
 setClass("hyperSpec",
   representation = representation(
     wavelength = "numeric", # spectral abscissa

--- a/hyperSpec/R/hyperspec-class.R
+++ b/hyperSpec/R/hyperspec-class.R
@@ -1,37 +1,37 @@
-##' Class "hyperSpec"
-##' This class handles hyperspectral data sets, i.e. spatially or time-resolved
-##' spectra, or spectra with any other kind of information associated with the
-##' spectra.
-##'
-##' The spectra can be data as obtained in XRF, UV/VIS, Fluorescence, AES, NIR,
-##' IR, Raman, NMR, MS, etc.
-##'
-##' More generally, any data that is recorded over a discretized variable, e.g.
-##' absorbance = f (wavelength), stored as a vector of absorbance values for
-##' discrete wavelengths is suitable.
-##'
-##' @include validate.R
-##' @aliases hyperSpec-class
-##' @docType class
-##' @name hyperSpec-class
-##' @rdname hyperSpec-class
-##' @slot wavelength wavelengths (wavenumbers, frequencies, etc.) for each of the columns of the
-##' spectra matrix
-##' @slot data  the data (extra data and spectra matrix)
-##' @slot label expressions for column labels (incl. units). The label of the wavelength axis is in
-##' the special element \code{.wavelength}.
-##' @slot log deprecated.
-##' @note Please note that the logbook is now removed.
-##' @author C. Beleites
-##' @seealso See the vignette "hyperspec" for an introduction to hyperSpec
-##'   from a spectroscopic point of view.
-##' @keywords classes
-##' @export
-##' @include validate.R
-##' @examples
-##'
-##' showClass("hyperSpec")
-##' \dontrun{vignette ("hyperspec")}
+#' Class "hyperSpec"
+#' This class handles hyperspectral data sets, i.e. spatially or time-resolved
+#' spectra, or spectra with any other kind of information associated with the
+#' spectra.
+#'
+#' The spectra can be data as obtained in XRF, UV/VIS, Fluorescence, AES, NIR,
+#' IR, Raman, NMR, MS, etc.
+#'
+#' More generally, any data that is recorded over a discretized variable, e.g.
+#' absorbance = f (wavelength), stored as a vector of absorbance values for
+#' discrete wavelengths is suitable.
+#'
+#' @include validate.R
+#' @aliases hyperSpec-class
+#' @docType class
+#' @name hyperSpec-class
+#' @rdname hyperSpec-class
+#' @slot wavelength wavelengths (wavenumbers, frequencies, etc.) for each of the columns of the
+#' spectra matrix
+#' @slot data  the data (extra data and spectra matrix)
+#' @slot label expressions for column labels (incl. units). The label of the wavelength axis is in
+#' the special element \code{.wavelength}.
+#' @slot log deprecated.
+#' @note Please note that the logbook is now removed.
+#' @author C. Beleites
+#' @seealso See the vignette "hyperspec" for an introduction to hyperSpec
+#'   from a spectroscopic point of view.
+#' @keywords classes
+#' @export
+#' @include validate.R
+#' @examples
+#'
+#' showClass("hyperSpec")
+#' \dontrun{vignette ("hyperspec")}
 setClass("hyperSpec",
   representation = representation(
     wavelength = "numeric", # spectral abscissa

--- a/hyperSpec/R/hyperspec-package.R
+++ b/hyperSpec/R/hyperspec-package.R
@@ -1,34 +1,34 @@
-##' Interface for hyperspectral data sets
-##' This package gives an interface to handle hyperspectral data sets in R.
-##' Hyperspectral data are spatially or time-resolved spectra, or spectra with
-##' any other kind of information associated with the spectra. E.g. spectral
-##' maps or images, time series, calibration series, etc.
-##'
-##' The spectra can be data as obtained in XRF, UV/VIS, Fluorescence, AES, NIR,
-##' IR, Raman, NMR, MS, etc.
-##'
-##' More generally, any data that is recorded over a discretized variable, e.g.
-##' absorbance = f (wavelength), stored as a vector of absorbance values for
-##' discrete wavelengths is suitable.
-##'
-##' @name hyperSpec-package
-##' @title Package hyperSpec
-##' @docType package
-##' @author C. Beleites
-##'
-##' Maintainer: Claudia Beleites <claudia.beleites@@chemometrix.eu>
-##' @seealso \code{citation ("hyperSpec")} produces the correct citation.
-##'
-##' \code{package?hyperSpec} for information about the package
-##'
-##' \code{class?hyperSpec} for details on the S4 class provided by this
-##'   package.
-##' @rdname hyperSpec-package
-##' @include flu.R
-##' @include faux_cell.R
-##' @include laser.R
-##' @include paracetamol.R
-##' @include barbiturates.R
-##' @include unittest.R
-##' @keywords package
+#' Interface for hyperspectral data sets
+#' This package gives an interface to handle hyperspectral data sets in R.
+#' Hyperspectral data are spatially or time-resolved spectra, or spectra with
+#' any other kind of information associated with the spectra. E.g. spectral
+#' maps or images, time series, calibration series, etc.
+#'
+#' The spectra can be data as obtained in XRF, UV/VIS, Fluorescence, AES, NIR,
+#' IR, Raman, NMR, MS, etc.
+#'
+#' More generally, any data that is recorded over a discretized variable, e.g.
+#' absorbance = f (wavelength), stored as a vector of absorbance values for
+#' discrete wavelengths is suitable.
+#'
+#' @name hyperSpec-package
+#' @title Package hyperSpec
+#' @docType package
+#' @author C. Beleites
+#'
+#' Maintainer: Claudia Beleites <claudia.beleites@@chemometrix.eu>
+#' @seealso \code{citation ("hyperSpec")} produces the correct citation.
+#'
+#' \code{package?hyperSpec} for information about the package
+#'
+#' \code{class?hyperSpec} for details on the S4 class provided by this
+#'   package.
+#' @rdname hyperSpec-package
+#' @include flu.R
+#' @include faux_cell.R
+#' @include laser.R
+#' @include paracetamol.R
+#' @include barbiturates.R
+#' @include unittest.R
+#' @keywords package
 NULL

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -191,29 +191,33 @@
 #' @keywords methods datagen
 #' @examples
 #'
-#' new ("hyperSpec")
+#' new("hyperSpec")
 #'
-#' spc <- matrix (rnorm (12), ncol = 4)
-#' new ("hyperSpec", spc = spc)
-#' new ("hyperSpec", data = data.frame (x = letters[1:3]),
-#'      spc = spc)
-#'
-#' colnames (spc) <- 600:603
-#' new ("hyperSpec", spc = spc)  # wavelength taken from colnames (spc)
-#'
-#' # given wavelengths precede over colnames of spc
-#' new ("hyperSpec", spc = spc, wavelength = 700:703)
-#'
-#' # specifying labels
-#' h <- new ("hyperSpec", spc = spc, data = data.frame (pos = 1 : 3),
-#'           label = list (spc = "I / a.u.",
-#'                         .wavelength = expression (tilde (nu) / cm^-1),
-#'                         pos = expression ("/" (x, mu*m)))
+#' spc <- matrix(rnorm(12), ncol = 4)
+#' new("hyperSpec", spc = spc)
+#' new("hyperSpec",
+#'   data = data.frame(x = letters[1:3]),
+#'   spc = spc
 #' )
 #'
-#' plot (h)
-#' plotc (h, spc ~ pos)
+#' colnames(spc) <- 600:603
+#' new("hyperSpec", spc = spc) # wavelength taken from colnames (spc)
 #'
+#' # given wavelengths precede over colnames of spc
+#' new("hyperSpec", spc = spc, wavelength = 700:703)
+#'
+#' # specifying labels
+#' h <- new("hyperSpec",
+#'   spc = spc, data = data.frame(pos = 1:3),
+#'   label = list(
+#'     spc = "I / a.u.",
+#'     .wavelength = expression(tilde(nu) / cm^-1),
+#'     pos = expression("/"(x, mu * m))
+#'   )
+#' )
+#'
+#' plot(h)
+#' plotc(h, spc ~ pos)
 setMethod("initialize", "hyperSpec", .initialize)
 
 #' @include unittest.R

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -308,8 +308,8 @@ setMethod("initialize", "hyperSpec", .initialize)
     on.exit(hy.setOptions(gc = option))
     hy.setOptions(gc = TRUE)
 
-    spc <- new("hyperSpec", spc = flu [[]])
-    expect_equal(spc [[]], flu [[]])
+    spc <- new("hyperSpec", spc = flu[[]])
+    expect_equal(spc[[]], flu[[]])
   })
 }
 
@@ -346,7 +346,7 @@ setGeneric(
 #' @export
 #'
 #' @examples
-#' tmp <- data.frame(flu [[, , 400 ~ 410]])
+#' tmp <- data.frame(flu[[, , 400 ~ 410]])
 #' (wl <- colnames(tmp))
 #' guess.wavelength(wl)
 setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -5,8 +5,8 @@
 ###  C. Beleites
 ###
 
-##' @include paste.row.R
-##' @noRd
+#' @include paste.row.R
+#' @noRd
 .initialize <- function(.Object, spc = NULL, data = NULL, wavelength = NULL, labels = NULL) {
 
   ## do the small stuff first, so we need not be too careful about copies
@@ -143,80 +143,80 @@
   .Object
 }
 
-##' Creating a hyperSpec Object
-##'
-##' Like other S4 objects, a hyperSpec object can be created by \code{new}. The
-##' hyperSpec object is then \code{initialize}d using the given parameters.
-##'
-##' If option \code{gc} is \code{TRUE}, the initialization will have frequent
-##' calls to \code{gc ()} which can help to avoid swapping or running out of
-##' memory.
-##'
-##' @name initialize
-##' @rdname initialize
-##' @aliases initialize,hyperSpec-method initialize create
-##'   create,hyperSpec-method new,hyperSpec-method new
-##' @docType methods
-##' @param .Object the new \code{hyperSpec} object.
-##' @param data \code{data.frame}, possibly with the spectra in
-##'   \code{data$spc}, and further variates in more columns.  A matrix can be
-##'   entered as \emph{one} column of a data frame by: \code{data.frame (spc =
-##'   I (as.matrix (spc)))}.
-##'
-##' However, it will usually be more convenient if the spectra are given in
-##'   \code{spc}
-##' @param spc the spectra matrix.
-##'
-##' \code{spc} does not need to be a matrix, it is converted explicitly by
-##'   \code{I (as.matrix (spc))}.
-##' @param wavelength The wavelengths corresponding to the columns of
-##'   \code{data}. If no wavelengths are given, an appropriate vector is
-##'   derived from the column names of \code{data$spc}. If this is not
-##'   possible, \code{1 : ncol (data$spc)} is used instead.
-##' @param labels A \code{list} containing the labels for the columns of the
-##'   \code{data} slot of the \code{hyperSpec} object and for the wavelength
-##'   (in \code{label$.wavelength}). The labels should be given in a form ready
-##'   for the text-drawing functions (see \code{\link[grDevices]{plotmath}}).
-##'
-##' If \code{label} is not given, a list containing \code{NULL} for each of the
-##'   columns of\code{data} and \code{wavelength} is used.
-##' @author C.Beleites
-##' @seealso \code{\link[methods]{new}} for more information on creating and
-##'   initializing S4 objects.
-##'
-##' \code{\link[grDevices]{plotmath}} on expressions for math annotations as
-##'   for slot \code{label}.
-##'
-##' \code{\link{hy.setOptions}}
-##' @keywords methods datagen
-##' @examples
-##'
-##' new ("hyperSpec")
-##'
-##' spc <- matrix (rnorm (12), ncol = 4)
-##' new ("hyperSpec", spc = spc)
-##' new ("hyperSpec", data = data.frame (x = letters[1:3]),
-##'      spc = spc)
-##'
-##' colnames (spc) <- 600:603
-##' new ("hyperSpec", spc = spc)  # wavelength taken from colnames (spc)
-##'
-##' # given wavelengths precede over colnames of spc
-##' new ("hyperSpec", spc = spc, wavelength = 700:703)
-##'
-##' # specifying labels
-##' h <- new ("hyperSpec", spc = spc, data = data.frame (pos = 1 : 3),
-##'           label = list (spc = "I / a.u.",
-##'                         .wavelength = expression (tilde (nu) / cm^-1),
-##'                         pos = expression ("/" (x, mu*m)))
-##' )
-##'
-##' plot (h)
-##' plotc (h, spc ~ pos)
-##'
+#' Creating a hyperSpec Object
+#'
+#' Like other S4 objects, a hyperSpec object can be created by \code{new}. The
+#' hyperSpec object is then \code{initialize}d using the given parameters.
+#'
+#' If option \code{gc} is \code{TRUE}, the initialization will have frequent
+#' calls to \code{gc ()} which can help to avoid swapping or running out of
+#' memory.
+#'
+#' @name initialize
+#' @rdname initialize
+#' @aliases initialize,hyperSpec-method initialize create
+#'   create,hyperSpec-method new,hyperSpec-method new
+#' @docType methods
+#' @param .Object the new \code{hyperSpec} object.
+#' @param data \code{data.frame}, possibly with the spectra in
+#'   \code{data$spc}, and further variates in more columns.  A matrix can be
+#'   entered as \emph{one} column of a data frame by: \code{data.frame (spc =
+#'   I (as.matrix (spc)))}.
+#'
+#' However, it will usually be more convenient if the spectra are given in
+#'   \code{spc}
+#' @param spc the spectra matrix.
+#'
+#' \code{spc} does not need to be a matrix, it is converted explicitly by
+#'   \code{I (as.matrix (spc))}.
+#' @param wavelength The wavelengths corresponding to the columns of
+#'   \code{data}. If no wavelengths are given, an appropriate vector is
+#'   derived from the column names of \code{data$spc}. If this is not
+#'   possible, \code{1 : ncol (data$spc)} is used instead.
+#' @param labels A \code{list} containing the labels for the columns of the
+#'   \code{data} slot of the \code{hyperSpec} object and for the wavelength
+#'   (in \code{label$.wavelength}). The labels should be given in a form ready
+#'   for the text-drawing functions (see \code{\link[grDevices]{plotmath}}).
+#'
+#' If \code{label} is not given, a list containing \code{NULL} for each of the
+#'   columns of\code{data} and \code{wavelength} is used.
+#' @author C.Beleites
+#' @seealso \code{\link[methods]{new}} for more information on creating and
+#'   initializing S4 objects.
+#'
+#' \code{\link[grDevices]{plotmath}} on expressions for math annotations as
+#'   for slot \code{label}.
+#'
+#' \code{\link{hy.setOptions}}
+#' @keywords methods datagen
+#' @examples
+#'
+#' new ("hyperSpec")
+#'
+#' spc <- matrix (rnorm (12), ncol = 4)
+#' new ("hyperSpec", spc = spc)
+#' new ("hyperSpec", data = data.frame (x = letters[1:3]),
+#'      spc = spc)
+#'
+#' colnames (spc) <- 600:603
+#' new ("hyperSpec", spc = spc)  # wavelength taken from colnames (spc)
+#'
+#' # given wavelengths precede over colnames of spc
+#' new ("hyperSpec", spc = spc, wavelength = 700:703)
+#'
+#' # specifying labels
+#' h <- new ("hyperSpec", spc = spc, data = data.frame (pos = 1 : 3),
+#'           label = list (spc = "I / a.u.",
+#'                         .wavelength = expression (tilde (nu) / cm^-1),
+#'                         pos = expression ("/" (x, mu*m)))
+#' )
+#'
+#' plot (h)
+#' plotc (h, spc ~ pos)
+#'
 setMethod("initialize", "hyperSpec", .initialize)
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.initialize) <- function() {
   context(".initialize / new (\"hyperSpec\")")
 
@@ -366,7 +366,7 @@ setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
 #' and returns a hyperSpec object with 0 wavelengths. To get the old behaviour}
 setMethod("as.hyperSpec", "data.frame", .as.hyperSpec.data.frame)
 
-##' @include unittest.R
+#' @include unittest.R
 .test(as.hyperSpec) <- function() {
   context("as.hyperSpec")
 

--- a/hyperSpec/R/labels.R
+++ b/hyperSpec/R/labels.R
@@ -80,8 +80,7 @@
 #' @return  \code{labels<-} returns a \code{hyperSpec} object.
 #' @examples
 #'
-#' labels (flu, "c") <- expression ("/" ("c", "mg / l"))
-#'
+#' labels(flu, "c") <- expression("/"("c", "mg / l"))
 `labels<-` <- function(object, which = NULL, ..., value) {
   chk.hy(object)
   validObject(object)
@@ -135,6 +134,5 @@
 #' @export
 #' @examples
 #'
-#' labels (faux_cell)
-#'
+#' labels(faux_cell)
 setMethod("labels", signature = signature(object = "hyperSpec"), .labels)

--- a/hyperSpec/R/labels.R
+++ b/hyperSpec/R/labels.R
@@ -22,7 +22,7 @@
   }
 
   if (drop && length(label) == 1L) {
-    label <- label [[1]]
+    label <- label[[1]]
   }
 
   label
@@ -97,7 +97,7 @@
       stop("Column to label does not exist!")
     }
 
-    object@label [[which]] <- value
+    object@label[[which]] <- value
   }
 
   validObject(object)

--- a/hyperSpec/R/labels.R
+++ b/hyperSpec/R/labels.R
@@ -1,4 +1,4 @@
-##' @importFrom utils modifyList
+#' @importFrom utils modifyList
 .labels <- function(object, which = bquote(), drop = TRUE, ..., use.colnames = TRUE) {
   validObject(object)
 
@@ -28,7 +28,7 @@
   label
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.labels) <- function() {
   context(".labels")
 
@@ -70,18 +70,18 @@
   })
 }
 
-##' @rdname labels
-##' @usage
-##' labels (object, which = NULL, ...) <- value
-##'
-##' @aliases labels<-,hyperSpec-method
-##' @export "labels<-"
-##' @param value the new label(s)
-##' @return  \code{labels<-} returns a \code{hyperSpec} object.
-##' @examples
-##'
-##' labels (flu, "c") <- expression ("/" ("c", "mg / l"))
-##'
+#' @rdname labels
+#' @usage
+#' labels (object, which = NULL, ...) <- value
+#'
+#' @aliases labels<-,hyperSpec-method
+#' @export "labels<-"
+#' @param value the new label(s)
+#' @return  \code{labels<-} returns a \code{hyperSpec} object.
+#' @examples
+#'
+#' labels (flu, "c") <- expression ("/" ("c", "mg / l"))
+#'
 `labels<-` <- function(object, which = NULL, ..., value) {
   chk.hy(object)
   validObject(object)
@@ -106,35 +106,35 @@
 }
 
 
-##' Get and Set Labels of a hyperSpec Object
-##' \code{value} may be a list or vector of labels giving the new label for
-##' each of the entries specified by \code{which}.
-##'
-##' The names of the labels are the same as the colnames of the
-##' \code{data.frame}.  The label for the wavelength axis has the name
-##' \code{.wavelength}.
-##'
-##' The labels should be given in a form ready for the text-drawing functions
-##' (see \code{\link[grDevices]{plotmath}}), e.g. as \code{expression} or a
-##' \code{character}.
-##'
-##' @param object a hyperSpec object
-##' @param which numeric or character to specify the label(s)
-##' @param ... ignored
-##' @param drop if the result would be a list with only one element, should the
-##'   element be returned instead?
-##' @param use.colnames should missing labels be replaced by column names of
-##'   the extra data?
-##' @return \code{labels} returns a list of labels.  If \code{drop} is
-##'   \code{TRUE} and the list contains only one element, the element is
-##'   returned instead.
-##' @docType methods
-##' @rdname labels
-##' @author C. Beleites
-##' @seealso \code{\link[base]{labels}}
-##' @export
-##' @examples
-##'
-##' labels (faux_cell)
-##'
+#' Get and Set Labels of a hyperSpec Object
+#' \code{value} may be a list or vector of labels giving the new label for
+#' each of the entries specified by \code{which}.
+#'
+#' The names of the labels are the same as the colnames of the
+#' \code{data.frame}.  The label for the wavelength axis has the name
+#' \code{.wavelength}.
+#'
+#' The labels should be given in a form ready for the text-drawing functions
+#' (see \code{\link[grDevices]{plotmath}}), e.g. as \code{expression} or a
+#' \code{character}.
+#'
+#' @param object a hyperSpec object
+#' @param which numeric or character to specify the label(s)
+#' @param ... ignored
+#' @param drop if the result would be a list with only one element, should the
+#'   element be returned instead?
+#' @param use.colnames should missing labels be replaced by column names of
+#'   the extra data?
+#' @return \code{labels} returns a list of labels.  If \code{drop} is
+#'   \code{TRUE} and the list contains only one element, the element is
+#'   returned instead.
+#' @docType methods
+#' @rdname labels
+#' @author C. Beleites
+#' @seealso \code{\link[base]{labels}}
+#' @export
+#' @examples
+#'
+#' labels (faux_cell)
+#'
 setMethod("labels", signature = signature(object = "hyperSpec"), .labels)

--- a/hyperSpec/R/laser.R
+++ b/hyperSpec/R/laser.R
@@ -14,15 +14,19 @@
 #'
 #' laser
 #'
-#' cols <- c ("black", "blue", "darkgreen", "red")
-#' wl <- c (405.0, 405.1, 405.3, 405.4)
-#' plotspc (laser, axis.args=list (x = list (at = seq (404.5, 405.8, .1))))
-#' for (i in seq_along (wl))
-#'    abline (v = wl[i], col = cols[i], lwd = 2, lty = 2)
+#' cols <- c("black", "blue", "darkgreen", "red")
+#' wl <- c(405.0, 405.1, 405.3, 405.4)
+#' plotspc(laser, axis.args = list(x = list(at = seq(404.5, 405.8, .1))))
+#' for (i in seq_along(wl)) {
+#'   abline(v = wl[i], col = cols[i], lwd = 2, lty = 2)
+#' }
 #'
-#' plotc (laser [,, wl], spc ~ t, groups = .wavelength, type = "b",
-#'        col = cols)
-#'
-#' \dontrun{vignette ("laser", package="hyperSpec")}
+#' plotc(laser [, , wl], spc ~ t,
+#'   groups = .wavelength, type = "b",
+#'   col = cols
+#' )
+#' \dontrun{
+#' vignette("laser", package = "hyperSpec")
+#' }
 #'
 NULL

--- a/hyperSpec/R/laser.R
+++ b/hyperSpec/R/laser.R
@@ -1,28 +1,28 @@
-##' Laser Emission
-##' A time series of an unstable laser emission.
-##'
-##' see the Vignette
-##'
-##' @name laser
-##' @docType data
-##' @format The data set consists of 84 laser emission spectra measured during
-##'   95 min.  Each spectrum has 36 data points in the range of 404.5 nm to
-##'   405.8 nm.
-##' @author C. Beleites
-##' @keywords datasets
-##' @examples
-##'
-##' laser
-##'
-##' cols <- c ("black", "blue", "darkgreen", "red")
-##' wl <- c (405.0, 405.1, 405.3, 405.4)
-##' plotspc (laser, axis.args=list (x = list (at = seq (404.5, 405.8, .1))))
-##' for (i in seq_along (wl))
-##'    abline (v = wl[i], col = cols[i], lwd = 2, lty = 2)
-##'
-##' plotc (laser [,, wl], spc ~ t, groups = .wavelength, type = "b",
-##'        col = cols)
-##'
-##' \dontrun{vignette ("laser", package="hyperSpec")}
-##'
+#' Laser Emission
+#' A time series of an unstable laser emission.
+#'
+#' see the Vignette
+#'
+#' @name laser
+#' @docType data
+#' @format The data set consists of 84 laser emission spectra measured during
+#'   95 min.  Each spectrum has 36 data points in the range of 404.5 nm to
+#'   405.8 nm.
+#' @author C. Beleites
+#' @keywords datasets
+#' @examples
+#'
+#' laser
+#'
+#' cols <- c ("black", "blue", "darkgreen", "red")
+#' wl <- c (405.0, 405.1, 405.3, 405.4)
+#' plotspc (laser, axis.args=list (x = list (at = seq (404.5, 405.8, .1))))
+#' for (i in seq_along (wl))
+#'    abline (v = wl[i], col = cols[i], lwd = 2, lty = 2)
+#'
+#' plotc (laser [,, wl], spc ~ t, groups = .wavelength, type = "b",
+#'        col = cols)
+#'
+#' \dontrun{vignette ("laser", package="hyperSpec")}
+#'
 NULL

--- a/hyperSpec/R/levelplot.R
+++ b/hyperSpec/R/levelplot.R
@@ -41,8 +41,8 @@ setGeneric("levelplot", package = "lattice")
 
   dots <- modifyList(
     list(
-      xlab = data@label [[use.x]],
-      ylab = data@label [[use.y]]
+      xlab = data@label[[use.x]],
+      ylab = data@label[[use.y]]
     ),
     dots
   )
@@ -67,9 +67,9 @@ setGeneric("levelplot", package = "lattice")
 
 
 
-  if (is.factor(data [[use.z]]) && transform.factor) {
-    dots <- trellis.factor.key(data [[use.z]], dots)
-    data [[use.z]] <- as.numeric(data [[use.z]])
+  if (is.factor(data[[use.z]]) && transform.factor) {
+    dots <- trellis.factor.key(data[[use.z]], dots)
+    data[[use.z]] <- as.numeric(data[[use.z]])
   }
 
   do.call(levelplot, c(list(x, data), dots))

--- a/hyperSpec/R/levelplot.R
+++ b/hyperSpec/R/levelplot.R
@@ -1,4 +1,4 @@
-##' @importFrom lattice latticeParseFormula
+#' @importFrom lattice latticeParseFormula
 setGeneric("levelplot", package = "lattice")
 
 #################################################################################
@@ -9,7 +9,7 @@ setGeneric("levelplot", package = "lattice")
 ###
 
 ### the workhorse function
-##' @importFrom utils modifyList
+#' @importFrom utils modifyList
 .levelplot <- function(x, data, transform.factor = TRUE, ...,
                        contour = FALSE, useRaster = !contour) {
   validObject(data)
@@ -75,7 +75,7 @@ setGeneric("levelplot", package = "lattice")
   do.call(levelplot, c(list(x, data), dots))
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.levelplot) <- function() {
   context(".levelplot")
 
@@ -91,17 +91,17 @@ setGeneric("levelplot", package = "lattice")
   })
 }
 
-##' @include plotmap.R
-##' @rdname levelplot
-##' @param transform.factor If the color-coded variable is a factor, should
-##'   \code{\link{trellis.factor.key}} be used to compute the color coding and
-##'   legend?
-##' @param contour,useRaster see  \code{\link[lattice]{levelplot}}
-##' @export
-##' @seealso  \code{\link[lattice]{levelplot}}
-##'
-##'  \code{\link{trellis.factor.key}} for improved color coding of factors
-##' @importFrom lattice levelplot
+#' @include plotmap.R
+#' @rdname levelplot
+#' @param transform.factor If the color-coded variable is a factor, should
+#'   \code{\link{trellis.factor.key}} be used to compute the color coding and
+#'   legend?
+#' @param contour,useRaster see  \code{\link[lattice]{levelplot}}
+#' @export
+#' @seealso  \code{\link[lattice]{levelplot}}
+#'
+#'  \code{\link{trellis.factor.key}} for improved color coding of factors
+#' @importFrom lattice levelplot
 setMethod(
   f = "levelplot", signature = signature(x = "hyperSpec", data = "missing"),
   definition = function(x, data, ...) {
@@ -109,8 +109,8 @@ setMethod(
   }
 )
 
-##' @rdname levelplot
-##' @export
+#' @rdname levelplot
+#' @export
 setMethod(
   f = "levelplot", signature = signature(x = "formula", data = "hyperSpec"),
   definition = .levelplot

--- a/hyperSpec/R/levelplot.R
+++ b/hyperSpec/R/levelplot.R
@@ -41,7 +41,7 @@ setGeneric("levelplot", package = "lattice")
 
   dots <- modifyList(
     list(
-      xlab = data@label [[use.x]], 
+      xlab = data@label [[use.x]],
       ylab = data@label [[use.y]]
     ),
     dots

--- a/hyperSpec/R/makeraster.R
+++ b/hyperSpec/R/makeraster.R
@@ -1,41 +1,41 @@
-##' find an evenly spaced grid for x
-##'
-##' \code{makeraster} fits the data to the specified raster.
-##'
-##' \code{fitraster} tries different raster parameter and returns the raster that covers most of the
-##' \code{x} values: The differences between the values of \code{x} are calculated (possible step
-##' sizes). For each of those step sizes, different points are tried (until all points have been
-##' covered by a raster) and the parameter combination leading to the best coverage (i.e. most points
-##' on the grid) ist used.
-##'
-##' Note that only differences between the sorted values of x are considered as step size.
-##' @title makeraster
-##' @param x numeric to be fitted with a raster
-##' @param startx starting point ("origin") for calculation of the raster
-##' @param d step size of the raster
-##' @param tol tolerance for rounding to new levels: elements of x within \code{tol} of the distance between the levels of the new grid are rounded to the new grid point.
-##' @param newlevels levels of the raster
-##' @return list with elements
-##' \item{x}{the values of \code{x}, possibly rounded to the raster values}
-##' \item{levels}{the values of the raster}
-##' @export
-##' @author Claudia Beleites
-##' @examples
-##' x <- c (sample (1:20, 10), (0 : 5) + 0.5)
-##' raster <- makeraster (x, x [1], 2)
-##' raster
-##' plot (x)
-##' abline (h = raster$levels, col = "#00000040")
-##'
-##' ## unoccupied levels
-##' missing <- setdiff (raster$levels, raster$x)
-##' abline (h = missing, col = "red")
-##'
-##' ## points acutally on the raster
-##' onraster <- raster$x %in% raster$levels
-##' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
-##'
-##' @importFrom utils tail
+#' find an evenly spaced grid for x
+#'
+#' \code{makeraster} fits the data to the specified raster.
+#'
+#' \code{fitraster} tries different raster parameter and returns the raster that covers most of the
+#' \code{x} values: The differences between the values of \code{x} are calculated (possible step
+#' sizes). For each of those step sizes, different points are tried (until all points have been
+#' covered by a raster) and the parameter combination leading to the best coverage (i.e. most points
+#' on the grid) ist used.
+#'
+#' Note that only differences between the sorted values of x are considered as step size.
+#' @title makeraster
+#' @param x numeric to be fitted with a raster
+#' @param startx starting point ("origin") for calculation of the raster
+#' @param d step size of the raster
+#' @param tol tolerance for rounding to new levels: elements of x within \code{tol} of the distance between the levels of the new grid are rounded to the new grid point.
+#' @param newlevels levels of the raster
+#' @return list with elements
+#' \item{x}{the values of \code{x}, possibly rounded to the raster values}
+#' \item{levels}{the values of the raster}
+#' @export
+#' @author Claudia Beleites
+#' @examples
+#' x <- c (sample (1:20, 10), (0 : 5) + 0.5)
+#' raster <- makeraster (x, x [1], 2)
+#' raster
+#' plot (x)
+#' abline (h = raster$levels, col = "#00000040")
+#'
+#' ## unoccupied levels
+#' missing <- setdiff (raster$levels, raster$x)
+#' abline (h = missing, col = "red")
+#'
+#' ## points acutally on the raster
+#' onraster <- raster$x %in% raster$levels
+#' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
+#'
+#' @importFrom utils tail
 makeraster <- function(x, startx, d, newlevels, tol = 0.1) {
   if (missing(newlevels)) {
     ## make sure to cover the whole data range + 1 point
@@ -63,37 +63,37 @@ makeraster <- function(x, startx, d, newlevels, tol = 0.1) {
   )
 }
 
-##' @rdname makeraster
-##' @export
-##' @examples
-##'
-##' raster <- fitraster (x)
-##' raster
-##' plot (x)
-##' abline (h = raster$levels, col = "#00000040")
-##'
-##' ## unoccupied levels
-##' missing <- setdiff (raster$levels, raster$x)
-##' abline (h = missing, col = "red")
-##'
-##' ## points acutally on the raster
-##' onraster <- raster$x %in% raster$levels
-##' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
-##'
-##' x <- c (sample (1:20, 10), (0 : 5) + 0.45)
-##' raster <- fitraster (x)
-##' raster
-##' plot (x)
-##' abline (h = raster$levels, col = "#00000040")
-##'
-##' ## unoccupied levels
-##' missing <- setdiff (raster$levels, raster$x)
-##' abline (h = missing, col = "red")
-##'
-##' ## points acutally on the raster
-##' onraster <- raster$x %in% raster$levels
-##' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
-##'
+#' @rdname makeraster
+#' @export
+#' @examples
+#'
+#' raster <- fitraster (x)
+#' raster
+#' plot (x)
+#' abline (h = raster$levels, col = "#00000040")
+#'
+#' ## unoccupied levels
+#' missing <- setdiff (raster$levels, raster$x)
+#' abline (h = missing, col = "red")
+#'
+#' ## points acutally on the raster
+#' onraster <- raster$x %in% raster$levels
+#' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
+#'
+#' x <- c (sample (1:20, 10), (0 : 5) + 0.45)
+#' raster <- fitraster (x)
+#' raster
+#' plot (x)
+#' abline (h = raster$levels, col = "#00000040")
+#'
+#' ## unoccupied levels
+#' missing <- setdiff (raster$levels, raster$x)
+#' abline (h = missing, col = "red")
+#'
+#' ## points acutally on the raster
+#' onraster <- raster$x %in% raster$levels
+#' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
+#'
 fitraster <- function(x, tol = 0.1) {
   levels <- sort(unique(x))
 

--- a/hyperSpec/R/makeraster.R
+++ b/hyperSpec/R/makeraster.R
@@ -21,27 +21,26 @@
 #' @export
 #' @author Claudia Beleites
 #' @examples
-#' x <- c (sample (1:20, 10), (0 : 5) + 0.5)
-#' raster <- makeraster (x, x [1], 2)
+#' x <- c(sample(1:20, 10), (0:5) + 0.5)
+#' raster <- makeraster(x, x [1], 2)
 #' raster
-#' plot (x)
-#' abline (h = raster$levels, col = "#00000040")
+#' plot(x)
+#' abline(h = raster$levels, col = "#00000040")
 #'
 #' ## unoccupied levels
-#' missing <- setdiff (raster$levels, raster$x)
-#' abline (h = missing, col = "red")
+#' missing <- setdiff(raster$levels, raster$x)
+#' abline(h = missing, col = "red")
 #'
 #' ## points acutally on the raster
 #' onraster <- raster$x %in% raster$levels
-#' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
-#'
+#' points(which(onraster), raster$x [onraster], col = "blue", pch = 20)
 #' @importFrom utils tail
 makeraster <- function(x, startx, d, newlevels, tol = 0.1) {
   if (missing(newlevels)) {
     ## make sure to cover the whole data range + 1 point
     newlevels <- c(
       rev(seq(startx, min(x, na.rm = TRUE) - d, by = -d) [-1]),
-          seq(startx, max(x, na.rm = TRUE) + d, by =  d)
+      seq(startx, max(x, na.rm = TRUE) + d, by = d)
     )
   }
 
@@ -67,33 +66,32 @@ makeraster <- function(x, startx, d, newlevels, tol = 0.1) {
 #' @export
 #' @examples
 #'
-#' raster <- fitraster (x)
+#' raster <- fitraster(x)
 #' raster
-#' plot (x)
-#' abline (h = raster$levels, col = "#00000040")
+#' plot(x)
+#' abline(h = raster$levels, col = "#00000040")
 #'
 #' ## unoccupied levels
-#' missing <- setdiff (raster$levels, raster$x)
-#' abline (h = missing, col = "red")
+#' missing <- setdiff(raster$levels, raster$x)
+#' abline(h = missing, col = "red")
 #'
 #' ## points acutally on the raster
 #' onraster <- raster$x %in% raster$levels
-#' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
+#' points(which(onraster), raster$x [onraster], col = "blue", pch = 20)
 #'
-#' x <- c (sample (1:20, 10), (0 : 5) + 0.45)
-#' raster <- fitraster (x)
+#' x <- c(sample(1:20, 10), (0:5) + 0.45)
+#' raster <- fitraster(x)
 #' raster
-#' plot (x)
-#' abline (h = raster$levels, col = "#00000040")
+#' plot(x)
+#' abline(h = raster$levels, col = "#00000040")
 #'
 #' ## unoccupied levels
-#' missing <- setdiff (raster$levels, raster$x)
-#' abline (h = missing, col = "red")
+#' missing <- setdiff(raster$levels, raster$x)
+#' abline(h = missing, col = "red")
 #'
 #' ## points acutally on the raster
 #' onraster <- raster$x %in% raster$levels
-#' points (which (onraster), raster$x [onraster], col = "blue", pch = 20)
-#'
+#' points(which(onraster), raster$x [onraster], col = "blue", pch = 20)
 fitraster <- function(x, tol = 0.1) {
   levels <- sort(unique(x))
 

--- a/hyperSpec/R/map.identify.R
+++ b/hyperSpec/R/map.identify.R
@@ -1,16 +1,16 @@
-##' @aliases levelplot,hyperSpec,missing-method
-##' @include plotmap.R
-##' @rdname levelplot
-##' @export
-##' @seealso  \code{\link[hyperSpec:options]{hyperSpec options}} \code{\link{spc.identify}}
-##' \code{\link{map.sel.poly}}
-##' @param tol tolerance for \code{map.identify} as fraction of the viewport
-##'   (i.e. in "npc" \link[grid]{unit}s)
-##' @param warn should a warning be issued if no point is within the specified
-##'   tolerance? See also details.
-##' @importFrom grid convertX convertY grid.locator grid.circle gpar
-##' @importFrom lattice trellis.focus ltext
-##' @importFrom utils modifyList
+#' @aliases levelplot,hyperSpec,missing-method
+#' @include plotmap.R
+#' @rdname levelplot
+#' @export
+#' @seealso  \code{\link[hyperSpec:options]{hyperSpec options}} \code{\link{spc.identify}}
+#' \code{\link{map.sel.poly}}
+#' @param tol tolerance for \code{map.identify} as fraction of the viewport
+#'   (i.e. in "npc" \link[grid]{unit}s)
+#' @param warn should a warning be issued if no point is within the specified
+#'   tolerance? See also details.
+#' @importFrom grid convertX convertY grid.locator grid.circle gpar
+#' @importFrom lattice trellis.focus ltext
+#' @importFrom utils modifyList
 map.identify <- function(object, model = spc ~ x * y, voronoi = FALSE, ...,
                          tol = .02, warn = TRUE) {
   if (!interactive()) {

--- a/hyperSpec/R/map.sel.poly.R
+++ b/hyperSpec/R/map.sel.poly.R
@@ -22,29 +22,29 @@
 #' @rdname map-sel-poly
 #' @keywords iplot
 #' @examples
-#' if (interactive ()){
-#' ## convenience wrapper
-#' map.sel.poly (faux_cell)
+#' if (interactive()) {
+#'   ## convenience wrapper
+#'   map.sel.poly(faux_cell)
 #'
-#' ## customized version
-#' data <- sample (faux_cell [,, 1004 - 2i ~ 1004 + 2i], 300)
+#'   ## customized version
+#'   data <- sample(faux_cell [, , 1004 - 2i ~ 1004 + 2i], 300)
 #'
-#' plotdata <- plotvoronoi (data, region ~ y * x, col.regions = alois.palette ())
-#' print (plotdata)
-#' map.sel.poly (plotdata)
+#'   plotdata <- plotvoronoi(data, region ~ y * x, col.regions = alois.palette())
+#'   print(plotdata)
+#'   map.sel.poly(plotdata)
 #'
-#' ## even more customization:
-#' plotvoronoi (data)
+#'   ## even more customization:
+#'   plotvoronoi(data)
 #'
-#' ## interactively retrieve polygon
-#' polygon <- sel.poly ()
+#'   ## interactively retrieve polygon
+#'   polygon <- sel.poly()
 #'
-#' ## find data points within polygon
-#' require ("sp")
-#' i.sel <- which (point.in.polygon (data$x, data$y, polygon [, 1], polygon [, 2]) > 0)
+#'   ## find data points within polygon
+#'   require("sp")
+#'   i.sel <- which(point.in.polygon(data$x, data$y, polygon [, 1], polygon [, 2]) > 0)
 #'
-#' ## work with selected points
-#' grid.points (unit (data$x [i.sel], "native"), unit (data$y [i.sel], "native"))
+#'   ## work with selected points
+#'   grid.points(unit(data$x [i.sel], "native"), unit(data$y [i.sel], "native"))
 #' }
 map.sel.poly <- function(data, pch = 19, size = 0.3, ...) {
   if (!interactive()) {

--- a/hyperSpec/R/map.sel.poly.R
+++ b/hyperSpec/R/map.sel.poly.R
@@ -1,51 +1,51 @@
-##' Interactively select a polygon (grid graphics) and highlight points
-##'
-##' Click the points that should be connected as polygon. Input ends with right click (see
-##' \code{\link[grid]{grid.locator}}). Polygon will be drawn closed.
-##'
-##' \code{map.sel.poly} is a convenience wrapper for \code{\link{plotmap}}, \code{sel.poly},
-##' and \code{\link[sp]{point.in.polygon}}. For custiomized plotting, the plot can be produced by
-##' \code{\link{plotmap}}, \code{\link{plotvoronoi}} or \code{\link{levelplot}}, and the result of
-##' that plot command handed over to \code{map.sel.poly}, see the example below.
-##'
-##' If even more customized plotting is required,\code{sel.poly} should be used (see example).
-##'
-##' @param data hyperSpec object for plotting map or list returned by \code{\link{plotmap}}
-##' @param pch symbol to display the points of the polygon for \code{\link{sel.poly}}
-##' @param size size for polygon point symbol for \code{\link{sel.poly}}
-##' @param ... further arguments for \code{\link[grid]{grid.points}} and
-##' \code{\link[grid]{grid.lines}}
-##' @return \code{map.sel.poly}: array of indices for points within the selected polygon
-##' @author Claudia Beleites, Sebastian Mellor
-##' @seealso \code{\link[grid]{grid.locator}}, \code{\link{map.identify}}
-##' @export
-##' @rdname map-sel-poly
-##' @keywords iplot
-##' @examples
-##' if (interactive ()){
-##' ## convenience wrapper
-##' map.sel.poly (faux_cell)
-##'
-##' ## customized version
-##' data <- sample (faux_cell [,, 1004 - 2i ~ 1004 + 2i], 300)
-##'
-##' plotdata <- plotvoronoi (data, region ~ y * x, col.regions = alois.palette ())
-##' print (plotdata)
-##' map.sel.poly (plotdata)
-##'
-##' ## even more customization:
-##' plotvoronoi (data)
-##'
-##' ## interactively retrieve polygon
-##' polygon <- sel.poly ()
-##'
-##' ## find data points within polygon
-##' require ("sp")
-##' i.sel <- which (point.in.polygon (data$x, data$y, polygon [, 1], polygon [, 2]) > 0)
-##'
-##' ## work with selected points
-##' grid.points (unit (data$x [i.sel], "native"), unit (data$y [i.sel], "native"))
-##' }
+#' Interactively select a polygon (grid graphics) and highlight points
+#'
+#' Click the points that should be connected as polygon. Input ends with right click (see
+#' \code{\link[grid]{grid.locator}}). Polygon will be drawn closed.
+#'
+#' \code{map.sel.poly} is a convenience wrapper for \code{\link{plotmap}}, \code{sel.poly},
+#' and \code{\link[sp]{point.in.polygon}}. For custiomized plotting, the plot can be produced by
+#' \code{\link{plotmap}}, \code{\link{plotvoronoi}} or \code{\link{levelplot}}, and the result of
+#' that plot command handed over to \code{map.sel.poly}, see the example below.
+#'
+#' If even more customized plotting is required,\code{sel.poly} should be used (see example).
+#'
+#' @param data hyperSpec object for plotting map or list returned by \code{\link{plotmap}}
+#' @param pch symbol to display the points of the polygon for \code{\link{sel.poly}}
+#' @param size size for polygon point symbol for \code{\link{sel.poly}}
+#' @param ... further arguments for \code{\link[grid]{grid.points}} and
+#' \code{\link[grid]{grid.lines}}
+#' @return \code{map.sel.poly}: array of indices for points within the selected polygon
+#' @author Claudia Beleites, Sebastian Mellor
+#' @seealso \code{\link[grid]{grid.locator}}, \code{\link{map.identify}}
+#' @export
+#' @rdname map-sel-poly
+#' @keywords iplot
+#' @examples
+#' if (interactive ()){
+#' ## convenience wrapper
+#' map.sel.poly (faux_cell)
+#'
+#' ## customized version
+#' data <- sample (faux_cell [,, 1004 - 2i ~ 1004 + 2i], 300)
+#'
+#' plotdata <- plotvoronoi (data, region ~ y * x, col.regions = alois.palette ())
+#' print (plotdata)
+#' map.sel.poly (plotdata)
+#'
+#' ## even more customization:
+#' plotvoronoi (data)
+#'
+#' ## interactively retrieve polygon
+#' polygon <- sel.poly ()
+#'
+#' ## find data points within polygon
+#' require ("sp")
+#' i.sel <- which (point.in.polygon (data$x, data$y, polygon [, 1], polygon [, 2]) > 0)
+#'
+#' ## work with selected points
+#' grid.points (unit (data$x [i.sel], "native"), unit (data$y [i.sel], "native"))
+#' }
 map.sel.poly <- function(data, pch = 19, size = 0.3, ...) {
   if (!interactive()) {
     stop("map.sel.poly works only on interactive graphics devices.")
@@ -85,14 +85,14 @@ map.sel.poly <- function(data, pch = 19, size = 0.3, ...) {
 
 
 
-##' @return \code{sel.poly}: n x 2 matrix with the corner points of the polygon
-##' @author Claudia Beleites
-##' @seealso \code{\link[grid]{grid.locator}}
-##' @export
-##' @keywords iplot
-##' @rdname map-sel-poly
-##' @importFrom grid grid.lines grid.points
-##' @importFrom utils tail
+#' @return \code{sel.poly}: n x 2 matrix with the corner points of the polygon
+#' @author Claudia Beleites
+#' @seealso \code{\link[grid]{grid.locator}}
+#' @export
+#' @keywords iplot
+#' @rdname map-sel-poly
+#' @importFrom grid grid.lines grid.points
+#' @importFrom utils tail
 sel.poly <- function(pch = 19, size = 0.3, ...) {
   if (!interactive()) {
     stop("sel.poly works only on interactive graphics devices.")

--- a/hyperSpec/R/mark.dendrogram.R
+++ b/hyperSpec/R/mark.dendrogram.R
@@ -1,42 +1,42 @@
-##' Groups are marked by colored rectangles as well as by their levels.
-##'
-##' The dendrogram should be plotted separately, see the example.
-##' @title Mark groups in \code{\link[stats]{hclust}} dendrograms
-##' @param dendrogram the dendrogram
-##' @param groups factor giving the the groups to mark
-##' @param col vector with colors for each group
-##' @param pos.marker top of the marker rectangle
-##' @param height height of the marker rectangle
-##' @param pos.text position of the text label
-##' @param border see \code{\link[graphics]{text}}
-##' @param text.col color (vector) giving the color for the text markers
-##' @param label side label see example
-##' @param label.right should the side labels be at the right side?
-##' @param ... handed to \code{\link[graphics]{rect}} and \code{\link[graphics]{text}}
-##' @author Claudia Beleites
-##' @export
-##' @rdname mark.dendrogram
-##' @examples
-##'
-##' dend <- hclust (pearson.dist (laser[[]]))
-##' par (xpd = TRUE, mar = c (5.1, 4, 4, 3)) # allows plotting into the margin
-##' plot (dend, hang = -1, labels = FALSE)
-##'
-##' ## mark clusters
-##' clusters <- as.factor (cutree (dend, k = 4))
-##' levels (clusters) <- LETTERS [1 : 4]
-##' mark.dendrogram (dend, clusters, label = "cluster")
-##'
-##' ## mark independent factor
-##' mark.dendrogram (dend, as.factor (laser [,,405.36] > 11000),
-##' pos.marker = -0.02, pos.text = - 0.03)
-##'
-##' ## mark continuous variable: convert it to a factor and omit labels
-##' mark.dendrogram (dend, cut (laser [[,, 405.36]], 100), alois.palette (100),
-##'                  pos.marker = -.015, text.col = NA,
-##'                  label = expression (I [lambda == 405.36~nm]), label.right = FALSE)
-##'
-##' @importFrom utils head tail
+#' Groups are marked by colored rectangles as well as by their levels.
+#'
+#' The dendrogram should be plotted separately, see the example.
+#' @title Mark groups in \code{\link[stats]{hclust}} dendrograms
+#' @param dendrogram the dendrogram
+#' @param groups factor giving the the groups to mark
+#' @param col vector with colors for each group
+#' @param pos.marker top of the marker rectangle
+#' @param height height of the marker rectangle
+#' @param pos.text position of the text label
+#' @param border see \code{\link[graphics]{text}}
+#' @param text.col color (vector) giving the color for the text markers
+#' @param label side label see example
+#' @param label.right should the side labels be at the right side?
+#' @param ... handed to \code{\link[graphics]{rect}} and \code{\link[graphics]{text}}
+#' @author Claudia Beleites
+#' @export
+#' @rdname mark.dendrogram
+#' @examples
+#'
+#' dend <- hclust (pearson.dist (laser[[]]))
+#' par (xpd = TRUE, mar = c (5.1, 4, 4, 3)) # allows plotting into the margin
+#' plot (dend, hang = -1, labels = FALSE)
+#'
+#' ## mark clusters
+#' clusters <- as.factor (cutree (dend, k = 4))
+#' levels (clusters) <- LETTERS [1 : 4]
+#' mark.dendrogram (dend, clusters, label = "cluster")
+#'
+#' ## mark independent factor
+#' mark.dendrogram (dend, as.factor (laser [,,405.36] > 11000),
+#' pos.marker = -0.02, pos.text = - 0.03)
+#'
+#' ## mark continuous variable: convert it to a factor and omit labels
+#' mark.dendrogram (dend, cut (laser [[,, 405.36]], 100), alois.palette (100),
+#'                  pos.marker = -.015, text.col = NA,
+#'                  label = expression (I [lambda == 405.36~nm]), label.right = FALSE)
+#'
+#' @importFrom utils head tail
 mark.dendrogram <- function(dendrogram, groups, col = seq_along(unique(groups)),
                             pos.marker = 0,
                             height = 0.025 * max(dendrogram$height),

--- a/hyperSpec/R/mark.dendrogram.R
+++ b/hyperSpec/R/mark.dendrogram.R
@@ -33,7 +33,7 @@
 #' )
 #'
 #' ## mark continuous variable: convert it to a factor and omit labels
-#' mark.dendrogram(dend, cut(laser [[, , 405.36]], 100), alois.palette(100),
+#' mark.dendrogram(dend, cut(laser[[, , 405.36]], 100), alois.palette(100),
 #'   pos.marker = -.015, text.col = NA,
 #'   label = expression(I [lambda == 405.36 ~ nm]), label.right = FALSE
 #' )

--- a/hyperSpec/R/mark.dendrogram.R
+++ b/hyperSpec/R/mark.dendrogram.R
@@ -18,24 +18,25 @@
 #' @rdname mark.dendrogram
 #' @examples
 #'
-#' dend <- hclust (pearson.dist (laser[[]]))
-#' par (xpd = TRUE, mar = c (5.1, 4, 4, 3)) # allows plotting into the margin
-#' plot (dend, hang = -1, labels = FALSE)
+#' dend <- hclust(pearson.dist(laser[[]]))
+#' par(xpd = TRUE, mar = c(5.1, 4, 4, 3)) # allows plotting into the margin
+#' plot(dend, hang = -1, labels = FALSE)
 #'
 #' ## mark clusters
-#' clusters <- as.factor (cutree (dend, k = 4))
-#' levels (clusters) <- LETTERS [1 : 4]
-#' mark.dendrogram (dend, clusters, label = "cluster")
+#' clusters <- as.factor(cutree(dend, k = 4))
+#' levels(clusters) <- LETTERS [1:4]
+#' mark.dendrogram(dend, clusters, label = "cluster")
 #'
 #' ## mark independent factor
-#' mark.dendrogram (dend, as.factor (laser [,,405.36] > 11000),
-#' pos.marker = -0.02, pos.text = - 0.03)
+#' mark.dendrogram(dend, as.factor(laser [, , 405.36] > 11000),
+#'   pos.marker = -0.02, pos.text = -0.03
+#' )
 #'
 #' ## mark continuous variable: convert it to a factor and omit labels
-#' mark.dendrogram (dend, cut (laser [[,, 405.36]], 100), alois.palette (100),
-#'                  pos.marker = -.015, text.col = NA,
-#'                  label = expression (I [lambda == 405.36~nm]), label.right = FALSE)
-#'
+#' mark.dendrogram(dend, cut(laser [[, , 405.36]], 100), alois.palette(100),
+#'   pos.marker = -.015, text.col = NA,
+#'   label = expression(I [lambda == 405.36 ~ nm]), label.right = FALSE
+#' )
 #' @importFrom utils head tail
 mark.dendrogram <- function(dendrogram, groups, col = seq_along(unique(groups)),
                             pos.marker = 0,

--- a/hyperSpec/R/mark.peak.R
+++ b/hyperSpec/R/mark.peak.R
@@ -11,8 +11,8 @@
 #' @author R. Kiselev
 #' @export
 #' @examples
-#' plot (faux_cell [7])
-#' markpeak (faux_cell [7], 1662)
+#' plot(faux_cell [7])
+#' markpeak(faux_cell [7], 1662)
 markpeak <- function(spc, xpos, col = "red") {
   chk.hy(spc)
   validObject(spc)

--- a/hyperSpec/R/mark.peak.R
+++ b/hyperSpec/R/mark.peak.R
@@ -1,18 +1,18 @@
-##' Mark peak
-##'
-##' Marks location of the \emph{first} spectrum at the data point closest to the
-##' specified position on the current plot.
-##'
-##' @param spc the \code{hyperSpec} object
-##' @param xpos position of the peak(s) in current x-axis units
-##' @param col color of the markers and text
-##'
-##'
-##' @author R. Kiselev
-##' @export
-##' @examples
-##' plot (faux_cell [7])
-##' markpeak (faux_cell [7], 1662)
+#' Mark peak
+#'
+#' Marks location of the \emph{first} spectrum at the data point closest to the
+#' specified position on the current plot.
+#'
+#' @param spc the \code{hyperSpec} object
+#' @param xpos position of the peak(s) in current x-axis units
+#' @param col color of the markers and text
+#'
+#'
+#' @author R. Kiselev
+#' @export
+#' @examples
+#' plot (faux_cell [7])
+#' markpeak (faux_cell [7], 1662)
 markpeak <- function(spc, xpos, col = "red") {
   chk.hy(spc)
   validObject(spc)

--- a/hyperSpec/R/matlab.palette.R
+++ b/hyperSpec/R/matlab.palette.R
@@ -1,35 +1,35 @@
-##' Matlab-like Palettes
-##' Two palettes going from blue over green to red, approximately as the
-##' standard palette of Matlab does. The second one has darker green values and
-##' is better suited for plotting lines on white background.
-##'
-##'
-##' @rdname palettes
-##' @aliases matlab.palette
-##' @param n the number of colors to be in the palette.
-##' @param ... further arguments are handed to \code{\link[grDevices]{rainbow}}
-##' (\code{alois.palette}: \code{\link[grDevices]{colorRampPalette}})
-##' @return A vector containing the color values in the form "\#rrbbggaa".
-##' @author C. Beleites and A. Bonifacio
-##' @seealso \code{\link[grDevices]{rainbow}}
-##' @export
-##' @importFrom grDevices rainbow
-##' @keywords color
-##' @examples
-##'
-##' plotmap (faux_cell [,, 778], col.regions = matlab.palette ())
-##'
+#' Matlab-like Palettes
+#' Two palettes going from blue over green to red, approximately as the
+#' standard palette of Matlab does. The second one has darker green values and
+#' is better suited for plotting lines on white background.
+#'
+#'
+#' @rdname palettes
+#' @aliases matlab.palette
+#' @param n the number of colors to be in the palette.
+#' @param ... further arguments are handed to \code{\link[grDevices]{rainbow}}
+#' (\code{alois.palette}: \code{\link[grDevices]{colorRampPalette}})
+#' @return A vector containing the color values in the form "\#rrbbggaa".
+#' @author C. Beleites and A. Bonifacio
+#' @seealso \code{\link[grDevices]{rainbow}}
+#' @export
+#' @importFrom grDevices rainbow
+#' @keywords color
+#' @examples
+#'
+#' plotmap (faux_cell [,, 778], col.regions = matlab.palette ())
+#'
 matlab.palette <- function(n = 100, ...) {
   rev(rainbow(n, start = 0, end = 4 / 6, ...))
 }
 
-##' @rdname palettes
-##' @aliases  matlab.dark.palette
-##' @export
-##' @examples
-##'
-##' plot (flu, col = matlab.dark.palette (nrow (flu)))
-##' @importFrom grDevices col2rgb rgb
+#' @rdname palettes
+#' @aliases  matlab.dark.palette
+#' @export
+#' @examples
+#'
+#' plot (flu, col = matlab.dark.palette (nrow (flu)))
+#' @importFrom grDevices col2rgb rgb
 matlab.dark.palette <- function(n = 100, ...) {
   pal <- rev(rainbow(n, start = 0, end = 4 / 6, ...))
   pal <- col2rgb(pal)
@@ -38,12 +38,12 @@ matlab.dark.palette <- function(n = 100, ...) {
   rgb(t(pal) / 255)
 }
 
-##' @rdname palettes
-##' @export
-##' @examples
-##'
-##' plotmap (faux_cell, col = alois.palette)
-##' @importFrom grDevices colorRampPalette
+#' @rdname palettes
+#' @export
+#' @examples
+#'
+#' plotmap (faux_cell, col = alois.palette)
+#' @importFrom grDevices colorRampPalette
 alois.palette <- function(n = 100, ...) {
   colorRampPalette(c("black", "blue", "cyan", "green", "yellow", "red"), ...)(n)
 }

--- a/hyperSpec/R/matlab.palette.R
+++ b/hyperSpec/R/matlab.palette.R
@@ -17,8 +17,7 @@
 #' @keywords color
 #' @examples
 #'
-#' plotmap (faux_cell [,, 778], col.regions = matlab.palette ())
-#'
+#' plotmap(faux_cell [, , 778], col.regions = matlab.palette())
 matlab.palette <- function(n = 100, ...) {
   rev(rainbow(n, start = 0, end = 4 / 6, ...))
 }
@@ -28,7 +27,7 @@ matlab.palette <- function(n = 100, ...) {
 #' @export
 #' @examples
 #'
-#' plot (flu, col = matlab.dark.palette (nrow (flu)))
+#' plot(flu, col = matlab.dark.palette(nrow(flu)))
 #' @importFrom grDevices col2rgb rgb
 matlab.dark.palette <- function(n = 100, ...) {
   pal <- rev(rainbow(n, start = 0, end = 4 / 6, ...))
@@ -42,7 +41,7 @@ matlab.dark.palette <- function(n = 100, ...) {
 #' @export
 #' @examples
 #'
-#' plotmap (faux_cell, col = alois.palette)
+#' plotmap(faux_cell, col = alois.palette)
 #' @importFrom grDevices colorRampPalette
 alois.palette <- function(n = 100, ...) {
   colorRampPalette(c("black", "blue", "cyan", "green", "yellow", "red"), ...)(n)

--- a/hyperSpec/R/mean_sd.R
+++ b/hyperSpec/R/mean_sd.R
@@ -22,7 +22,7 @@ setGeneric("mean_pm_sd", function(x, na.rm = TRUE, ...) standardGeneric("mean_pm
 #' @export
 #' @examples
 #'
-#' mean_sd (flu [,, 405 ~ 410])
+#' mean_sd(flu [, , 405 ~ 410])
 setMethod("mean_sd",
   signature = signature(x = "numeric"),
   function(x, na.rm = TRUE, ...) {
@@ -38,7 +38,7 @@ setMethod("mean_sd",
 #' @export
 #' @examples
 #'
-#' mean_sd (flu$spc)
+#' mean_sd(flu$spc)
 setMethod("mean_sd",
   signature = signature(x = "matrix"),
   function(x, na.rm = TRUE, ...) {
@@ -56,7 +56,7 @@ setMethod("mean_sd",
 #' @export
 #' @examples
 #'
-#' mean_sd (flu)
+#' mean_sd(flu)
 setMethod("mean_sd",
   signature = signature(x = "hyperSpec"),
   function(x, na.rm = TRUE, ...) {
@@ -73,7 +73,7 @@ setMethod("mean_sd",
 #' @export
 #' @examples
 #'
-#'   mean_pm_sd (flu$c)
+#' mean_pm_sd(flu$c)
 setMethod("mean_pm_sd",
   signature = signature(x = "numeric"),
   function(x, na.rm = TRUE, ...) {
@@ -89,7 +89,7 @@ setMethod("mean_pm_sd",
 #' @export
 #' @examples
 #'
-#' mean_pm_sd (flu$spc)
+#' mean_pm_sd(flu$spc)
 setMethod("mean_pm_sd",
   signature = signature(x = "matrix"),
   function(x, na.rm = TRUE, ...) {
@@ -105,7 +105,7 @@ setMethod("mean_pm_sd",
 #' @export
 #' @examples
 #'
-#' mean_pm_sd (flu)
+#' mean_pm_sd(flu)
 setMethod("mean_pm_sd",
   signature = signature(x = "hyperSpec"),
   function(x, na.rm = TRUE, ...) {
@@ -119,7 +119,7 @@ setMethod("mean_pm_sd",
 #' @export
 #' @examples
 #'
-#' plot (mean (faux_cell))
+#' plot(mean(faux_cell))
 setMethod("mean",
   signature = signature(x = "hyperSpec"),
   function(x, na.rm = TRUE, ...) {

--- a/hyperSpec/R/mean_sd.R
+++ b/hyperSpec/R/mean_sd.R
@@ -1,28 +1,28 @@
 ## make generic functions without default
-##' @noRd
+#' @noRd
 setGeneric("mean_sd", function(x, na.rm = TRUE, ...) standardGeneric("mean_sd"))
-##' @noRd
+#' @noRd
 setGeneric("mean_pm_sd", function(x, na.rm = TRUE, ...) standardGeneric("mean_pm_sd"))
 
-##' Mean and Standard Deviation
-##' Calculate mean and standard deviation, and mean, mean \eqn{\pm}{+-} one
-##' standard deviation, respectively.
-##'
-##' These functions are provided for convenience.
-##'
-##' @aliases mean_sd
-##' @rdname mean_sd
-##' @param x a numeric vector
-##' @param na.rm handed to \code{\link[base]{mean}} and \code{\link[stats]{sd}}
-##' @param ... ignored (needed to make function generic)
-##' @return \code{mean_sd} returns a vector with two values (mean and standard
-##'   deviation) of \code{x}.
-##' @seealso \code{\link[base]{mean}}, \code{\link[stats]{sd}}
-##' @keywords multivar
-##' @export
-##' @examples
-##'
-##' mean_sd (flu [,, 405 ~ 410])
+#' Mean and Standard Deviation
+#' Calculate mean and standard deviation, and mean, mean \eqn{\pm}{+-} one
+#' standard deviation, respectively.
+#'
+#' These functions are provided for convenience.
+#'
+#' @aliases mean_sd
+#' @rdname mean_sd
+#' @param x a numeric vector
+#' @param na.rm handed to \code{\link[base]{mean}} and \code{\link[stats]{sd}}
+#' @param ... ignored (needed to make function generic)
+#' @return \code{mean_sd} returns a vector with two values (mean and standard
+#'   deviation) of \code{x}.
+#' @seealso \code{\link[base]{mean}}, \code{\link[stats]{sd}}
+#' @keywords multivar
+#' @export
+#' @examples
+#'
+#' mean_sd (flu [,, 405 ~ 410])
 setMethod("mean_sd",
   signature = signature(x = "numeric"),
   function(x, na.rm = TRUE, ...) {
@@ -33,12 +33,12 @@ setMethod("mean_sd",
   }
 )
 
-##' @rdname mean_sd
-##' @return \code{mean_sd (matrix)} returns a matrix with the mean spectrum in the first row and the standard deviation in the 2nd.
-##' @export
-##' @examples
-##'
-##' mean_sd (flu$spc)
+#' @rdname mean_sd
+#' @return \code{mean_sd (matrix)} returns a matrix with the mean spectrum in the first row and the standard deviation in the 2nd.
+#' @export
+#' @examples
+#'
+#' mean_sd (flu$spc)
 setMethod("mean_sd",
   signature = signature(x = "matrix"),
   function(x, na.rm = TRUE, ...) {
@@ -48,15 +48,15 @@ setMethod("mean_sd",
   }
 )
 
-##' @rdname mean_sd
-##' @return \code{mean_sd} returns a hyperSpec object with the mean spectrum in the first row and the standard deviation in the 2nd.
-##' @author C. Beleites
-##' @seealso \code{\link[base]{mean}}, \code{\link[stats]{sd}}
-##' @keywords univar
-##' @export
-##' @examples
-##'
-##' mean_sd (flu)
+#' @rdname mean_sd
+#' @return \code{mean_sd} returns a hyperSpec object with the mean spectrum in the first row and the standard deviation in the 2nd.
+#' @author C. Beleites
+#' @seealso \code{\link[base]{mean}}, \code{\link[stats]{sd}}
+#' @keywords univar
+#' @export
+#' @examples
+#'
+#' mean_sd (flu)
 setMethod("mean_sd",
   signature = signature(x = "hyperSpec"),
   function(x, na.rm = TRUE, ...) {
@@ -65,15 +65,15 @@ setMethod("mean_sd",
 )
 
 
-##' @aliases mean_pm_sd
-##' @rdname mean_sd
-##' @return
-##'
-##' \code{mean_pm_sd} returns a vector with 3 values: mean - 1 sd, mean, mean + 1 sd
-##' @export
-##' @examples
-##'
-##'   mean_pm_sd (flu$c)
+#' @aliases mean_pm_sd
+#' @rdname mean_sd
+#' @return
+#'
+#' \code{mean_pm_sd} returns a vector with 3 values: mean - 1 sd, mean, mean + 1 sd
+#' @export
+#' @examples
+#'
+#'   mean_pm_sd (flu$c)
 setMethod("mean_pm_sd",
   signature = signature(x = "numeric"),
   function(x, na.rm = TRUE, ...) {
@@ -83,13 +83,13 @@ setMethod("mean_pm_sd",
   }
 )
 
-##' @rdname mean_sd
-##' @return \code{mean_pm_sd (matrix)} returns a matrix containing mean - sd, mean, and mean + sd
-##' rows.
-##' @export
-##' @examples
-##'
-##' mean_pm_sd (flu$spc)
+#' @rdname mean_sd
+#' @return \code{mean_pm_sd (matrix)} returns a matrix containing mean - sd, mean, and mean + sd
+#' rows.
+#' @export
+#' @examples
+#'
+#' mean_pm_sd (flu$spc)
 setMethod("mean_pm_sd",
   signature = signature(x = "matrix"),
   function(x, na.rm = TRUE, ...) {
@@ -99,13 +99,13 @@ setMethod("mean_pm_sd",
   }
 )
 
-##' @rdname mean_sd
-##' @return For hyperSpec objects, \code{mean_pm_sd} returns a hyperSpec object containing mean - sd,
-##' mean, and mean + sd spectra.
-##' @export
-##' @examples
-##'
-##' mean_pm_sd (flu)
+#' @rdname mean_sd
+#' @return For hyperSpec objects, \code{mean_pm_sd} returns a hyperSpec object containing mean - sd,
+#' mean, and mean + sd spectra.
+#' @export
+#' @examples
+#'
+#' mean_pm_sd (flu)
 setMethod("mean_pm_sd",
   signature = signature(x = "hyperSpec"),
   function(x, na.rm = TRUE, ...) {
@@ -113,13 +113,13 @@ setMethod("mean_pm_sd",
   }
 )
 
-##' @rdname mean_sd
-##' @return For hyperSpec object, \code{mean} returns a hyperSpec object containing the mean
-##' spectrum.
-##' @export
-##' @examples
-##'
-##' plot (mean (faux_cell))
+#' @rdname mean_sd
+#' @return For hyperSpec object, \code{mean} returns a hyperSpec object containing the mean
+#' spectrum.
+#' @export
+#' @examples
+#'
+#' plot (mean (faux_cell))
 setMethod("mean",
   signature = signature(x = "hyperSpec"),
   function(x, na.rm = TRUE, ...) {

--- a/hyperSpec/R/merge.R
+++ b/hyperSpec/R/merge.R
@@ -26,35 +26,37 @@
 #' @keywords manip
 #' @examples
 #'
-#' merge (faux_cell [1:10,, 600], faux_cell [5:15,, 600], by = c("x", "y"))$.
-#' tmp <- merge (faux_cell [1:10,, 610], faux_cell [5:15,, 610],
-#'               by = c("x", "y"), all = TRUE)
+#' merge(faux_cell [1:10, , 600], faux_cell [5:15, , 600], by = c("x", "y"))$.
+#' tmp <- merge(faux_cell [1:10, , 610], faux_cell [5:15, , 610],
+#'   by = c("x", "y"), all = TRUE
+#' )
 #' tmp$.
-#' wl (tmp)
+#' wl(tmp)
 #'
 #' ## remove duplicated wavelengths:
-#' approxfun <- function (y, wl, new.wl){
-#'   approx (wl, y, new.wl, method = "constant",
-#'           ties = function (x) mean (x, na.rm = TRUE)
-#'           )$y
+#' approxfun <- function(y, wl, new.wl) {
+#'   approx(wl, y, new.wl,
+#'     method = "constant",
+#'     ties = function(x) mean(x, na.rm = TRUE)
+#'   )$y
 #' }
 #'
-#' merged <- merge (faux_cell [1:7,, 610 ~ 620], faux_cell [5:10,, 615 ~ 625], all = TRUE)
+#' merged <- merge(faux_cell [1:7, , 610 ~ 620], faux_cell [5:10, , 615 ~ 625], all = TRUE)
 #' merged$.
-#' merged <- apply (merged, 1, approxfun,
-#'                  wl = wl (merged), new.wl = unique (wl (merged)),
-#'                  new.wavelength = "new.wl")
+#' merged <- apply(merged, 1, approxfun,
+#'   wl = wl(merged), new.wl = unique(wl(merged)),
+#'   new.wavelength = "new.wl"
+#' )
 #' merged$.
 #'
 #' ## merging data.frame into hyperSpec object => hyperSpec object
-#' y <- data.frame (filename = sample (flu$filename, 4, replace = TRUE), cpred = 1:4)
+#' y <- data.frame(filename = sample(flu$filename, 4, replace = TRUE), cpred = 1:4)
 #' y
-#' tmp <- merge (flu, y)
+#' tmp <- merge(flu, y)
 #' tmp$..
 #'
 #' ## merging hyperSpec object into data.frame => data.frame
-#' merge (y, flu)
-
+#' merge(y, flu)
 setMethod("merge",
   signature = signature(x = "hyperSpec", y = "hyperSpec"),
   function(x, y, ...) {

--- a/hyperSpec/R/merge.R
+++ b/hyperSpec/R/merge.R
@@ -1,59 +1,59 @@
-##' Merge hyperSpec objects
-##'
-##' Merges two hyperSpec objects and \code{\link[base]{cbind}}s their spectra
-##' matrices, or merges additional extra data into a hyperSpec object.
-##'
-##' After merging, the spectra matrix can contain duplicates, and is not
-##' ordered according to the wavelength.
-##'
-##' If the wavelength axis should be ordered, use \code{\link{orderwl}}.
-##'
-##' If a \code{hyperSpec} object and  a \code{data.frame} are merged, the result is of the class of the first (\code{x}) object.
-##'
-##' @aliases merge,hyperSpec,hyperSpec-method merge
-##' @param x a hyperSpec object or data.frame
-##' @param y a hyperSpec object or data.frame (including derived classes like tibble)
-##' @param ... handed to \code{\link[base]{merge.data.frame}}
-##' @author C. Beleites
-##' @export
-##' @rdname merge
-##' @docType methods
-##' @aliases merge
-##' @seealso \code{\link[base]{merge}}.
-##'
-##' \code{\link{collapse}} combines hyperSpec objects that do not share the wavelength axis.
-##' \code{\link{rbind}}, and \code{\link{cbind}} for combining hyperSpec objects that.
-##' @keywords manip
-##' @examples
-##'
-##' merge (faux_cell [1:10,, 600], faux_cell [5:15,, 600], by = c("x", "y"))$.
-##' tmp <- merge (faux_cell [1:10,, 610], faux_cell [5:15,, 610],
-##'               by = c("x", "y"), all = TRUE)
-##' tmp$.
-##' wl (tmp)
-##'
-##' ## remove duplicated wavelengths:
-##' approxfun <- function (y, wl, new.wl){
-##'   approx (wl, y, new.wl, method = "constant",
-##'           ties = function (x) mean (x, na.rm = TRUE)
-##'           )$y
-##' }
-##'
-##' merged <- merge (faux_cell [1:7,, 610 ~ 620], faux_cell [5:10,, 615 ~ 625], all = TRUE)
-##' merged$.
-##' merged <- apply (merged, 1, approxfun,
-##'                  wl = wl (merged), new.wl = unique (wl (merged)),
-##'                  new.wavelength = "new.wl")
-##' merged$.
-##'
-##' ## merging data.frame into hyperSpec object => hyperSpec object
-##' y <- data.frame (filename = sample (flu$filename, 4, replace = TRUE), cpred = 1:4)
-##' y
-##' tmp <- merge (flu, y)
-##' tmp$..
-##'
-##' ## merging hyperSpec object into data.frame => data.frame
-##' merge (y, flu)
+#' Merge hyperSpec objects
+#'
+#' Merges two hyperSpec objects and \code{\link[base]{cbind}}s their spectra
+#' matrices, or merges additional extra data into a hyperSpec object.
+#'
+#' After merging, the spectra matrix can contain duplicates, and is not
+#' ordered according to the wavelength.
+#'
+#' If the wavelength axis should be ordered, use \code{\link{orderwl}}.
+#'
+#' If a \code{hyperSpec} object and  a \code{data.frame} are merged, the result is of the class of the first (\code{x}) object.
+#'
+#' @aliases merge,hyperSpec,hyperSpec-method merge
+#' @param x a hyperSpec object or data.frame
+#' @param y a hyperSpec object or data.frame (including derived classes like tibble)
+#' @param ... handed to \code{\link[base]{merge.data.frame}}
+#' @author C. Beleites
+#' @export
+#' @rdname merge
+#' @docType methods
+#' @aliases merge
+#' @seealso \code{\link[base]{merge}}.
+#'
+#' \code{\link{collapse}} combines hyperSpec objects that do not share the wavelength axis.
+#' \code{\link{rbind}}, and \code{\link{cbind}} for combining hyperSpec objects that.
+#' @keywords manip
+#' @examples
+#'
+#' merge (faux_cell [1:10,, 600], faux_cell [5:15,, 600], by = c("x", "y"))$.
+#' tmp <- merge (faux_cell [1:10,, 610], faux_cell [5:15,, 610],
+#'               by = c("x", "y"), all = TRUE)
+#' tmp$.
+#' wl (tmp)
+#'
+#' ## remove duplicated wavelengths:
+#' approxfun <- function (y, wl, new.wl){
+#'   approx (wl, y, new.wl, method = "constant",
+#'           ties = function (x) mean (x, na.rm = TRUE)
+#'           )$y
+#' }
+#'
+#' merged <- merge (faux_cell [1:7,, 610 ~ 620], faux_cell [5:10,, 615 ~ 625], all = TRUE)
+#' merged$.
+#' merged <- apply (merged, 1, approxfun,
+#'                  wl = wl (merged), new.wl = unique (wl (merged)),
+#'                  new.wavelength = "new.wl")
+#' merged$.
+#'
+#' ## merging data.frame into hyperSpec object => hyperSpec object
+#' y <- data.frame (filename = sample (flu$filename, 4, replace = TRUE), cpred = 1:4)
+#' y
+#' tmp <- merge (flu, y)
+#' tmp$..
+#'
+#' ## merging hyperSpec object into data.frame => data.frame
+#' merge (y, flu)
 
 setMethod("merge",
   signature = signature(x = "hyperSpec", y = "hyperSpec"),
@@ -112,7 +112,7 @@ setMethod("merge",
   x
 }
 
-##' @rdname merge
+#' @rdname merge
 setMethod("merge",
   signature = signature(x = "hyperSpec", y = "data.frame"),
   function(x, y, ...) {
@@ -130,7 +130,7 @@ setMethod("merge",
   }
 )
 
-##' @rdname merge
+#' @rdname merge
 setMethod("merge",
   signature = signature(x = "data.frame", y = "hyperSpec"),
   function(x, y, ...) {
@@ -143,7 +143,7 @@ setMethod("merge",
 
 
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.merge) <- function() {
   context("merge")
 

--- a/hyperSpec/R/mergeextra.R
+++ b/hyperSpec/R/mergeextra.R
@@ -16,18 +16,18 @@
 #' @export
 #'
 #' @examples
-#' tmp <- flu [,FALSE,]
+#' tmp <- flu [, FALSE, ]
 #' tmp$prediction <- 1:6
 #' tmp
 #'
 #' mergeextra(flu, tmp)
 mergeextra <- function(x, y) {
-
   validObject(x)
   validObject(y)
 
-  if (nrow(x) != nrow(y))
+  if (nrow(x) != nrow(y)) {
     stop("Rows of x and y must correspond.")
+  }
 
   ylabels <- labels(y)
   ylabels$spc <- NULL
@@ -38,20 +38,19 @@ mergeextra <- function(x, y) {
   for (col in rev(seq_along(y))) {
     colname <- colnames(y)[col]
 
-    if (!colname %in% colnames(x))
+    if (!colname %in% colnames(x)) {
       next
+    }
 
-    if ((is.null(ylabels[[colname]]) |                      # no label or
-         as.character(ylabels[[colname]]) == colname |      # default label or
-                                                            # same label
-         as.character(ylabels[[colname]]) == as.character(labels(x, colname))) &
-                                                            # AND
-        identical(y[[col]],  x@data[[colname]])             # content identical
-        ) {
-
+    if ((is.null(ylabels[[colname]]) | # no label or
+      as.character(ylabels[[colname]]) == colname | # default label or
+      # same label
+      as.character(ylabels[[colname]]) == as.character(labels(x, colname))) &
+      # AND
+      identical(y[[col]], x@data[[colname]]) # content identical
+    ) {
       y[[col]] <- NULL
       ylabels[[colname]] <- NULL
-
     } else if (colname %in% colnames(x)) {
       # y column needs to be renamed
 
@@ -99,8 +98,10 @@ mergeextra <- function(x, y) {
     expect_equal(res$c, flu$c)
     expect_equal(res$filename, flu$filename)
     expect_equal(res$pred, tmp$pred)
-    expect_equal(.sortbyname(labels(res)),
-                 .sortbyname(modifyList(labels(flu), labels(tmp))))
+    expect_equal(
+      .sortbyname(labels(res)),
+      .sortbyname(modifyList(labels(flu), labels(tmp)))
+    )
   })
 
   test_that("different content, same label", {
@@ -114,8 +115,10 @@ mergeextra <- function(x, y) {
     expect_equal(sort(colnames(res)), sort(c(colnames(flu), "c.y")))
     expect_equal(res$c, flu$c)
     expect_equal(res$c.y, tmp$c)
-    expect_equal(.sortbyname(labels(res)),
-                 .sortbyname(c(labels(flu), list(c.y = labels(flu, "c")))))
+    expect_equal(
+      .sortbyname(labels(res)),
+      .sortbyname(c(labels(flu), list(c.y = labels(flu, "c"))))
+    )
   })
 
   test_that("different content type, same label", {
@@ -129,10 +132,13 @@ mergeextra <- function(x, y) {
     expect_equal(res$c, flu$c)
     expect_equal(res$filename, flu$filename)
     expect_equal(res$filename.y, tmp$filename)
-    expect_equal(.sortbyname(labels(res)),
-                 .sortbyname(c(labels(flu),
-                               list(filename.y = labels(flu, "filename")))))
-
+    expect_equal(
+      .sortbyname(labels(res)),
+      .sortbyname(c(
+        labels(flu),
+        list(filename.y = labels(flu, "filename"))
+      ))
+    )
   })
 
   test_that("different label, same content", {
@@ -146,8 +152,10 @@ mergeextra <- function(x, y) {
     expect_equal(sort(colnames(res)), sort(c(colnames(flu), "c.y")))
     expect_equal(res$c, flu$c)
     expect_equal(res$c.y, flu$c)
-    expect_equal(.sortbyname(labels(res)),
-                 .sortbyname(c(labels(flu), list(c.y = expression(c / mg * l)))))
+    expect_equal(
+      .sortbyname(labels(res)),
+      .sortbyname(c(labels(flu), list(c.y = expression(c / mg * l))))
+    )
   })
 
   test_that("x missing labels", {
@@ -155,5 +163,4 @@ mergeextra <- function(x, y) {
     spc@label$region <- NULL
     spc - spc
   })
-
 }

--- a/hyperSpec/R/mvtnorm.R
+++ b/hyperSpec/R/mvtnorm.R
@@ -49,12 +49,11 @@ setGeneric("rmmvnorm", .rmmvnorm)
 #' @examples
 #' ## multiple groups, common covariance matrix
 #'
-#' if (require ("mvtnorm")){
-#'    pcov <- pooled.cov (faux_cell, faux_cell$region)
-#'    rnd <- rmmvnorm (rep (10, 3), mean = pcov$mean, sigma = pcov$COV)
-#'    plot (rnd, col = rnd$.group)
+#' if (require("mvtnorm")) {
+#'   pcov <- pooled.cov(faux_cell, faux_cell$region)
+#'   rnd <- rmmvnorm(rep(10, 3), mean = pcov$mean, sigma = pcov$COV)
+#'   plot(rnd, col = rnd$.group)
 #' }
-
 setMethod(
   "rmmvnorm", signature(n = "numeric", mean = "hyperSpec", sigma = "matrix"),
   function(n, mean, sigma) {

--- a/hyperSpec/R/mvtnorm.R
+++ b/hyperSpec/R/mvtnorm.R
@@ -23,37 +23,37 @@
   tmp
 }
 
-##' @export
-##' @name rmmvnorm
+#' @export
+#' @name rmmvnorm
 setGeneric("rmmvnorm", .rmmvnorm)
 
 
-##' Multivariate normal random numbers
-##'
-##' Interface functions to use \code{\link[mvtnorm]{rmvnorm}} for
-##' \code{\link[hyperSpec]{hyperSpec-class}} objects.
-##'
-##' The \code{mvtnorm} method for hyperSpec objects supports producing multivariate normal data for
-##' groups with different mean but common covariance matrix, see the examples.
-##'
-##' @param n vector giving the numer of cases to generate for each group
-##' @param mean matrix with mean cases in rows
-##' @param sigma common covariance matrix or array (\code{ncol (mean)} x \code{ncol (mean)} x \code{nrow (mean)}) with individual covariance matrices for the groups.
-##' @export
-##' @seealso \code{\link[mvtnorm]{rmvnorm}}
-##'
-##' \code{\link[hyperSpec]{cov}} and \code{\link[hyperSpec]{pooled.cov}} about calculating  covariance of hyperSpec objects.
-##' @rdname rmmvnorm
-##' @aliases rmmvnorm rmmvnorm,hyperSpec-method
-##' @docType methods
-##' @examples
-##' ## multiple groups, common covariance matrix
-##'
-##' if (require ("mvtnorm")){
-##'    pcov <- pooled.cov (faux_cell, faux_cell$region)
-##'    rnd <- rmmvnorm (rep (10, 3), mean = pcov$mean, sigma = pcov$COV)
-##'    plot (rnd, col = rnd$.group)
-##' }
+#' Multivariate normal random numbers
+#'
+#' Interface functions to use \code{\link[mvtnorm]{rmvnorm}} for
+#' \code{\link[hyperSpec]{hyperSpec-class}} objects.
+#'
+#' The \code{mvtnorm} method for hyperSpec objects supports producing multivariate normal data for
+#' groups with different mean but common covariance matrix, see the examples.
+#'
+#' @param n vector giving the numer of cases to generate for each group
+#' @param mean matrix with mean cases in rows
+#' @param sigma common covariance matrix or array (\code{ncol (mean)} x \code{ncol (mean)} x \code{nrow (mean)}) with individual covariance matrices for the groups.
+#' @export
+#' @seealso \code{\link[mvtnorm]{rmvnorm}}
+#'
+#' \code{\link[hyperSpec]{cov}} and \code{\link[hyperSpec]{pooled.cov}} about calculating  covariance of hyperSpec objects.
+#' @rdname rmmvnorm
+#' @aliases rmmvnorm rmmvnorm,hyperSpec-method
+#' @docType methods
+#' @examples
+#' ## multiple groups, common covariance matrix
+#'
+#' if (require ("mvtnorm")){
+#'    pcov <- pooled.cov (faux_cell, faux_cell$region)
+#'    rnd <- rmmvnorm (rep (10, 3), mean = pcov$mean, sigma = pcov$COV)
+#'    plot (rnd, col = rnd$.group)
+#' }
 
 setMethod(
   "rmmvnorm", signature(n = "numeric", mean = "hyperSpec", sigma = "matrix"),
@@ -70,8 +70,8 @@ setMethod(
   }
 )
 
-##' @rdname rmmvnorm
-##' @export
+#' @rdname rmmvnorm
+#' @export
 setMethod(
   "rmmvnorm", signature(n = "numeric", mean = "hyperSpec", sigma = "array"),
   function(n, mean, sigma) {
@@ -87,15 +87,15 @@ setMethod(
   }
 )
 
-##' @rdname rmmvnorm
-##' @export
+#' @rdname rmmvnorm
+#' @export
 setMethod(
   "rmmvnorm", signature(n = "numeric", mean = "matrix", sigma = "matrix"),
   .rmmvnorm
 )
 
-##' @rdname rmmvnorm
-##' @export
+#' @rdname rmmvnorm
+#' @export
 setMethod(
   "rmmvnorm", signature(n = "numeric", mean = "matrix", sigma = "array"),
   .rmmvnorm

--- a/hyperSpec/R/normalize01.R
+++ b/hyperSpec/R/normalize01.R
@@ -87,7 +87,7 @@ setMethod(normalize01, signature(x = "hyperSpec"), function(x, ...) {
   test_that("hyperSpec method", {
     tmp.hy <- normalize01(-vanderMonde(flu, 1))
 
-    expect_equal(apply(tmp.hy [[]], 1, min), 1:0)
-    expect_equal(apply(tmp.hy [[]], 1, max), c(1, 1))
+    expect_equal(apply(tmp.hy[[]], 1, min), 1:0)
+    expect_equal(apply(tmp.hy[[]], 1, max), c(1, 1))
   })
 }

--- a/hyperSpec/R/normalize01.R
+++ b/hyperSpec/R/normalize01.R
@@ -1,21 +1,21 @@
-##' Normalize numbers -> [0, 1]
-##'
-##' The input \code{x} is mapped to [0, 1] by subtracting the minimum and subsequently dividing by
-##' the maximum. If all elements of \code{x} are equal, 1 is returned.
-##'
-##' @title normalization for mixed colors
-##' @name normalize01
-##' @param x  vector with values to transform
-##' @param tolerance tolerance level for determining what is 0 and 1
-##' @param ... additional parameters such as \code{tolerance} handed down.
-##' @return vector with \code{x} values mapped to the interval [0, 1]
-##' @author C. Beleites
-##' @seealso \code{\link[hyperSpec]{wl.eval}}, \code{\link[hyperSpec]{vanderMonde}}
-##' @export
+#' Normalize numbers -> [0, 1]
+#'
+#' The input \code{x} is mapped to [0, 1] by subtracting the minimum and subsequently dividing by
+#' the maximum. If all elements of \code{x} are equal, 1 is returned.
+#'
+#' @title normalization for mixed colors
+#' @name normalize01
+#' @param x  vector with values to transform
+#' @param tolerance tolerance level for determining what is 0 and 1
+#' @param ... additional parameters such as \code{tolerance} handed down.
+#' @return vector with \code{x} values mapped to the interval [0, 1]
+#' @author C. Beleites
+#' @seealso \code{\link[hyperSpec]{wl.eval}}, \code{\link[hyperSpec]{vanderMonde}}
+#' @export
 setGeneric("normalize01", function(x, ...) standardGeneric("normalize01"))
 
-##' @export
-##' @rdname normalize01
+#' @export
+#' @rdname normalize01
 setMethod(
   normalize01, signature(x = "matrix"),
   function(x, tolerance = hy.getOption("tolerance")) {
@@ -28,8 +28,8 @@ setMethod(
   }
 )
 
-##' @export
-##' @rdname normalize01
+#' @export
+#' @rdname normalize01
 setMethod("normalize01", signature(x = "numeric"), function(x, tolerance = hy.getOption("tolerance")) {
   x <- x - min(x)
 
@@ -41,8 +41,8 @@ setMethod("normalize01", signature(x = "numeric"), function(x, tolerance = hy.ge
   }
 })
 
-##' @export
-##' @rdname normalize01
+#' @export
+#' @rdname normalize01
 setMethod(normalize01, signature(x = "hyperSpec"), function(x, ...) {
   validObject(x)
 
@@ -52,7 +52,7 @@ setMethod(normalize01, signature(x = "hyperSpec"), function(x, ...) {
   x
 })
 
-##' @include unittest.R
+#' @include unittest.R
 .test(normalize01) <- function() {
   context("normalize01")
 

--- a/hyperSpec/R/options.R
+++ b/hyperSpec/R/options.R
@@ -47,8 +47,7 @@
 #' @export
 #' @examples
 #'
-#' hy.getOptions ()
-#'
+#' hy.getOptions()
 hy.getOptions <- function(...) {
   dots <- c(...)
   if (length(dots) == 0L) {

--- a/hyperSpec/R/options.R
+++ b/hyperSpec/R/options.R
@@ -11,44 +11,44 @@
   ggplot.spc.nmax = 10
 )
 
-##' Options for package hyperSpec
-##' Functions to access and set hyperSpec's options.
-##'
-##' Currently, the following options are defined:
-##' \tabular{llll}{
-##' \bold{Name}          \tab \bold{Default Value (range)}      \tab \bold{Description}                               \tab \bold{Used by}\cr
-##' debuglevel           \tab 0 (1L 2L 3L)                      \tab amount of debugging information produced         \tab \code{\link{spc.identify}} \code{\link{map.identify}}\cr
-##'                      \tab                                   \tab                                                  \tab various file import functions\cr
-##'                      \tab                                   \tab                                                  \tab \code{\link{spc.fit.poly.below}}\cr
-##' gc                   \tab FALSE                             \tab triggers frequent calling of gc ()               \tab \code{\link{read.ENVI}}, \code{new ("hyperSpec")}\cr
-##' file.remove.emptyspc \tab TRUE                              \tab remove empty spectra directly on file import     \tab various file import functions\cr
-##' file.keep.name       \tab TRUE                              \tab always create filename column                    \tab various file import functions\cr
-##' tolerance            \tab \code{sqrt (.Machine$double.eps)} \tab tolerance for numerical comparisons              \tab \code{\link{normalize01}}, file import: \code{file.remove.emptyspc}\cr
-##' wl.tolerance         \tab \code{sqrt (.Machine$double.eps)} \tab tolerance for comparisons of the wavelength axis \tab \code{\link{all.equal}}, \code{\link{collapse}}, \code{\link{rbind}}\cr
-##' plot.spc.nmax        \tab 25                                \tab number of spectra to be plotted by default       \tab \code{\link{plotspc}}\cr
-##' ggplot.spc.nmax      \tab 10                                \tab                                                  \tab \code{\link{qplotspc}}\cr
-##' }
-##'
-##' \code{hy.setOptions} will discard any values that were given without a
-##' name.
-##'
-##' @rdname options
-##' @param ... \code{hy.setOptions}: pairs of argument names and values.
-##'
-##' \code{hy.getOptions}: indices (or names) of the options.
-##' @return
-##' \tabular{ll}{
-##' \code{hy.getOptions} \tab returns a list of all options\cr
-##' \code{hy.setOptions} \tab invisibly returns a list with the options \cr
-##' \code{hy.getOption}  \tab returns the value of the requested option \cr
-##' }
-##' @author C. Beleites
-##' @keywords misc
-##' @export
-##' @examples
-##'
-##' hy.getOptions ()
-##'
+#' Options for package hyperSpec
+#' Functions to access and set hyperSpec's options.
+#'
+#' Currently, the following options are defined:
+#' \tabular{llll}{
+#' \bold{Name}          \tab \bold{Default Value (range)}      \tab \bold{Description}                               \tab \bold{Used by}\cr
+#' debuglevel           \tab 0 (1L 2L 3L)                      \tab amount of debugging information produced         \tab \code{\link{spc.identify}} \code{\link{map.identify}}\cr
+#'                      \tab                                   \tab                                                  \tab various file import functions\cr
+#'                      \tab                                   \tab                                                  \tab \code{\link{spc.fit.poly.below}}\cr
+#' gc                   \tab FALSE                             \tab triggers frequent calling of gc ()               \tab \code{\link{read.ENVI}}, \code{new ("hyperSpec")}\cr
+#' file.remove.emptyspc \tab TRUE                              \tab remove empty spectra directly on file import     \tab various file import functions\cr
+#' file.keep.name       \tab TRUE                              \tab always create filename column                    \tab various file import functions\cr
+#' tolerance            \tab \code{sqrt (.Machine$double.eps)} \tab tolerance for numerical comparisons              \tab \code{\link{normalize01}}, file import: \code{file.remove.emptyspc}\cr
+#' wl.tolerance         \tab \code{sqrt (.Machine$double.eps)} \tab tolerance for comparisons of the wavelength axis \tab \code{\link{all.equal}}, \code{\link{collapse}}, \code{\link{rbind}}\cr
+#' plot.spc.nmax        \tab 25                                \tab number of spectra to be plotted by default       \tab \code{\link{plotspc}}\cr
+#' ggplot.spc.nmax      \tab 10                                \tab                                                  \tab \code{\link{qplotspc}}\cr
+#' }
+#'
+#' \code{hy.setOptions} will discard any values that were given without a
+#' name.
+#'
+#' @rdname options
+#' @param ... \code{hy.setOptions}: pairs of argument names and values.
+#'
+#' \code{hy.getOptions}: indices (or names) of the options.
+#' @return
+#' \tabular{ll}{
+#' \code{hy.getOptions} \tab returns a list of all options\cr
+#' \code{hy.setOptions} \tab invisibly returns a list with the options \cr
+#' \code{hy.getOption}  \tab returns the value of the requested option \cr
+#' }
+#' @author C. Beleites
+#' @keywords misc
+#' @export
+#' @examples
+#'
+#' hy.getOptions ()
+#'
 hy.getOptions <- function(...) {
   dots <- c(...)
   if (length(dots) == 0L) {
@@ -58,7 +58,7 @@ hy.getOptions <- function(...) {
   }
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(hy.getOptions) <- function() {
   context("hy.getOptions")
 
@@ -76,16 +76,16 @@ hy.getOptions <- function(...) {
   })
 }
 
-##' @rdname options
-##' @export
-##' @param name the name of the option
+#' @rdname options
+#' @export
+#' @param name the name of the option
 hy.getOption <- function(name) {
   .options [[name]]
 }
 
-##' @rdname options
-##' @export
-##' @importFrom utils modifyList
+#' @rdname options
+#' @export
+#' @importFrom utils modifyList
 hy.setOptions <- function(...) {
   new <- list(...)
 

--- a/hyperSpec/R/options.R
+++ b/hyperSpec/R/options.R
@@ -79,7 +79,7 @@ hy.getOptions <- function(...) {
 #' @export
 #' @param name the name of the option
 hy.getOption <- function(name) {
-  .options [[name]]
+  .options[[name]]
 }
 
 #' @rdname options
@@ -89,8 +89,8 @@ hy.setOptions <- function(...) {
   new <- list(...)
 
   ## if called with list in 1st argument, use that list
-  if (length(new) == 1 && is.list(new [[1]])) {
-    new <- new [[1]]
+  if (length(new) == 1 && is.list(new[[1]])) {
+    new <- new[[1]]
   }
 
   names <- nzchar(names(new))

--- a/hyperSpec/R/orderwl.R
+++ b/hyperSpec/R/orderwl.R
@@ -1,39 +1,39 @@
 
-##' Sorting the Wavelengths of a hyperSpec Object
-##' Rearranges the \code{hyperSpec} object so that the wavelength vector is in increasing (or
-##' decreasing) order.
-##'
-##' The wavelength vector is sorted and the columns of the spectra matrix are rearranged accordingly.
-##'
-##' @param x The \code{hyperSpec} object.
-##' @param na.last,decreasing Handed to \code{\link[base]{order}}.
-##' @return A \code{hyperSpec} object.
-##' @author C. Beleites
-##' @export
-##' @seealso \code{\link[base]{order}}
-##' @examples
-##'
-##' ## Example 1: different drawing order in plotspc
-##' spc <- new ("hyperSpec", spc = matrix (rnorm (5) + 1:5, ncol = 5))
-##' spc <- cbind (spc, spc+.5)
-##'
-##' plot (spc, "spc")
-##' text (wl (spc), spc [[]], as.character (1:10))
-##' spc <- orderwl (spc)
-##' plot (spc, "spc")
-##' text (wl (spc), spc [[]], as.character (1:10))
-##'
-##' ## Example 2
-##' spc <- new ("hyperSpec", spc = matrix (rnorm (5)*2 + 1:5, ncol = 5))
-##' spc <- cbind (spc, spc)
-##'
-##' plot (seq_len(nwl(spc)), spc[[]], type = "b")
-##' spc[[]]
-##'
-##' spc <- orderwl (spc)
-##' lines (seq_len(nwl(spc)), spc[[]], type = "l", col = "red")
-##' spc[[]]
-##'
+#' Sorting the Wavelengths of a hyperSpec Object
+#' Rearranges the \code{hyperSpec} object so that the wavelength vector is in increasing (or
+#' decreasing) order.
+#'
+#' The wavelength vector is sorted and the columns of the spectra matrix are rearranged accordingly.
+#'
+#' @param x The \code{hyperSpec} object.
+#' @param na.last,decreasing Handed to \code{\link[base]{order}}.
+#' @return A \code{hyperSpec} object.
+#' @author C. Beleites
+#' @export
+#' @seealso \code{\link[base]{order}}
+#' @examples
+#'
+#' ## Example 1: different drawing order in plotspc
+#' spc <- new ("hyperSpec", spc = matrix (rnorm (5) + 1:5, ncol = 5))
+#' spc <- cbind (spc, spc+.5)
+#'
+#' plot (spc, "spc")
+#' text (wl (spc), spc [[]], as.character (1:10))
+#' spc <- orderwl (spc)
+#' plot (spc, "spc")
+#' text (wl (spc), spc [[]], as.character (1:10))
+#'
+#' ## Example 2
+#' spc <- new ("hyperSpec", spc = matrix (rnorm (5)*2 + 1:5, ncol = 5))
+#' spc <- cbind (spc, spc)
+#'
+#' plot (seq_len(nwl(spc)), spc[[]], type = "b")
+#' spc[[]]
+#'
+#' spc <- orderwl (spc)
+#' lines (seq_len(nwl(spc)), spc[[]], type = "l", col = "red")
+#' spc[[]]
+#'
 orderwl <- function(x, na.last = TRUE, decreasing = FALSE) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/orderwl.R
+++ b/hyperSpec/R/orderwl.R
@@ -18,10 +18,10 @@
 #' spc <- cbind(spc, spc + .5)
 #'
 #' plot(spc, "spc")
-#' text(wl(spc), spc [[]], as.character(1:10))
+#' text(wl(spc), spc[[]], as.character(1:10))
 #' spc <- orderwl(spc)
 #' plot(spc, "spc")
-#' text(wl(spc), spc [[]], as.character(1:10))
+#' text(wl(spc), spc[[]], as.character(1:10))
 #'
 #' ## Example 2
 #' spc <- new("hyperSpec", spc = matrix(rnorm(5) * 2 + 1:5, ncol = 5))

--- a/hyperSpec/R/orderwl.R
+++ b/hyperSpec/R/orderwl.R
@@ -14,26 +14,25 @@
 #' @examples
 #'
 #' ## Example 1: different drawing order in plotspc
-#' spc <- new ("hyperSpec", spc = matrix (rnorm (5) + 1:5, ncol = 5))
-#' spc <- cbind (spc, spc+.5)
+#' spc <- new("hyperSpec", spc = matrix(rnorm(5) + 1:5, ncol = 5))
+#' spc <- cbind(spc, spc + .5)
 #'
-#' plot (spc, "spc")
-#' text (wl (spc), spc [[]], as.character (1:10))
-#' spc <- orderwl (spc)
-#' plot (spc, "spc")
-#' text (wl (spc), spc [[]], as.character (1:10))
+#' plot(spc, "spc")
+#' text(wl(spc), spc [[]], as.character(1:10))
+#' spc <- orderwl(spc)
+#' plot(spc, "spc")
+#' text(wl(spc), spc [[]], as.character(1:10))
 #'
 #' ## Example 2
-#' spc <- new ("hyperSpec", spc = matrix (rnorm (5)*2 + 1:5, ncol = 5))
-#' spc <- cbind (spc, spc)
+#' spc <- new("hyperSpec", spc = matrix(rnorm(5) * 2 + 1:5, ncol = 5))
+#' spc <- cbind(spc, spc)
 #'
-#' plot (seq_len(nwl(spc)), spc[[]], type = "b")
+#' plot(seq_len(nwl(spc)), spc[[]], type = "b")
 #' spc[[]]
 #'
-#' spc <- orderwl (spc)
-#' lines (seq_len(nwl(spc)), spc[[]], type = "l", col = "red")
+#' spc <- orderwl(spc)
+#' lines(seq_len(nwl(spc)), spc[[]], type = "l", col = "red")
 #' spc[[]]
-#'
 orderwl <- function(x, na.last = TRUE, decreasing = FALSE) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/paracetamol.R
+++ b/hyperSpec/R/paracetamol.R
@@ -13,8 +13,9 @@
 #'
 #' paracetamol
 #'
-#' plot (paracetamol)
-#' plotspc (paracetamol, c (min ~ 1750, 2800 ~ max), xoffset = 800,
-#' wl.reverse = TRUE)
-#'
+#' plot(paracetamol)
+#' plotspc(paracetamol, c(min ~ 1750, 2800 ~ max),
+#'   xoffset = 800,
+#'   wl.reverse = TRUE
+#' )
 NULL

--- a/hyperSpec/R/paracetamol.R
+++ b/hyperSpec/R/paracetamol.R
@@ -1,20 +1,20 @@
-##' Paracetamol Spectrum
-##' A Raman spectrum of a paracetamol tablet.
-##'
-##'
-##' @name paracetamol
-##' @docType data
-##' @format The spectrum was acquired with a Renishaw InVia spectrometer from
-##'   100 to 3200 cm^-1 in step scan mode. Thus the spectrum has several
-##'   overlapping wavelength regions.
-##' @author C. Beleites
-##' @keywords datasets
-##' @examples
-##'
-##' paracetamol
-##'
-##' plot (paracetamol)
-##' plotspc (paracetamol, c (min ~ 1750, 2800 ~ max), xoffset = 800,
-##' wl.reverse = TRUE)
-##'
+#' Paracetamol Spectrum
+#' A Raman spectrum of a paracetamol tablet.
+#'
+#'
+#' @name paracetamol
+#' @docType data
+#' @format The spectrum was acquired with a Renishaw InVia spectrometer from
+#'   100 to 3200 cm^-1 in step scan mode. Thus the spectrum has several
+#'   overlapping wavelength regions.
+#' @author C. Beleites
+#' @keywords datasets
+#' @examples
+#'
+#' paracetamol
+#'
+#' plot (paracetamol)
+#' plotspc (paracetamol, c (min ~ 1750, 2800 ~ max), xoffset = 800,
+#' wl.reverse = TRUE)
+#'
 NULL

--- a/hyperSpec/R/paste.row.R
+++ b/hyperSpec/R/paste.row.R
@@ -4,7 +4,7 @@
 ###  .paste.row
 ###
 ###
-##' @importFrom utils head tail
+#' @importFrom utils head tail
 .paste.row <- function(x, label = "", name = "", ins = 0, i = NULL, val = FALSE,
                        ...) {
   .print.val <- function(x, range = TRUE, digits = getOption("digits"),

--- a/hyperSpec/R/pearson.dist.R
+++ b/hyperSpec/R/pearson.dist.R
@@ -16,7 +16,7 @@
 #' @export
 #' @examples
 #'
-#' pearson.dist(flu [[]])
+#' pearson.dist(flu[[]])
 #' pearson.dist(flu)
 pearson.dist <- function(x) {
   x <- as.matrix(x)
@@ -51,7 +51,7 @@ pearson.dist <- function(x) {
 
 ## benchmark
 # function (){
-#   m <- sample (faux_cell, 10000) [[]]
+#   m <- sample (faux_cell, 10000)[[]]
 #   microbenchmark (
 #     cor = as.dist (0.5 - cor (t (as.matrix (m))) / 2),
 #     tcross = pearson.dist (m),

--- a/hyperSpec/R/pearson.dist.R
+++ b/hyperSpec/R/pearson.dist.R
@@ -1,23 +1,23 @@
-##' Distance based on Pearson's \eqn{R^2}{R squared}
-##'
-##' The calculated distance is
-##' \eqn{D^2 = \frac{1 - COR (\code{x}')}{2}}{D^2 = (1 - COR (x')) / 2}
-##'
-##' The distance between the rows of \code{x} is calculated.  The possible
-##' values range from 0 (prefectly correlated) over 0.5 (uncorrelated) to 1
-##' (perfectly anti-correlated).
-##'
-##' @param x a matrix
-##' @return distance matrix (distance object)
-##' @author C. Beleites
-##' @seealso \code{\link[stats]{as.dist}}
-##' @references S. Theodoridis and K. Koutroumbas: Pattern Recognition, 3rd ed., p. 495
-##' @keywords cluster
-##' @export
-##' @examples
-##'
-##' pearson.dist (flu [[]])
-##' pearson.dist (flu)
+#' Distance based on Pearson's \eqn{R^2}{R squared}
+#'
+#' The calculated distance is
+#' \eqn{D^2 = \frac{1 - COR (\code{x}')}{2}}{D^2 = (1 - COR (x')) / 2}
+#'
+#' The distance between the rows of \code{x} is calculated.  The possible
+#' values range from 0 (prefectly correlated) over 0.5 (uncorrelated) to 1
+#' (perfectly anti-correlated).
+#'
+#' @param x a matrix
+#' @return distance matrix (distance object)
+#' @author C. Beleites
+#' @seealso \code{\link[stats]{as.dist}}
+#' @references S. Theodoridis and K. Koutroumbas: Pattern Recognition, 3rd ed., p. 495
+#' @keywords cluster
+#' @export
+#' @examples
+#'
+#' pearson.dist (flu [[]])
+#' pearson.dist (flu)
 pearson.dist <- function(x) {
   x <- as.matrix(x)
 
@@ -37,7 +37,7 @@ pearson.dist <- function(x) {
   0.5 - x / 2
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(pearson.dist) <- function() {
   context("pearson.dist")
 

--- a/hyperSpec/R/pearson.dist.R
+++ b/hyperSpec/R/pearson.dist.R
@@ -16,8 +16,8 @@
 #' @export
 #' @examples
 #'
-#' pearson.dist (flu [[]])
-#' pearson.dist (flu)
+#' pearson.dist(flu [[]])
+#' pearson.dist(flu)
 pearson.dist <- function(x) {
   x <- as.matrix(x)
 

--- a/hyperSpec/R/plot.R
+++ b/hyperSpec/R/plot.R
@@ -29,45 +29,48 @@
 
   switch(tolower(y),
 
-         spc = plotspc(x, ...),
+    spc = plotspc(x, ...),
 
-         spcmeansd = {
-           dots <- modifyList(
-             list(object = mean_pm_sd(x), fill = c(1, NA, 1)),
-             dots)
+    spcmeansd = {
+      dots <- modifyList(
+        list(object = mean_pm_sd(x), fill = c(1, NA, 1)),
+        dots
+      )
 
-           do.call(plotspc, dots)
-         },
+      do.call(plotspc, dots)
+    },
 
-         spcprctile = {
-           dots <- modifyList(
-             list(object = quantile(x, probs = c(0.16, 0.5, 0.84)), fill = c(1, NA, 1)),
-             dots)
+    spcprctile = {
+      dots <- modifyList(
+        list(object = quantile(x, probs = c(0.16, 0.5, 0.84)), fill = c(1, NA, 1)),
+        dots
+      )
 
-           do.call(plotspc, dots)
-         },
+      do.call(plotspc, dots)
+    },
 
-         spcprctl5 = {
-           dots <- modifyList(
-             list(object = quantile(x, probs = c(0.05, 0.16, 0.5, 0.84, 0.95)), fill = c(1, 2, 3, 2, 1), fill.col = c("#00000040")),
-             dots)
+    spcprctl5 = {
+      dots <- modifyList(
+        list(object = quantile(x, probs = c(0.05, 0.16, 0.5, 0.84, 0.95)), fill = c(1, 2, 3, 2, 1), fill.col = c("#00000040")),
+        dots
+      )
 
-           do.call(plotspc, dots)
-         },
+      do.call(plotspc, dots)
+    },
 
-         map = plotmap(x, ...),
+    map = plotmap(x, ...),
 
-         voronoi = plotvoronoi(x, ...),
+    voronoi = plotvoronoi(x, ...),
 
-         mat = plotmat(x, ...),
+    mat = plotmat(x, ...),
 
-         c = plotc(x, ...),
+    c = plotc(x, ...),
 
-         ts = plotc(x, spc ~ t, ...),
+    ts = plotc(x, spc ~ t, ...),
 
-         depth = plotc(x, spc ~ z, ...),
+    depth = plotc(x, spc ~ z, ...),
 
-         stop(paste("y = ", y, "unknown.", collapse = " "))
+    stop(paste("y = ", y, "unknown.", collapse = " "))
   )
 }
 
@@ -142,19 +145,19 @@ setGeneric("plot")
 #' @export
 #' @examples
 #'
-#' plot (flu)
+#' plot(flu)
 #'
-#' plot (flu, "c")
+#' plot(flu, "c")
 #'
-#' plot (laser, "ts")
+#' plot(laser, "ts")
 #'
-#' spc <- apply (faux_cell, 2, quantile, probs = 0.05)
-#' spc <- sweep (faux_cell, 2, spc, "-")
-#' plot (spc, "spcprctl5")
-#' plot (spc, "spcprctile")
-#' plot (spc, "spcmeansd")
+#' spc <- apply(faux_cell, 2, quantile, probs = 0.05)
+#' spc <- sweep(faux_cell, 2, spc, "-")
+#' plot(spc, "spcprctl5")
+#' plot(spc, "spcprctile")
+#' plot(spc, "spcmeansd")
 #'
-### use plotspc as default plot function
+#' ### use plotspc as default plot function
 setMethod(
   "plot",
   signature(x = "hyperSpec", y = "missing"),

--- a/hyperSpec/R/plot.R
+++ b/hyperSpec/R/plot.R
@@ -7,7 +7,7 @@
 ###
 ### .plot: main switchyard for plotting functions
 ###
-##' @importFrom utils modifyList
+#' @importFrom utils modifyList
 .plot <- function(x, y, ...) {
   ##    'spc'        ... spectra
   ##    'map'        ... map
@@ -71,89 +71,89 @@
   )
 }
 
-##' @noRd
-##' @export
+#' @noRd
+#' @export
 setGeneric("plot")
 
-##' Plotting hyperSpec Objects
-##'
-##' Plotting \code{hyperSpec} objects. The \code{plot} method for
-##' \code{hyperSpec} objects is a switchyard to \code{\link{plotspc}},
-##' \code{\link{plotmap}}, and \code{\link{plotc}}.
-##'
-##' It also supplies some convenient abbrevations for much used plots.
-##'
-##' If \code{y} is missing, \code{plot} behaves like \code{plot (x, y =
-##' "spc")}.
-##'
-##' Supported values for \code{y} are:
-##'
-##' \describe{ \item{"spc"}{calls \code{\link{plotspc}} to produce a spectra
-##' plot.}
-##'
-##' \item{"spcmeansd"}{plots mean spectrum +/- one standard deviation}
-##'
-##' \item{"spcprctile"}{plots 16th, 50th, and 84th percentile spectre. If the
-##' distributions of the intensities at all wavelengths were normal, this would
-##' correspond to \code{"spcmeansd"}. However, this is frequently not the case.
-##' Then \code{"spcprctile"} gives a better impression of the spectral data
-##' set.}
-##'
-##' \item{"spcprctl5"}{like \code{"spcprctile"}, but additionally the 5th and
-##' 95th percentile spectra are plotted.}
-##'
-##' \item{"map"}{calls \code{\link{plotmap}} to produce a map plot.}
-##'
-##' \item{"voronoi"}{calls \code{\link{plotvoronoi}} to produce a Voronoi plot
-##' (tesselated plot, like "map" for hyperSpec objects with uneven/non-rectangular
-##' grid).}
-##'
-##' \item{"mat"}{calls \code{\link{plotmat}} to produce a plot of the spectra
-##' matrix (not to be confused with \code{\link[graphics]{matplot}}).}
-##'
-##' \item{"c"}{calls \code{\link{plotc}} to produce a calibration (or time
-##' series, depth-profile, or the like)}
-##'
-##' \item{"ts"}{plots a time series: abbrevation for \code{\link{plotc} (x,
-##' use.c = "t")}}
-##'
-##' \item{"depth"}{plots a depth profile: abbrevation for \code{\link{plotc}
-##' (x, use.c = "z")}} }
-##'
-##' @name plot-methods
-##' @rdname plot
-##' @aliases plot plot,ANY,ANY-method plot,hyperSpec,character-method
-##'   plot,hyperSpec,missing-method
-##' @docType methods
-##' @param x the \code{hyperSpec} object
-##' @param y selects what plot should be produced
-##' @param ... arguments passed to the respective plot function
-##' @author C. Beleites
-##' @seealso \code{\link{plotspc}} for spectra plots (intensity over
-##'   wavelength),
-##'
-##' \code{\link{plotmap}} for plotting maps, i.e. color coded summary value on
-##'   two (usually spatial) dimensions.
-##'
-##' \code{\link{plotc}}
-##'
-##' \code{\link[graphics]{plot}}
-##' @keywords methods hplot
-##' @export
-##' @examples
-##'
-##' plot (flu)
-##'
-##' plot (flu, "c")
-##'
-##' plot (laser, "ts")
-##'
-##' spc <- apply (faux_cell, 2, quantile, probs = 0.05)
-##' spc <- sweep (faux_cell, 2, spc, "-")
-##' plot (spc, "spcprctl5")
-##' plot (spc, "spcprctile")
-##' plot (spc, "spcmeansd")
-##'
+#' Plotting hyperSpec Objects
+#'
+#' Plotting \code{hyperSpec} objects. The \code{plot} method for
+#' \code{hyperSpec} objects is a switchyard to \code{\link{plotspc}},
+#' \code{\link{plotmap}}, and \code{\link{plotc}}.
+#'
+#' It also supplies some convenient abbrevations for much used plots.
+#'
+#' If \code{y} is missing, \code{plot} behaves like \code{plot (x, y =
+#' "spc")}.
+#'
+#' Supported values for \code{y} are:
+#'
+#' \describe{ \item{"spc"}{calls \code{\link{plotspc}} to produce a spectra
+#' plot.}
+#'
+#' \item{"spcmeansd"}{plots mean spectrum +/- one standard deviation}
+#'
+#' \item{"spcprctile"}{plots 16th, 50th, and 84th percentile spectre. If the
+#' distributions of the intensities at all wavelengths were normal, this would
+#' correspond to \code{"spcmeansd"}. However, this is frequently not the case.
+#' Then \code{"spcprctile"} gives a better impression of the spectral data
+#' set.}
+#'
+#' \item{"spcprctl5"}{like \code{"spcprctile"}, but additionally the 5th and
+#' 95th percentile spectra are plotted.}
+#'
+#' \item{"map"}{calls \code{\link{plotmap}} to produce a map plot.}
+#'
+#' \item{"voronoi"}{calls \code{\link{plotvoronoi}} to produce a Voronoi plot
+#' (tesselated plot, like "map" for hyperSpec objects with uneven/non-rectangular
+#' grid).}
+#'
+#' \item{"mat"}{calls \code{\link{plotmat}} to produce a plot of the spectra
+#' matrix (not to be confused with \code{\link[graphics]{matplot}}).}
+#'
+#' \item{"c"}{calls \code{\link{plotc}} to produce a calibration (or time
+#' series, depth-profile, or the like)}
+#'
+#' \item{"ts"}{plots a time series: abbrevation for \code{\link{plotc} (x,
+#' use.c = "t")}}
+#'
+#' \item{"depth"}{plots a depth profile: abbrevation for \code{\link{plotc}
+#' (x, use.c = "z")}} }
+#'
+#' @name plot-methods
+#' @rdname plot
+#' @aliases plot plot,ANY,ANY-method plot,hyperSpec,character-method
+#'   plot,hyperSpec,missing-method
+#' @docType methods
+#' @param x the \code{hyperSpec} object
+#' @param y selects what plot should be produced
+#' @param ... arguments passed to the respective plot function
+#' @author C. Beleites
+#' @seealso \code{\link{plotspc}} for spectra plots (intensity over
+#'   wavelength),
+#'
+#' \code{\link{plotmap}} for plotting maps, i.e. color coded summary value on
+#'   two (usually spatial) dimensions.
+#'
+#' \code{\link{plotc}}
+#'
+#' \code{\link[graphics]{plot}}
+#' @keywords methods hplot
+#' @export
+#' @examples
+#'
+#' plot (flu)
+#'
+#' plot (flu, "c")
+#'
+#' plot (laser, "ts")
+#'
+#' spc <- apply (faux_cell, 2, quantile, probs = 0.05)
+#' spc <- sweep (faux_cell, 2, spc, "-")
+#' plot (spc, "spcprctl5")
+#' plot (spc, "spcprctile")
+#' plot (spc, "spcmeansd")
+#'
 ### use plotspc as default plot function
 setMethod(
   "plot",
@@ -162,8 +162,8 @@ setMethod(
 )
 
 ### allow choice of spectral or map plot by second argument
-##' @rdname plot
-##' @export
+#' @rdname plot
+#' @export
 setMethod(
   "plot",
   signature(x = "hyperSpec", y = "character"), .plot

--- a/hyperSpec/R/plotc.R
+++ b/hyperSpec/R/plotc.R
@@ -6,82 +6,82 @@
 
 
 
-##' Calibration- and Timeseries Plots, Depth-Profiles and the like
-##' \code{plotc} plots intensities of a \code{hyperSpec} object over another
-##' dimension such as concentration, time, or a spatial coordinate.
-##'
-##' If \code{func} is not \code{NULL}, the summary characteristic is calculated
-##' first by applying \code{func} with the respective arguments (in
-##' \code{func.args}) to each of the spectra. If \code{func} returns more than
-##' one value (for each spectrum), the different values end up as different
-##' wavelengths.
-##'
-##' If the wavelength is not used in the model specification nor in
-##' \code{groups}, nor for specifying \code{subsets}, and neither is
-##' \code{func} given, then only the first wavelength's intensities are plotted
-##' and a warning is issued.
-##'
-##' The special column names \code{.rownames} and \code{.wavelength} may be
-##' used.
-##'
-##' The actual plotting is done by \code{\link[lattice]{xyplot}}.
-##'
-##' @param object the \code{hyperSpec} object
-##' @param model the lattice model specifying the plot
-##' @param func function to compute a summary value from the spectra to be
-##'   plotted instead of single intensities
-##' @param func.args further arguments to \code{func}
-##' @param groups grouping variable, e.g. \code{.wavelength} if intensities of
-##'   more than one wavelength should be plotted
-##' @param ... further arguments to \code{\link[lattice]{xyplot}}.
-##' @author C. Beleites
-##' @seealso \code{\link[lattice]{xyplot}}
-##' @keywords hplot
-##' @export
-##' @import graphics
-##' @importFrom lattice xyplot
-##' @examples
-##'
-##'
-##' ## example 1: calibration of fluorescence
-##' plotc (flu) ## gives a warning
-##'
-##' plotc (flu, func = mean)
-##' plotc (flu, func = range, groups = .wavelength)
-##'
-##' plotc (flu[,,450], ylab = expression (I ["450 nm"] / a.u.))
-##'
-##'
-##' calibration <- lm (spc ~ c, data = flu[,,450]$.)
-##' summary (calibration)
-##' plotc (flu [,, 450], type = c("p", "r"))
-##'
-##' conc <- list (c = seq (from = 0.04, to = 0.31, by = 0.01))
-##' ci <- predict (calibration, newdata = conc, interval = "confidence", level = 0.999)
-##'
-##' panel.ci <-  function (x, y, ...,
-##'                        conc, ci.lwr, ci.upr, ci.col = "#606060") {
-##'    panel.xyplot (x, y, ...)
-##'    panel.lmline (x, y,...)
-##'    panel.lines (conc, ci.lwr, col = ci.col)
-##'    panel.lines (conc, ci.upr, col = ci.col)
-##' }
-##'
-##' plotc (flu [,, 450], panel = panel.ci,
-##'        conc = conc$c, ci.lwr = ci [, 2], ci.upr = ci [, 3])
-##'
-##' ## example 2: time-trace of laser emission modes
-##' cols <- c ("black", "blue", "#008000", "red")
-##' wl <- i2wl (laser, c(13, 17, 21, 23))
-##'
-##' plotspc (laser, axis.args=list (x = list (at = seq (404.5, 405.8, .1))))
-##' for (i in seq_along (wl))
-##'    abline (v = wl[i], col = cols[i], lwd = 2)
-##'
-##' plotc (laser [,, wl], spc ~ t, groups = .wavelength, type = "b",
-##'        col = cols)
-##'
-##' @importFrom utils modifyList
+#' Calibration- and Timeseries Plots, Depth-Profiles and the like
+#' \code{plotc} plots intensities of a \code{hyperSpec} object over another
+#' dimension such as concentration, time, or a spatial coordinate.
+#'
+#' If \code{func} is not \code{NULL}, the summary characteristic is calculated
+#' first by applying \code{func} with the respective arguments (in
+#' \code{func.args}) to each of the spectra. If \code{func} returns more than
+#' one value (for each spectrum), the different values end up as different
+#' wavelengths.
+#'
+#' If the wavelength is not used in the model specification nor in
+#' \code{groups}, nor for specifying \code{subsets}, and neither is
+#' \code{func} given, then only the first wavelength's intensities are plotted
+#' and a warning is issued.
+#'
+#' The special column names \code{.rownames} and \code{.wavelength} may be
+#' used.
+#'
+#' The actual plotting is done by \code{\link[lattice]{xyplot}}.
+#'
+#' @param object the \code{hyperSpec} object
+#' @param model the lattice model specifying the plot
+#' @param func function to compute a summary value from the spectra to be
+#'   plotted instead of single intensities
+#' @param func.args further arguments to \code{func}
+#' @param groups grouping variable, e.g. \code{.wavelength} if intensities of
+#'   more than one wavelength should be plotted
+#' @param ... further arguments to \code{\link[lattice]{xyplot}}.
+#' @author C. Beleites
+#' @seealso \code{\link[lattice]{xyplot}}
+#' @keywords hplot
+#' @export
+#' @import graphics
+#' @importFrom lattice xyplot
+#' @examples
+#'
+#'
+#' ## example 1: calibration of fluorescence
+#' plotc (flu) ## gives a warning
+#'
+#' plotc (flu, func = mean)
+#' plotc (flu, func = range, groups = .wavelength)
+#'
+#' plotc (flu[,,450], ylab = expression (I ["450 nm"] / a.u.))
+#'
+#'
+#' calibration <- lm (spc ~ c, data = flu[,,450]$.)
+#' summary (calibration)
+#' plotc (flu [,, 450], type = c("p", "r"))
+#'
+#' conc <- list (c = seq (from = 0.04, to = 0.31, by = 0.01))
+#' ci <- predict (calibration, newdata = conc, interval = "confidence", level = 0.999)
+#'
+#' panel.ci <-  function (x, y, ...,
+#'                        conc, ci.lwr, ci.upr, ci.col = "#606060") {
+#'    panel.xyplot (x, y, ...)
+#'    panel.lmline (x, y,...)
+#'    panel.lines (conc, ci.lwr, col = ci.col)
+#'    panel.lines (conc, ci.upr, col = ci.col)
+#' }
+#'
+#' plotc (flu [,, 450], panel = panel.ci,
+#'        conc = conc$c, ci.lwr = ci [, 2], ci.upr = ci [, 3])
+#'
+#' ## example 2: time-trace of laser emission modes
+#' cols <- c ("black", "blue", "#008000", "red")
+#' wl <- i2wl (laser, c(13, 17, 21, 23))
+#'
+#' plotspc (laser, axis.args=list (x = list (at = seq (404.5, 405.8, .1))))
+#' for (i in seq_along (wl))
+#'    abline (v = wl[i], col = cols[i], lwd = 2)
+#'
+#' plotc (laser [,, wl], spc ~ t, groups = .wavelength, type = "b",
+#'        col = cols)
+#'
+#' @importFrom utils modifyList
 plotc <- function(object, model = spc ~ c, groups = NULL,
                   func = NULL, func.args = list(), ...) {
   chk.hy(object)

--- a/hyperSpec/R/plotc.R
+++ b/hyperSpec/R/plotc.R
@@ -123,19 +123,19 @@ plotc <- function(object, model = spc ~ c, groups = NULL,
   }
 
   if (is.null(func)) {
-    ylab <- object@label [[use.spc]]
+    ylab <- object@label[[use.spc]]
   } else {
     ylab <- substitute(func())
-    ylab [[2]] <- object@label [[use.spc]][[1]]
+    ylab[[2]] <- object@label[[use.spc]][[1]]
     for (i in seq_along(func.args)) {
       if (names(func.args)[[i]] == "") {
-        ylab [[i + 2]] <- func.args [[i]]
+        ylab[[i + 2]] <- func.args[[i]]
       } else {
-        ylab [[i + 2]] <- bquote(
+        ylab[[i + 2]] <- bquote(
           .(x) == .(y),
           list(
-            x = names(func.args) [[i]],
-            y = as.character(func.args [[i]])
+            x = names(func.args)[[i]],
+            y = as.character(func.args[[i]])
           )
         )
       }
@@ -146,7 +146,7 @@ plotc <- function(object, model = spc ~ c, groups = NULL,
   ## set defaults: axis labels, plot style
   dots <- modifyList(
     list(
-      xlab = object@label [[use.c]],
+      xlab = object@label[[use.c]],
       ylab = ylab,
       pch = 19
     ),

--- a/hyperSpec/R/plotc.R
+++ b/hyperSpec/R/plotc.R
@@ -44,43 +44,47 @@
 #'
 #'
 #' ## example 1: calibration of fluorescence
-#' plotc (flu) ## gives a warning
+#' plotc(flu) ## gives a warning
 #'
-#' plotc (flu, func = mean)
-#' plotc (flu, func = range, groups = .wavelength)
+#' plotc(flu, func = mean)
+#' plotc(flu, func = range, groups = .wavelength)
 #'
-#' plotc (flu[,,450], ylab = expression (I ["450 nm"] / a.u.))
+#' plotc(flu[, , 450], ylab = expression(I ["450 nm"] / a.u.))
 #'
 #'
-#' calibration <- lm (spc ~ c, data = flu[,,450]$.)
-#' summary (calibration)
-#' plotc (flu [,, 450], type = c("p", "r"))
+#' calibration <- lm(spc ~ c, data = flu[, , 450]$.)
+#' summary(calibration)
+#' plotc(flu [, , 450], type = c("p", "r"))
 #'
-#' conc <- list (c = seq (from = 0.04, to = 0.31, by = 0.01))
-#' ci <- predict (calibration, newdata = conc, interval = "confidence", level = 0.999)
+#' conc <- list(c = seq(from = 0.04, to = 0.31, by = 0.01))
+#' ci <- predict(calibration, newdata = conc, interval = "confidence", level = 0.999)
 #'
-#' panel.ci <-  function (x, y, ...,
-#'                        conc, ci.lwr, ci.upr, ci.col = "#606060") {
-#'    panel.xyplot (x, y, ...)
-#'    panel.lmline (x, y,...)
-#'    panel.lines (conc, ci.lwr, col = ci.col)
-#'    panel.lines (conc, ci.upr, col = ci.col)
+#' panel.ci <- function(x, y, ...,
+#'                      conc, ci.lwr, ci.upr, ci.col = "#606060") {
+#'   panel.xyplot(x, y, ...)
+#'   panel.lmline(x, y, ...)
+#'   panel.lines(conc, ci.lwr, col = ci.col)
+#'   panel.lines(conc, ci.upr, col = ci.col)
 #' }
 #'
-#' plotc (flu [,, 450], panel = panel.ci,
-#'        conc = conc$c, ci.lwr = ci [, 2], ci.upr = ci [, 3])
+#' plotc(flu [, , 450],
+#'   panel = panel.ci,
+#'   conc = conc$c, ci.lwr = ci [, 2], ci.upr = ci [, 3]
+#' )
 #'
 #' ## example 2: time-trace of laser emission modes
-#' cols <- c ("black", "blue", "#008000", "red")
-#' wl <- i2wl (laser, c(13, 17, 21, 23))
+#' cols <- c("black", "blue", "#008000", "red")
+#' wl <- i2wl(laser, c(13, 17, 21, 23))
 #'
-#' plotspc (laser, axis.args=list (x = list (at = seq (404.5, 405.8, .1))))
-#' for (i in seq_along (wl))
-#'    abline (v = wl[i], col = cols[i], lwd = 2)
+#' plotspc(laser, axis.args = list(x = list(at = seq(404.5, 405.8, .1))))
+#' for (i in seq_along(wl)) {
+#'   abline(v = wl[i], col = cols[i], lwd = 2)
+#' }
 #'
-#' plotc (laser [,, wl], spc ~ t, groups = .wavelength, type = "b",
-#'        col = cols)
-#'
+#' plotc(laser [, , wl], spc ~ t,
+#'   groups = .wavelength, type = "b",
+#'   col = cols
+#' )
 #' @importFrom utils modifyList
 plotc <- function(object, model = spc ~ c, groups = NULL,
                   func = NULL, func.args = list(), ...) {

--- a/hyperSpec/R/plotmap.R
+++ b/hyperSpec/R/plotmap.R
@@ -77,28 +77,30 @@
 #' @examples
 #'
 #' \dontrun{
-#' vignette (plotting)
-#' vignette (hyperspec)
+#' vignette(plotting)
+#' vignette(hyperspec)
 #' }
 #'
-#' levelplot (spc ~ y * x, faux_cell [,,1003]) # properly rotated
-#' plotmap (faux_cell [,,1003])
+#' levelplot(spc ~ y * x, faux_cell [, , 1003]) # properly rotated
+#' plotmap(faux_cell [, , 1003])
 #'
 #' # plot spectra matrix
-#' levelplot (spc ~ .wavelength * t, laser, contour = TRUE, col = "#00000080")
+#' levelplot(spc ~ .wavelength * t, laser, contour = TRUE, col = "#00000080")
 #' # see also plotmat
 #'
-#' plotmap (faux_cell, region ~ x * y)
+#' plotmap(faux_cell, region ~ x * y)
 #'
 #' # Voronoi plots
-#' smpl <- sample (faux_cell, 300)
-#' plotmap (smpl, region ~ x * y)
-#' if (require (tripack))
-#'     plotvoronoi (smpl, region ~ x * y)
-#' if (require (deldir))
-#'     plotvoronoi (smpl, region ~ x * y,
-#'                  use.tripack = FALSE)
-#'
+#' smpl <- sample(faux_cell, 300)
+#' plotmap(smpl, region ~ x * y)
+#' if (require(tripack)) {
+#'   plotvoronoi(smpl, region ~ x * y)
+#' }
+#' if (require(deldir)) {
+#'   plotvoronoi(smpl, region ~ x * y,
+#'     use.tripack = FALSE
+#'   )
+#' }
 #' @importFrom utils modifyList
 plotmap <- function(object, model = spc ~ x * y,
                     func = mean, func.args = list(), ...) {

--- a/hyperSpec/R/plotmap.R
+++ b/hyperSpec/R/plotmap.R
@@ -8,98 +8,98 @@
 
 
 
-##' Plot a Map and Identify/Select Spectra in the Map
-##' \code{\link[lattice]{levelplot}} functions for hyperSpec objects.  An image or map of a summary
-##' value of each spectrum is plotted. Spectra may be identified by mouse click.
-##'
-##' The \code{model} can contain the special column name \code{.wavelength} to specify the wavelength
-##' axis.
-##'
-##' \code{plotmap}, \code{map.identify}, and the \code{levelplot} methods internally use the same
-##' gateway function to \code{\link[lattice]{levelplot}}. Thus \code{transform.factor} can be used
-##' with all of them and the panel function defaults to \code{\link[lattice]{panel.levelplot.raster}}
-##' for all three. Two special column names, \code{.rownames} and \code{.wavelength} may be used.
-##'
-##' \code{levelplot} plots the spectra matrix.
-##'
-##' \code{plotvoronoi} calls \code{plotmap} with different default settings, namely the panel
-##' function defaults to \code{\link[latticeExtra]{panel.voronoi}}.
-##' \code{\link[latticeExtra]{panel.voronoi}} depends on either of the packages 'tripack' or 'deldir'
-##' being installed. For further information, please consult the help page of
-##' \code{\link[latticeExtra]{panel.voronoi}}.  On the \code{\link{faux_cell}} data set, \code{plotmap}
-##' is roughly 5 times faster than \code{plotvoronoi} using tripack, and ca. 15 times faster than
-##' \code{plotvoronoi} using deldir. Package tripack, however, is free only for non-commercial
-##' use. Also, it seems that tripack version hang (R running at full CPU power, but not responding
-##' nor finishing the calculation) for certain data sets. In this case, \code{mix = TRUE} may help.
-##'
-##' \code{map.identify} calls \code{plotmap} and \code{plotvoronoi}, respectively and waits for
-##' (left) mouse clicks on points. Other mouse clicks end the input.
-##'
-##' Unlike \code{\link[lattice]{panel.identify}}, the indices returned by \code{map.identify} are in
-##' the same order as the points were clicked. Also, multiple clicks on the same point are returned
-##' as multiple entries with the same index.
-##'
-##' \code{map.identify} uses option \code{debuglevel} similar to \code{\link{spc.identify}}:
-##' \code{debuglevel == 1} will plot the tolerance window if no data point was inside (and
-##' additionally labels the point) while \code{debuglevel == 2} will always plot the tolerance
-##' window.
-##'
-##' The \code{map.sel.*} functions offer further interactive selection, see
-##' \code{\link{map.sel.poly}}.
-##'
-##' @rdname levelplot
-##' @aliases plotmap plotvoronoi levelplot,formula,hyperSpec-method
-##'   levelplot,hyperSpec,missing-method map.identify
-##' @param object,data the \code{hyperSpec} object
-##' @param model,x formula specifying the columns of object that are to be
-##'   displayed by \code{\link[lattice]{levelplot}}
-##' @param func,func.args Before plotting, \code{plotmap} applies function
-##'   \code{func} with the arguments given in the list \code{func.args} to each
-##'   of the spectra. Thus a single summary value is displayed for each of the
-##'   spectra.
-##'
-##' This can be suppressed manually by setting \code{func} to NULL. It is automatically suppressed if
-##' \code{.wavelength} appears in the formula.
-##' @param voronoi Should the plot for identifying spectra by mouse click be
-##'   produced by \code{plotmap} (default) or \code{plotvoronoi}?
-##' @param ... further arguments are passed down the call chain, and finally
-##'   to \code{\link[lattice]{levelplot}}
-##' @return \code{map.identify} returns a vector of row indices into
-##'   \code{object} of the clicked points.
-##'
-##' The other functions return a lattice object.
-##' @author C. Beleites
-##' @seealso \code{vignette (plotting)}, \code{vignette (hyperspec)}
-##'
-##' \code{\link{plot}}
-##' @export
-##' @keywords hplot
-##' @examples
-##'
-##' \dontrun{
-##' vignette (plotting)
-##' vignette (hyperspec)
-##' }
-##'
-##' levelplot (spc ~ y * x, faux_cell [,,1003]) # properly rotated
-##' plotmap (faux_cell [,,1003])
-##'
-##' # plot spectra matrix
-##' levelplot (spc ~ .wavelength * t, laser, contour = TRUE, col = "#00000080")
-##' # see also plotmat
-##'
-##' plotmap (faux_cell, region ~ x * y)
-##'
-##' # Voronoi plots
-##' smpl <- sample (faux_cell, 300)
-##' plotmap (smpl, region ~ x * y)
-##' if (require (tripack))
-##'     plotvoronoi (smpl, region ~ x * y)
-##' if (require (deldir))
-##'     plotvoronoi (smpl, region ~ x * y,
-##'                  use.tripack = FALSE)
-##'
-##' @importFrom utils modifyList
+#' Plot a Map and Identify/Select Spectra in the Map
+#' \code{\link[lattice]{levelplot}} functions for hyperSpec objects.  An image or map of a summary
+#' value of each spectrum is plotted. Spectra may be identified by mouse click.
+#'
+#' The \code{model} can contain the special column name \code{.wavelength} to specify the wavelength
+#' axis.
+#'
+#' \code{plotmap}, \code{map.identify}, and the \code{levelplot} methods internally use the same
+#' gateway function to \code{\link[lattice]{levelplot}}. Thus \code{transform.factor} can be used
+#' with all of them and the panel function defaults to \code{\link[lattice]{panel.levelplot.raster}}
+#' for all three. Two special column names, \code{.rownames} and \code{.wavelength} may be used.
+#'
+#' \code{levelplot} plots the spectra matrix.
+#'
+#' \code{plotvoronoi} calls \code{plotmap} with different default settings, namely the panel
+#' function defaults to \code{\link[latticeExtra]{panel.voronoi}}.
+#' \code{\link[latticeExtra]{panel.voronoi}} depends on either of the packages 'tripack' or 'deldir'
+#' being installed. For further information, please consult the help page of
+#' \code{\link[latticeExtra]{panel.voronoi}}.  On the \code{\link{faux_cell}} data set, \code{plotmap}
+#' is roughly 5 times faster than \code{plotvoronoi} using tripack, and ca. 15 times faster than
+#' \code{plotvoronoi} using deldir. Package tripack, however, is free only for non-commercial
+#' use. Also, it seems that tripack version hang (R running at full CPU power, but not responding
+#' nor finishing the calculation) for certain data sets. In this case, \code{mix = TRUE} may help.
+#'
+#' \code{map.identify} calls \code{plotmap} and \code{plotvoronoi}, respectively and waits for
+#' (left) mouse clicks on points. Other mouse clicks end the input.
+#'
+#' Unlike \code{\link[lattice]{panel.identify}}, the indices returned by \code{map.identify} are in
+#' the same order as the points were clicked. Also, multiple clicks on the same point are returned
+#' as multiple entries with the same index.
+#'
+#' \code{map.identify} uses option \code{debuglevel} similar to \code{\link{spc.identify}}:
+#' \code{debuglevel == 1} will plot the tolerance window if no data point was inside (and
+#' additionally labels the point) while \code{debuglevel == 2} will always plot the tolerance
+#' window.
+#'
+#' The \code{map.sel.*} functions offer further interactive selection, see
+#' \code{\link{map.sel.poly}}.
+#'
+#' @rdname levelplot
+#' @aliases plotmap plotvoronoi levelplot,formula,hyperSpec-method
+#'   levelplot,hyperSpec,missing-method map.identify
+#' @param object,data the \code{hyperSpec} object
+#' @param model,x formula specifying the columns of object that are to be
+#'   displayed by \code{\link[lattice]{levelplot}}
+#' @param func,func.args Before plotting, \code{plotmap} applies function
+#'   \code{func} with the arguments given in the list \code{func.args} to each
+#'   of the spectra. Thus a single summary value is displayed for each of the
+#'   spectra.
+#'
+#' This can be suppressed manually by setting \code{func} to NULL. It is automatically suppressed if
+#' \code{.wavelength} appears in the formula.
+#' @param voronoi Should the plot for identifying spectra by mouse click be
+#'   produced by \code{plotmap} (default) or \code{plotvoronoi}?
+#' @param ... further arguments are passed down the call chain, and finally
+#'   to \code{\link[lattice]{levelplot}}
+#' @return \code{map.identify} returns a vector of row indices into
+#'   \code{object} of the clicked points.
+#'
+#' The other functions return a lattice object.
+#' @author C. Beleites
+#' @seealso \code{vignette (plotting)}, \code{vignette (hyperspec)}
+#'
+#' \code{\link{plot}}
+#' @export
+#' @keywords hplot
+#' @examples
+#'
+#' \dontrun{
+#' vignette (plotting)
+#' vignette (hyperspec)
+#' }
+#'
+#' levelplot (spc ~ y * x, faux_cell [,,1003]) # properly rotated
+#' plotmap (faux_cell [,,1003])
+#'
+#' # plot spectra matrix
+#' levelplot (spc ~ .wavelength * t, laser, contour = TRUE, col = "#00000080")
+#' # see also plotmat
+#'
+#' plotmap (faux_cell, region ~ x * y)
+#'
+#' # Voronoi plots
+#' smpl <- sample (faux_cell, 300)
+#' plotmap (smpl, region ~ x * y)
+#' if (require (tripack))
+#'     plotvoronoi (smpl, region ~ x * y)
+#' if (require (deldir))
+#'     plotvoronoi (smpl, region ~ x * y,
+#'                  use.tripack = FALSE)
+#'
+#' @importFrom utils modifyList
 plotmap <- function(object, model = spc ~ x * y,
                     func = mean, func.args = list(), ...) {
   chk.hy(object)

--- a/hyperSpec/R/plotmat.R
+++ b/hyperSpec/R/plotmat.R
@@ -16,18 +16,18 @@
 #' @seealso  \code{\link[graphics]{image}}, \code{\link[graphics]{contour}}, \code{\link[hyperSpec]{levelplot}}
 #' @export
 #' @examples
-#' plotmat (laser, col = alois.palette (100))
+#' plotmat(laser, col = alois.palette(100))
 #'
-#' plot (laser, "mat")
+#' plot(laser, "mat")
 #'
-#' plotmat (laser)
-#' plotmat (laser, contour = TRUE, add = TRUE)
+#' plotmat(laser)
+#' plotmat(laser, contour = TRUE, add = TRUE)
 #'
 #' ## use different y axis labels
 #'
-#' plotmat (laser, "t")
+#' plotmat(laser, "t")
 #'
-#' plotmat (laser, laser$t / 3600, ylab = "t / h")
+#' plotmat(laser, laser$t / 3600, ylab = "t / h")
 #' @importFrom utils modifyList
 plotmat <- function(object, y = ".row", ylab, col = alois.palette(20), ...,
                     contour = FALSE) {

--- a/hyperSpec/R/plotmat.R
+++ b/hyperSpec/R/plotmat.R
@@ -1,34 +1,34 @@
-##' Plot spectra matrix
-##'
-##' plots the spectra matrix.
-##'
-##' If package plotrix is available, a color legend is plotted to the right. The right margin is set
-##' to at least 5 lines.
-##' @param object hyperSpec object
-##' @param y character giving the name of the extra data column to label the y axis.
-##' @param ylab y axis label, defaults to \code{"row"} and the label of the extra data column used
-##' for the y axis, respectively.
-##' @param col see  \code{\link[graphics]{image}}
-##' @param ... further parameters for \code{\link[graphics]{image}}
-##' @param contour should \code{\link[graphics]{contour}} be called instead of
-##' \code{\link[graphics]{image}}?
-##' @author Claudia Beleites
-##' @seealso  \code{\link[graphics]{image}}, \code{\link[graphics]{contour}}, \code{\link[hyperSpec]{levelplot}}
-##' @export
-##' @examples
-##' plotmat (laser, col = alois.palette (100))
-##'
-##' plot (laser, "mat")
-##'
-##' plotmat (laser)
-##' plotmat (laser, contour = TRUE, add = TRUE)
-##'
-##' ## use different y axis labels
-##'
-##' plotmat (laser, "t")
-##'
-##' plotmat (laser, laser$t / 3600, ylab = "t / h")
-##' @importFrom utils modifyList
+#' Plot spectra matrix
+#'
+#' plots the spectra matrix.
+#'
+#' If package plotrix is available, a color legend is plotted to the right. The right margin is set
+#' to at least 5 lines.
+#' @param object hyperSpec object
+#' @param y character giving the name of the extra data column to label the y axis.
+#' @param ylab y axis label, defaults to \code{"row"} and the label of the extra data column used
+#' for the y axis, respectively.
+#' @param col see  \code{\link[graphics]{image}}
+#' @param ... further parameters for \code{\link[graphics]{image}}
+#' @param contour should \code{\link[graphics]{contour}} be called instead of
+#' \code{\link[graphics]{image}}?
+#' @author Claudia Beleites
+#' @seealso  \code{\link[graphics]{image}}, \code{\link[graphics]{contour}}, \code{\link[hyperSpec]{levelplot}}
+#' @export
+#' @examples
+#' plotmat (laser, col = alois.palette (100))
+#'
+#' plot (laser, "mat")
+#'
+#' plotmat (laser)
+#' plotmat (laser, contour = TRUE, add = TRUE)
+#'
+#' ## use different y axis labels
+#'
+#' plotmat (laser, "t")
+#'
+#' plotmat (laser, laser$t / 3600, ylab = "t / h")
+#' @importFrom utils modifyList
 plotmat <- function(object, y = ".row", ylab, col = alois.palette(20), ...,
                     contour = FALSE) {
   chk.hy(object)
@@ -94,7 +94,7 @@ plotmat <- function(object, y = ".row", ylab, col = alois.palette(20), ...,
   }
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(plotmat) <- function() {
   context("plotmat")
 

--- a/hyperSpec/R/plotmat.R
+++ b/hyperSpec/R/plotmat.R
@@ -45,7 +45,7 @@ plotmat <- function(object, y = ".row", ylab, col = alois.palette(20), ...,
 
     y <- switch(y,
       .row = seq_len(nrow(object)),
-      object@data [[y]]
+      object@data[[y]]
     )
   }
 
@@ -53,7 +53,7 @@ plotmat <- function(object, y = ".row", ylab, col = alois.palette(20), ...,
     list(
       x = wl(object),
       y = y,
-      z = t(object [[]]),
+      z = t(object[[]]),
       xlab = labels(object, ".wavelength"),
       ylab = ylab,
       col = col
@@ -100,7 +100,7 @@ plotmat <- function(object, y = ".row", ylab, col = alois.palette(20), ...,
 
   test_that("non-increasing wavelength axis", {
     tmp <- flu
-    tmp [[]] <- tmp [[, , max ~ min]]
+    tmp[[]] <- tmp[[, , max ~ min]]
     tmp@wavelength <- rev(tmp@wavelength)
 
     expect_silent(plotmat(tmp))

--- a/hyperSpec/R/plotspc.R
+++ b/hyperSpec/R/plotspc.R
@@ -7,156 +7,156 @@
 
 
 
-##' Plotting Spectra
-##' Plot the spectra of a \code{hyperSpec} object, i.e. intensity over
-##' wavelength. Instead of the intensity values of the spectra matrix summary
-##' values calculated from these may be used.
-##'
-##' This is \code{hyperSpec}'s main plotting function for spectra plots.
-##'
-##' New plots are created by \code{\link[graphics]{plot}}, but the abscissa and
-##' ordinate are drawn separately by \code{\link[graphics]{axis}}. Also,
-##' \code{\link[graphics]{title}} is called explicitly to set up titles and
-##' axis labels. This allows fine-grained customization of the plots.
-##'
-##' If package plotrix is available, its function
-##' \code{\link[plotrix]{axis.break}} is used to produce break marks for cut
-##' wavelength axes.
-##'
-##' @param object the \code{hyperSpec} object
-##' @param wl.range the wavelength range to be plotted.
-##'
-##' Either a numeric vector or a list of vectors with different wavelength
-##'   ranges to be plotted separately.
-##'
-##' The values can be either wavelengths or wavelength indices (according to
-##'   \code{wl.index}).
-##' @param wl.index if \code{TRUE}, \code{wl.range} is considered to give
-##'   column indices into the spectra matrix. Defaults to specifying wavelength
-##'   values rather than indices.
-##' @param wl.reverse if \code{TRUE}, the wavelength axis is plotted backwards.
-##' @param spc.nmax maximal number of spectra to be plotted (to avoid
-##'   accidentally plotting of large numbers of spectra).
-##' @param func a function to apply to each wavelength in order to calculate
-##'   summary spectra such as mean, min, max, etc.
-##' @param func.args \code{list} with furter arguments for \code{func}
-##' @param add if \code{TRUE}, the output is added to the existing plot
-##' @param bty see \code{\link[graphics]{par}}
-##' @param col see \code{\link[graphics]{par}}. \code{col} might be a vector
-##'   giving individual colors for the spectra.
-##' @param xoffset vector with abscissa offsets for each of the
-##'   \code{wl.range}s. If it has one element less than there are
-##'   \code{wl.range}s, 0 is padded at the beginning.
-##'
-##' The values are interpreted as the distance along the wavelength axis that
-##'   the following parts of the spectra are shifted towards the origin. E.g.
-##'   if \code{wl.range = list (600 ~ 1800, 2800 ~ 3200)}, \code{xoffset = 750}
-##'   would result in a reasonable plot. See also the examples.
-##' @param yoffset ordinate offset values for the spectra. May be offsets to
-##'   stack the spectra (\code{\link{stacked.offsets}}). Either one for all
-##'   spectra, one per spectrum or one per group in \code{stacked}.
-##' @param nxticks hint how many tick marks the abscissa should have.
-##' @param stacked if not \code{NULL}, a "stacked" plot is produced, see the
-##'   example. \code{stacked} may be \code{TRUE} to stack single spectra.  A
-##'   numeric or factor is interpreted as giving the grouping, character is
-##'   interpreted as the name of the extra data column that holds the groups.
-##' @param stacked.args a list with further arguments to
-##'   \code{\link{stacked.offsets}}.
-##' @param fill if not \code{NULL}, the area between the specified spectra is
-##'   filled with color \code{col}. The grouping can be given as factor or
-##'   numeric, or as a character with the name of the extra data column to use.
-##'   If a group contains more than 2 spectra, the first and the last are used.
-##'
-##' If \code{TRUE} spectra n and nrow (spc) - n build a group.
-##' @param fill.col character vector with fill color. Defaults to brightened
-##'   colors from \code{col}.
-##' @param border character vector with border color. You will need to set the
-##'   line color \code{col} to \code{NA} in order see the effect.
-##' @param plot.args \code{list} with further arguments to
-##'   \code{\link[graphics]{plot}}
-##' @param axis.args \code{list} with further arguments for
-##'   \code{\link[graphics]{axis}}. \code{axis.args$x} should contain arguments
-##'   for plotting the abscissa, \code{axis.args$y} those for the ordinate
-##'   (again as \code{lists}).
-##' @param title.args list with further arguments to
-##'   \code{\link[graphics]{title}}.
-##'
-##' \code{title.args} may contain two lists, \code{$x}, and \code{$y} to set
-##'   parameters individually for each axis.
-##' @param lines.args list with further arguments to
-##'   \code{\link[graphics]{lines}}.
-##'
-##' \code{lines.args$type} defaults to "l".
-##' @param break.args list with arguments for
-##'   \code{\link[plotrix]{axis.break}}.
-##' @param polygon.args list with further arguments to
-##'   \code{\link[graphics]{polygon}} which draws the filled areas.
-##' @param zeroline \code{NA} or a list with arguments
-##'   \code{\link[graphics]{abline}}, used to plot line (s) marking I = 0.
-##'
-##' \code{NA} suppresses plotting of the line.  The line is by default turned
-##'   off if \code{yoffset} is not 0.
-##' @param debuglevel if > 0, additional debug output is produced,
-##' see \code{\link[hyperSpec]{options}} for details
-##' @return \code{plotspc} invisibly returns a list with
-##'
-##' \item{x}{the abscissa coordinates of the plotted spectral data points}
-##'
-##' \item{y}{a matrix the ordinate coordinates of the plotted spectral data
-##'   points}
-##'
-##' \item{wavelengths}{the wavelengths of the plotted spectral data points}
-##'
-##' This can be used together with \code{\link{spc.identify}}.
-##' @author C. Beleites
-##' @seealso \code{\link[graphics]{plot}}, \code{\link[graphics]{axis}},
-##'   \code{\link[graphics]{title}}, \code{\link[graphics]{lines}},
-##'   \code{\link[graphics]{polygon}}, \code{\link[graphics]{par}} for the
-##'   description of the respective arguments.
-##'
-##' \code{\link[plotrix]{axis.break}} for cut marks
-##'
-##' See \code{\link{plot}} for some predefined spectra plots such as mean
-##'   spectrum +/- one standard deviation and the like.
-##'
-##' \code{\link[graphics]{identify}} and \code{\link[graphics]{locator}} about
-##'   interaction with plots.
-##' @keywords hplot
-##' @export
-##' @examples
-##'
-##' plotspc (flu)
-##'
-##' ## artificial example to show wavelength axis cutting
-##' plotspc (faux_cell [sample (nrow (faux_cell), 50)],
-##'          wl.range = list (600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
-##'          xoffset = c (0, 300, 450))
-##'
-##' plotspc (faux_cell [sample (nrow (faux_cell), 50)],
-##'          wl.range = list (600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
-##'          xoffset = c (300, 450))
-##'
-##' ## some journals publish Raman spectra backwards
-##' plotspc (faux_cell [sample (nrow (faux_cell), 50)], wl.reverse = TRUE)
-##'
-##' plotspc (laser[(0:4)*20+1,,], stacked = TRUE)
-##'
-##' plotspc (laser, func = mean_pm_sd,
-##'          col = c(NA, "red", "black"), lines.args = list (lwd = 2),
-##'          fill = c (1, NA, 1),
-##'          fill.col = "yellow", border = "blue",
-##'          polygon.args = list (lty = 2, lwd = 4),
-##'          title.args = list (xlab = expression (lambda[emission] / nm),
-##'                             y = list(line = 3.4),
-##'                             col.lab = "darkgreen"),
-##'          axis.args = list (x = list (col = "magenta"), y = list (las = 1))
-##'         )
-##'
-##' mean.pm.sd <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
-##' plot (mean.pm.sd, col = matlab.palette (3), fill = ".aggregate", stacked = ".aggregate")
-##'
-##' @importFrom utils modifyList relist head tail
-##' @importFrom grDevices rgb col2rgb
+#' Plotting Spectra
+#' Plot the spectra of a \code{hyperSpec} object, i.e. intensity over
+#' wavelength. Instead of the intensity values of the spectra matrix summary
+#' values calculated from these may be used.
+#'
+#' This is \code{hyperSpec}'s main plotting function for spectra plots.
+#'
+#' New plots are created by \code{\link[graphics]{plot}}, but the abscissa and
+#' ordinate are drawn separately by \code{\link[graphics]{axis}}. Also,
+#' \code{\link[graphics]{title}} is called explicitly to set up titles and
+#' axis labels. This allows fine-grained customization of the plots.
+#'
+#' If package plotrix is available, its function
+#' \code{\link[plotrix]{axis.break}} is used to produce break marks for cut
+#' wavelength axes.
+#'
+#' @param object the \code{hyperSpec} object
+#' @param wl.range the wavelength range to be plotted.
+#'
+#' Either a numeric vector or a list of vectors with different wavelength
+#'   ranges to be plotted separately.
+#'
+#' The values can be either wavelengths or wavelength indices (according to
+#'   \code{wl.index}).
+#' @param wl.index if \code{TRUE}, \code{wl.range} is considered to give
+#'   column indices into the spectra matrix. Defaults to specifying wavelength
+#'   values rather than indices.
+#' @param wl.reverse if \code{TRUE}, the wavelength axis is plotted backwards.
+#' @param spc.nmax maximal number of spectra to be plotted (to avoid
+#'   accidentally plotting of large numbers of spectra).
+#' @param func a function to apply to each wavelength in order to calculate
+#'   summary spectra such as mean, min, max, etc.
+#' @param func.args \code{list} with furter arguments for \code{func}
+#' @param add if \code{TRUE}, the output is added to the existing plot
+#' @param bty see \code{\link[graphics]{par}}
+#' @param col see \code{\link[graphics]{par}}. \code{col} might be a vector
+#'   giving individual colors for the spectra.
+#' @param xoffset vector with abscissa offsets for each of the
+#'   \code{wl.range}s. If it has one element less than there are
+#'   \code{wl.range}s, 0 is padded at the beginning.
+#'
+#' The values are interpreted as the distance along the wavelength axis that
+#'   the following parts of the spectra are shifted towards the origin. E.g.
+#'   if \code{wl.range = list (600 ~ 1800, 2800 ~ 3200)}, \code{xoffset = 750}
+#'   would result in a reasonable plot. See also the examples.
+#' @param yoffset ordinate offset values for the spectra. May be offsets to
+#'   stack the spectra (\code{\link{stacked.offsets}}). Either one for all
+#'   spectra, one per spectrum or one per group in \code{stacked}.
+#' @param nxticks hint how many tick marks the abscissa should have.
+#' @param stacked if not \code{NULL}, a "stacked" plot is produced, see the
+#'   example. \code{stacked} may be \code{TRUE} to stack single spectra.  A
+#'   numeric or factor is interpreted as giving the grouping, character is
+#'   interpreted as the name of the extra data column that holds the groups.
+#' @param stacked.args a list with further arguments to
+#'   \code{\link{stacked.offsets}}.
+#' @param fill if not \code{NULL}, the area between the specified spectra is
+#'   filled with color \code{col}. The grouping can be given as factor or
+#'   numeric, or as a character with the name of the extra data column to use.
+#'   If a group contains more than 2 spectra, the first and the last are used.
+#'
+#' If \code{TRUE} spectra n and nrow (spc) - n build a group.
+#' @param fill.col character vector with fill color. Defaults to brightened
+#'   colors from \code{col}.
+#' @param border character vector with border color. You will need to set the
+#'   line color \code{col} to \code{NA} in order see the effect.
+#' @param plot.args \code{list} with further arguments to
+#'   \code{\link[graphics]{plot}}
+#' @param axis.args \code{list} with further arguments for
+#'   \code{\link[graphics]{axis}}. \code{axis.args$x} should contain arguments
+#'   for plotting the abscissa, \code{axis.args$y} those for the ordinate
+#'   (again as \code{lists}).
+#' @param title.args list with further arguments to
+#'   \code{\link[graphics]{title}}.
+#'
+#' \code{title.args} may contain two lists, \code{$x}, and \code{$y} to set
+#'   parameters individually for each axis.
+#' @param lines.args list with further arguments to
+#'   \code{\link[graphics]{lines}}.
+#'
+#' \code{lines.args$type} defaults to "l".
+#' @param break.args list with arguments for
+#'   \code{\link[plotrix]{axis.break}}.
+#' @param polygon.args list with further arguments to
+#'   \code{\link[graphics]{polygon}} which draws the filled areas.
+#' @param zeroline \code{NA} or a list with arguments
+#'   \code{\link[graphics]{abline}}, used to plot line (s) marking I = 0.
+#'
+#' \code{NA} suppresses plotting of the line.  The line is by default turned
+#'   off if \code{yoffset} is not 0.
+#' @param debuglevel if > 0, additional debug output is produced,
+#' see \code{\link[hyperSpec]{options}} for details
+#' @return \code{plotspc} invisibly returns a list with
+#'
+#' \item{x}{the abscissa coordinates of the plotted spectral data points}
+#'
+#' \item{y}{a matrix the ordinate coordinates of the plotted spectral data
+#'   points}
+#'
+#' \item{wavelengths}{the wavelengths of the plotted spectral data points}
+#'
+#' This can be used together with \code{\link{spc.identify}}.
+#' @author C. Beleites
+#' @seealso \code{\link[graphics]{plot}}, \code{\link[graphics]{axis}},
+#'   \code{\link[graphics]{title}}, \code{\link[graphics]{lines}},
+#'   \code{\link[graphics]{polygon}}, \code{\link[graphics]{par}} for the
+#'   description of the respective arguments.
+#'
+#' \code{\link[plotrix]{axis.break}} for cut marks
+#'
+#' See \code{\link{plot}} for some predefined spectra plots such as mean
+#'   spectrum +/- one standard deviation and the like.
+#'
+#' \code{\link[graphics]{identify}} and \code{\link[graphics]{locator}} about
+#'   interaction with plots.
+#' @keywords hplot
+#' @export
+#' @examples
+#'
+#' plotspc (flu)
+#'
+#' ## artificial example to show wavelength axis cutting
+#' plotspc (faux_cell [sample (nrow (faux_cell), 50)],
+#'          wl.range = list (600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
+#'          xoffset = c (0, 300, 450))
+#'
+#' plotspc (faux_cell [sample (nrow (faux_cell), 50)],
+#'          wl.range = list (600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
+#'          xoffset = c (300, 450))
+#'
+#' ## some journals publish Raman spectra backwards
+#' plotspc (faux_cell [sample (nrow (faux_cell), 50)], wl.reverse = TRUE)
+#'
+#' plotspc (laser[(0:4)*20+1,,], stacked = TRUE)
+#'
+#' plotspc (laser, func = mean_pm_sd,
+#'          col = c(NA, "red", "black"), lines.args = list (lwd = 2),
+#'          fill = c (1, NA, 1),
+#'          fill.col = "yellow", border = "blue",
+#'          polygon.args = list (lty = 2, lwd = 4),
+#'          title.args = list (xlab = expression (lambda[emission] / nm),
+#'                             y = list(line = 3.4),
+#'                             col.lab = "darkgreen"),
+#'          axis.args = list (x = list (col = "magenta"), y = list (las = 1))
+#'         )
+#'
+#' mean.pm.sd <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
+#' plot (mean.pm.sd, col = matlab.palette (3), fill = ".aggregate", stacked = ".aggregate")
+#'
+#' @importFrom utils modifyList relist head tail
+#' @importFrom grDevices rgb col2rgb
 plotspc <- function(object,
                     ## what wavelengths to plot
                     wl.range = TRUE, wl.index = FALSE, wl.reverse = FALSE,
@@ -541,44 +541,44 @@ plotspc <- function(object,
 
 
 
-##' y Offsets for Stacked Plots
-##' Calculate approriate \code{yoffset} values for stacking in \code{\link[hyperSpec]{plotspc}}.
-##'
-##' Usually, the \code{stacked} argument of \code{\link[hyperSpec]{plotspc}} will do fine, but if you
-##' need fine control over the stacking, you may calculate the y offsets yourself.
-##'
-##' Empty levels of the stacking factor are dropped (as no stacking offset can be calculated in that
-##' case.)
-##'
-##' @param x a \code{hyperSpec} object
-##' @param min.zero if \code{TRUE}, the lesser of zero and the minimum intensity of the spectrum is
-##' used as minimum.
-##' @param add.factor,add.sum proportion and absolute amount of space that should be added.
-##' @param .spc for internal use. If given, the ranges are evaluated on \code{.spc}. However, this
-##' may change in future.
-##' @return a list containing \item{offsets}{numeric with the yoffset for each group in
-##' \code{stacked}} \item{groups}{numeric with the group number for each spectrum} \item{levels}{if
-##' \code{stacked} is a factor, the levels of the groups}
-##' @author C. Beleites
-##' @seealso \code{\link[hyperSpec]{plotspc}}
-##' @rdname plotspc
-##' @export
-##' @examples
-##'
-##' mean.pm.sd <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
-##'
-##' offset <- stacked.offsets (mean.pm.sd, ".aggregate")
-##' plot (mean.pm.sd, fill.col = matlab.palette (3), fill = ".aggregate",
-##'       stacked = ".aggregate")
-##'
-##' plot (aggregate (faux_cell, faux_cell$region, mean), yoffset = offset$offsets,
-##'       lines.args = list (lty = 2, lwd = 2), add = TRUE)
-##'
-##' barb <- do.call (collapse, barbiturates [1:3])
-##' plot (barb, lines.args = list (type = "h"), stacked = TRUE,
-##'       stacked.args = list (add.factor = .2))
-##'
-##'
+#' y Offsets for Stacked Plots
+#' Calculate approriate \code{yoffset} values for stacking in \code{\link[hyperSpec]{plotspc}}.
+#'
+#' Usually, the \code{stacked} argument of \code{\link[hyperSpec]{plotspc}} will do fine, but if you
+#' need fine control over the stacking, you may calculate the y offsets yourself.
+#'
+#' Empty levels of the stacking factor are dropped (as no stacking offset can be calculated in that
+#' case.)
+#'
+#' @param x a \code{hyperSpec} object
+#' @param min.zero if \code{TRUE}, the lesser of zero and the minimum intensity of the spectrum is
+#' used as minimum.
+#' @param add.factor,add.sum proportion and absolute amount of space that should be added.
+#' @param .spc for internal use. If given, the ranges are evaluated on \code{.spc}. However, this
+#' may change in future.
+#' @return a list containing \item{offsets}{numeric with the yoffset for each group in
+#' \code{stacked}} \item{groups}{numeric with the group number for each spectrum} \item{levels}{if
+#' \code{stacked} is a factor, the levels of the groups}
+#' @author C. Beleites
+#' @seealso \code{\link[hyperSpec]{plotspc}}
+#' @rdname plotspc
+#' @export
+#' @examples
+#'
+#' mean.pm.sd <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
+#'
+#' offset <- stacked.offsets (mean.pm.sd, ".aggregate")
+#' plot (mean.pm.sd, fill.col = matlab.palette (3), fill = ".aggregate",
+#'       stacked = ".aggregate")
+#'
+#' plot (aggregate (faux_cell, faux_cell$region, mean), yoffset = offset$offsets,
+#'       lines.args = list (lty = 2, lwd = 2), add = TRUE)
+#'
+#' barb <- do.call (collapse, barbiturates [1:3])
+#' plot (barb, lines.args = list (type = "h"), stacked = TRUE,
+#'       stacked.args = list (add.factor = .2))
+#'
+#'
 stacked.offsets <- function(x, stacked = TRUE,
                             min.zero = FALSE, add.factor = 0.05, add.sum = 0,
                             # tight = FALSE, TODO
@@ -638,7 +638,7 @@ stacked.offsets <- function(x, stacked = TRUE,
   )
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(stacked.offsets) <- function() {
   context("stacked.offsets")
 
@@ -674,7 +674,7 @@ stacked.offsets <- function(x, stacked = TRUE,
 }
 
 ### .cut.ticks - pretty tick marks for cut axes
-##' @importFrom utils head
+#' @importFrom utils head
 .cut.ticks <- function(start.ranges,
                        end.ranges,
                        offsets,
@@ -725,7 +725,7 @@ stacked.offsets <- function(x, stacked = TRUE,
   )
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(.cut.ticks) <- function() {
   context(".cut.ticks")
 

--- a/hyperSpec/R/plotspc.R
+++ b/hyperSpec/R/plotspc.R
@@ -711,18 +711,18 @@ stacked.offsets <- function(x, stacked = TRUE,
   start.ranges <- start.ranges - offsets
   end.ranges <- end.ranges - offsets
 
-  delta <- start.ranges [-1] - head(end.ranges, -1)
+  delta <- start.ranges[-1] - head(end.ranges, -1)
 
   cutmarks <- head(end.ranges, -1) + delta / 2
 
   ## make sure that the ticks are not too close
   for (i in seq_along(delta)) {
-    keep <- at[[i]] < end.ranges [i] + delta [i] / 4
-    at[[i]] <- at    [[i]][keep]
+    keep <- at[[i]] < end.ranges[i] + delta [i] / 4
+        at[[i]] <-     at[[i]][keep]
     labels[[i]] <- labels[[i]][keep]
 
-    keep <- at[[i + 1]] > start.ranges [i + 1] - delta [i] / 4
-    at[[i + 1]] <- at    [[i + 1]][keep]
+    keep <- at[[i + 1]] > start.ranges[i + 1] - delta[i] / 4
+        at[[i + 1]] <-     at[[i + 1]][keep]
     labels[[i + 1]] <- labels[[i + 1]][keep]
   }
 

--- a/hyperSpec/R/plotspc.R
+++ b/hyperSpec/R/plotspc.R
@@ -125,36 +125,40 @@
 #' @export
 #' @examples
 #'
-#' plotspc (flu)
+#' plotspc(flu)
 #'
 #' ## artificial example to show wavelength axis cutting
-#' plotspc (faux_cell [sample (nrow (faux_cell), 50)],
-#'          wl.range = list (600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
-#'          xoffset = c (0, 300, 450))
+#' plotspc(faux_cell [sample(nrow(faux_cell), 50)],
+#'   wl.range = list(600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
+#'   xoffset = c(0, 300, 450)
+#' )
 #'
-#' plotspc (faux_cell [sample (nrow (faux_cell), 50)],
-#'          wl.range = list (600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
-#'          xoffset = c (300, 450))
+#' plotspc(faux_cell [sample(nrow(faux_cell), 50)],
+#'   wl.range = list(600 ~ 650, 1000 ~ 1100, 1600 ~ 1700),
+#'   xoffset = c(300, 450)
+#' )
 #'
 #' ## some journals publish Raman spectra backwards
-#' plotspc (faux_cell [sample (nrow (faux_cell), 50)], wl.reverse = TRUE)
+#' plotspc(faux_cell [sample(nrow(faux_cell), 50)], wl.reverse = TRUE)
 #'
-#' plotspc (laser[(0:4)*20+1,,], stacked = TRUE)
+#' plotspc(laser[(0:4) * 20 + 1, , ], stacked = TRUE)
 #'
-#' plotspc (laser, func = mean_pm_sd,
-#'          col = c(NA, "red", "black"), lines.args = list (lwd = 2),
-#'          fill = c (1, NA, 1),
-#'          fill.col = "yellow", border = "blue",
-#'          polygon.args = list (lty = 2, lwd = 4),
-#'          title.args = list (xlab = expression (lambda[emission] / nm),
-#'                             y = list(line = 3.4),
-#'                             col.lab = "darkgreen"),
-#'          axis.args = list (x = list (col = "magenta"), y = list (las = 1))
-#'         )
+#' plotspc(laser,
+#'   func = mean_pm_sd,
+#'   col = c(NA, "red", "black"), lines.args = list(lwd = 2),
+#'   fill = c(1, NA, 1),
+#'   fill.col = "yellow", border = "blue",
+#'   polygon.args = list(lty = 2, lwd = 4),
+#'   title.args = list(
+#'     xlab = expression(lambda[emission] / nm),
+#'     y = list(line = 3.4),
+#'     col.lab = "darkgreen"
+#'   ),
+#'   axis.args = list(x = list(col = "magenta"), y = list(las = 1))
+#' )
 #'
-#' mean.pm.sd <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
-#' plot (mean.pm.sd, col = matlab.palette (3), fill = ".aggregate", stacked = ".aggregate")
-#'
+#' mean.pm.sd <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
+#' plot(mean.pm.sd, col = matlab.palette(3), fill = ".aggregate", stacked = ".aggregate")
 #' @importFrom utils modifyList relist head tail
 #' @importFrom grDevices rgb col2rgb
 plotspc <- function(object,
@@ -565,20 +569,24 @@ plotspc <- function(object,
 #' @export
 #' @examples
 #'
-#' mean.pm.sd <- aggregate (faux_cell, faux_cell$region, mean_pm_sd)
+#' mean.pm.sd <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
 #'
-#' offset <- stacked.offsets (mean.pm.sd, ".aggregate")
-#' plot (mean.pm.sd, fill.col = matlab.palette (3), fill = ".aggregate",
-#'       stacked = ".aggregate")
+#' offset <- stacked.offsets(mean.pm.sd, ".aggregate")
+#' plot(mean.pm.sd,
+#'   fill.col = matlab.palette(3), fill = ".aggregate",
+#'   stacked = ".aggregate"
+#' )
 #'
-#' plot (aggregate (faux_cell, faux_cell$region, mean), yoffset = offset$offsets,
-#'       lines.args = list (lty = 2, lwd = 2), add = TRUE)
+#' plot(aggregate(faux_cell, faux_cell$region, mean),
+#'   yoffset = offset$offsets,
+#'   lines.args = list(lty = 2, lwd = 2), add = TRUE
+#' )
 #'
-#' barb <- do.call (collapse, barbiturates [1:3])
-#' plot (barb, lines.args = list (type = "h"), stacked = TRUE,
-#'       stacked.args = list (add.factor = .2))
-#'
-#'
+#' barb <- do.call(collapse, barbiturates [1:3])
+#' plot(barb,
+#'   lines.args = list(type = "h"), stacked = TRUE,
+#'   stacked.args = list(add.factor = .2)
+#' )
 stacked.offsets <- function(x, stacked = TRUE,
                             min.zero = FALSE, add.factor = 0.05, add.sum = 0,
                             # tight = FALSE, TODO

--- a/hyperSpec/R/plotspc.R
+++ b/hyperSpec/R/plotspc.R
@@ -232,7 +232,7 @@ plotspc <- function(object,
   ## x are the actual x coordinates
   x <- wavelengths
   for (i in seq_along(x)) {
-    x [[i]] <- x [[i]] - xoffset[i]
+    x[[i]] <- x[[i]] - xoffset[i]
   }
 
   ## prepare spectra ................................................................................
@@ -450,7 +450,7 @@ plotspc <- function(object,
     ## groupings for upper and lower bound of the bands
     if (!is.null(fill)) {
       if (is.character(fill) && length(fill) == 1) {
-        fill <- unlist(object [[, fill]])
+        fill <- unlist(object[[, fill]])
       } else if (isTRUE(fill)) {
         fill <- seq_len(nrow(spc) / 2)
         if (nrow(spc) %% 2 == 1) { # odd number of spectra
@@ -490,7 +490,7 @@ plotspc <- function(object,
 
       border <- rep(border, length.out = length(groups))
 
-      polygon.args$x <- c(x [[i]], rev(x [[i]]))
+      polygon.args$x <- c(x[[i]], rev(x[[i]]))
 
       for (j in seq_along(groups)) {
         tmp <- which(fill == groups [j])
@@ -598,7 +598,7 @@ stacked.offsets <- function(x, stacked = TRUE,
   }
 
   if (is.character(stacked)) {
-    stacked <- unlist(x [[, stacked]])
+    stacked <- unlist(x[[, stacked]])
   } else if (isTRUE(stacked)) {
     stacked <- row.seq(x)
   }
@@ -654,7 +654,7 @@ stacked.offsets <- function(x, stacked = TRUE,
     spc <- do.call(collapse, barbiturates [1:3])
     ofs <- stacked.offsets(spc)
     spc <- spc + ofs$offsets
-    rngs <- apply(spc [[]], 1, range, na.rm = TRUE)
+    rngs <- apply(spc[[]], 1, range, na.rm = TRUE)
 
     expect_equal(as.numeric(rngs), sort(rngs))
   })
@@ -671,7 +671,7 @@ stacked.offsets <- function(x, stacked = TRUE,
     ofs <- stacked.offsets(flu, min.zero = TRUE, add.factor = 0)
     expect_equal(
       ofs$offsets,
-      c(0, cumsum(apply(flu [[-nrow(flu)]], 1, max)))
+      c(0, cumsum(apply(flu[[-nrow(flu)]], 1, max)))
     )
   })
 }
@@ -717,13 +717,13 @@ stacked.offsets <- function(x, stacked = TRUE,
 
   ## make sure that the ticks are not too close
   for (i in seq_along(delta)) {
-    keep <- at [[i]] < end.ranges [i] + delta [i] / 4
-    at [[i]] <- at     [[i]][keep]
-    labels [[i]] <- labels [[i]][keep]
+    keep <- at[[i]] < end.ranges [i] + delta [i] / 4
+    at[[i]] <- at    [[i]][keep]
+    labels[[i]] <- labels[[i]][keep]
 
-    keep <- at [[i + 1]] > start.ranges [i + 1] - delta [i] / 4
-    at [[i + 1]] <- at     [[i + 1]][keep]
-    labels [[i + 1]] <- labels [[i + 1]][keep]
+    keep <- at[[i + 1]] > start.ranges [i + 1] - delta [i] / 4
+    at[[i + 1]] <- at    [[i + 1]][keep]
+    labels[[i + 1]] <- labels[[i + 1]][keep]
   }
 
   list(

--- a/hyperSpec/R/plotvoronoi.R
+++ b/hyperSpec/R/plotvoronoi.R
@@ -4,19 +4,19 @@
 ###
 ###  plots intensity or extra data column over 2 extra data columns
 
-##' @param use.tripack Whether package tripack should be used for calculating
-##'   the voronoi polygons. If \code{FALSE}, package deldir is used instead.
-##'   See details.
-##' @param mix For Voronoi plots using package tripack, I experienced errors if
-##'   the data was spatially ordered. Randomly rearrangig the rows of the
-##'   hyperSpec object circumvents this problem.
-##' @rdname levelplot
-##' @include levelplot.R
-##' @export
-##' @seealso \code{\link[latticeExtra]{panel.voronoi}}
-##' @importFrom latticeExtra panel.voronoi
-##' @importFrom lattice prepanel.default.levelplot
-##' @importFrom utils modifyList
+#' @param use.tripack Whether package tripack should be used for calculating
+#'   the voronoi polygons. If \code{FALSE}, package deldir is used instead.
+#'   See details.
+#' @param mix For Voronoi plots using package tripack, I experienced errors if
+#'   the data was spatially ordered. Randomly rearrangig the rows of the
+#'   hyperSpec object circumvents this problem.
+#' @rdname levelplot
+#' @include levelplot.R
+#' @export
+#' @seealso \code{\link[latticeExtra]{panel.voronoi}}
+#' @importFrom latticeExtra panel.voronoi
+#' @importFrom lattice prepanel.default.levelplot
+#' @importFrom utils modifyList
 plotvoronoi <- function(object, model = spc ~ x * y,
                         use.tripack = FALSE, mix = FALSE, ...) {
   if (!requireNamespace("latticeExtra")) {

--- a/hyperSpec/R/qplot.R
+++ b/hyperSpec/R/qplot.R
@@ -1,36 +1,36 @@
-##' Spectra plotting with ggplot2
-##'
-##' These functions are still experimental and may change in future.
-##' @title Spectra plotting with ggplot2
-##' @param x hyperSpec object
-##' @param wl.range wavelength ranges to plot
-##' @param ... handed to [ggplot2::geom_line()]
-##' @param mapping see  [ggplot2::geom_line()]
-##' @param spc.nmax maximum number of spectra to plot
-##' @param map.lineonly if `TRUE`, `mapping` will be handed to
-##' [ggplot2::geom_line()] instead of [ggplot2::ggplot()].
-##' @param debuglevel if > 0, additional debug output is produced
-##' @return a [ggplot2::ggplot()] object
-##' @author Claudia Beleites
-##' @export
-##' @md
-##' @seealso [plotspc()]
-##'
-##' [ggplot2::ggplot()], [ggplot2::geom_line()]
-##' @examples
-##'
-##'   qplotspc (faux_cell)
-##'
-##'   qplotspc (paracetamol, c (2800 ~ max, min ~ 1800)) +
-##'      scale_x_reverse (breaks = seq (0, 3200, 400))
-##'
-##'   qplotspc (aggregate (faux_cell, faux_cell$region, mean),
-##'             mapping = aes (x = .wavelength, y = spc, colour = region)) +
-##'     facet_grid (region ~ .)
-##'
-##'   qplotspc (aggregate (faux_cell, faux_cell$region, mean_pm_sd),
-##'             mapping = aes (x = .wavelength, y = spc, colour = region, group = .rownames)) +
-##'     facet_grid (region ~ .)
+#' Spectra plotting with ggplot2
+#'
+#' These functions are still experimental and may change in future.
+#' @title Spectra plotting with ggplot2
+#' @param x hyperSpec object
+#' @param wl.range wavelength ranges to plot
+#' @param ... handed to [ggplot2::geom_line()]
+#' @param mapping see  [ggplot2::geom_line()]
+#' @param spc.nmax maximum number of spectra to plot
+#' @param map.lineonly if `TRUE`, `mapping` will be handed to
+#' [ggplot2::geom_line()] instead of [ggplot2::ggplot()].
+#' @param debuglevel if > 0, additional debug output is produced
+#' @return a [ggplot2::ggplot()] object
+#' @author Claudia Beleites
+#' @export
+#' @md
+#' @seealso [plotspc()]
+#'
+#' [ggplot2::ggplot()], [ggplot2::geom_line()]
+#' @examples
+#'
+#'   qplotspc (faux_cell)
+#'
+#'   qplotspc (paracetamol, c (2800 ~ max, min ~ 1800)) +
+#'      scale_x_reverse (breaks = seq (0, 3200, 400))
+#'
+#'   qplotspc (aggregate (faux_cell, faux_cell$region, mean),
+#'             mapping = aes (x = .wavelength, y = spc, colour = region)) +
+#'     facet_grid (region ~ .)
+#'
+#'   qplotspc (aggregate (faux_cell, faux_cell$region, mean_pm_sd),
+#'             mapping = aes (x = .wavelength, y = spc, colour = region, group = .rownames)) +
+#'     facet_grid (region ~ .)
 qplotspc <- function(x,
                      wl.range = TRUE, ...,
                      mapping = aes_string(x = ".wavelength", y = "spc",
@@ -91,33 +91,33 @@ qplotspc <- function(x,
 }
 
 
-##' Spectra plotting with ggplot2
-##'
-##' These functions are still experimental and may change in future.
-##'
-##' Note that `qplotmap()` will currently produce the wrong scales if x or y are
-##' discrete.
-##'
-##' @title Spectra plotting with ggplot2
-##' @param object  hyperSpec object
-##' @param mapping see  [ggplot2::geom_tile()]
-##' @param ... handed to [ggplot2::geom_tile()]
-##' @param func function to summarize the wavelengths
-##' @param func.args arguments to `func`
-##' @param map.tileonly if `TRUE`, `mapping` will be handed to
-##'   [ggplot2::geom_tile()] instead of [ggplot2::ggplot()].
-##' @return a [ggplot2::ggplot()] object
-##' @export
-##' @md
-##' @author Claudia Beleites
-##' @seealso [plotmap()]
-##'
-##'   [ggplot2::ggplot()], [ggplot2::geom_tile()]
-##' @examples
-##' qplotmap (faux_cell)
-##' qplotmap (faux_cell) + scale_fill_gradientn (colours = alois.palette ())
-##' @importFrom utils tail
-##' @importFrom rlang as_label
+#' Spectra plotting with ggplot2
+#'
+#' These functions are still experimental and may change in future.
+#'
+#' Note that `qplotmap()` will currently produce the wrong scales if x or y are
+#' discrete.
+#'
+#' @title Spectra plotting with ggplot2
+#' @param object  hyperSpec object
+#' @param mapping see  [ggplot2::geom_tile()]
+#' @param ... handed to [ggplot2::geom_tile()]
+#' @param func function to summarize the wavelengths
+#' @param func.args arguments to `func`
+#' @param map.tileonly if `TRUE`, `mapping` will be handed to
+#'   [ggplot2::geom_tile()] instead of [ggplot2::ggplot()].
+#' @return a [ggplot2::ggplot()] object
+#' @export
+#' @md
+#' @author Claudia Beleites
+#' @seealso [plotmap()]
+#'
+#'   [ggplot2::ggplot()], [ggplot2::geom_tile()]
+#' @examples
+#' qplotmap (faux_cell)
+#' qplotmap (faux_cell) + scale_fill_gradientn (colours = alois.palette ())
+#' @importFrom utils tail
+#' @importFrom rlang as_label
 qplotmap <- function(object,
                      mapping = aes_string(x = "x", y = "y", fill = "spc"),
                      ...,
@@ -171,28 +171,28 @@ qplotmap <- function(object,
 }
 
 
-##' Spectra plotting with ggplot2
-##'
-##' These functions are still experimental and may change in future.
-##' @title Spectra plotting with ggplot2
-##' @param object hyperSpec object
-##' @param mapping see  [ggplot2::geom_point()]
-##' @param ... handed to [ggplot2::geom_point()]
-##' @export
-##' @param func function to summarize the wavelengths, if `NULL`, only the first
-##'   wavelength is used
-##' @param func.args arguments to `func`
-##' @param map.pointonly if `TRUE`, `mapping` will be handed to
-##'   [ggplot2::geom_point()] instead of [ggplot2::ggplot()].
-##' @return a [ggplot2::ggplot()] object
-##' @author Claudia Beleites
-##' @md
-##' @seealso [plotc()]
-##'
-##'   [ggplot2::ggplot()], [ggplot2::geom_point()]
-##' @examples
-##' qplotc (flu)
-##' qplotc (flu) + geom_smooth (method = "lm")
+#' Spectra plotting with ggplot2
+#'
+#' These functions are still experimental and may change in future.
+#' @title Spectra plotting with ggplot2
+#' @param object hyperSpec object
+#' @param mapping see  [ggplot2::geom_point()]
+#' @param ... handed to [ggplot2::geom_point()]
+#' @export
+#' @param func function to summarize the wavelengths, if `NULL`, only the first
+#'   wavelength is used
+#' @param func.args arguments to `func`
+#' @param map.pointonly if `TRUE`, `mapping` will be handed to
+#'   [ggplot2::geom_point()] instead of [ggplot2::ggplot()].
+#' @return a [ggplot2::ggplot()] object
+#' @author Claudia Beleites
+#' @md
+#' @seealso [plotc()]
+#'
+#'   [ggplot2::ggplot()], [ggplot2::geom_point()]
+#' @examples
+#' qplotc (flu)
+#' qplotc (flu) + geom_smooth (method = "lm")
 qplotc <- function(object, mapping = aes_string(x = "c", y = "spc"), ...,
                    func = NULL, func.args = list(),
                    map.pointonly = FALSE) {

--- a/hyperSpec/R/qplot.R
+++ b/hyperSpec/R/qplot.R
@@ -19,22 +19,26 @@
 #' [ggplot2::ggplot()], [ggplot2::geom_line()]
 #' @examples
 #'
-#'   qplotspc (faux_cell)
+#' qplotspc(faux_cell)
 #'
-#'   qplotspc (paracetamol, c (2800 ~ max, min ~ 1800)) +
-#'      scale_x_reverse (breaks = seq (0, 3200, 400))
+#' qplotspc(paracetamol, c(2800 ~ max, min ~ 1800)) +
+#'   scale_x_reverse(breaks = seq(0, 3200, 400))
 #'
-#'   qplotspc (aggregate (faux_cell, faux_cell$region, mean),
-#'             mapping = aes (x = .wavelength, y = spc, colour = region)) +
-#'     facet_grid (region ~ .)
+#' qplotspc(aggregate(faux_cell, faux_cell$region, mean),
+#'   mapping = aes(x = .wavelength, y = spc, colour = region)
+#' ) +
+#'   facet_grid(region ~ .)
 #'
-#'   qplotspc (aggregate (faux_cell, faux_cell$region, mean_pm_sd),
-#'             mapping = aes (x = .wavelength, y = spc, colour = region, group = .rownames)) +
-#'     facet_grid (region ~ .)
+#' qplotspc(aggregate(faux_cell, faux_cell$region, mean_pm_sd),
+#'   mapping = aes(x = .wavelength, y = spc, colour = region, group = .rownames)
+#' ) +
+#'   facet_grid(region ~ .)
 qplotspc <- function(x,
                      wl.range = TRUE, ...,
-                     mapping = aes_string(x = ".wavelength", y = "spc",
-                                          group = ".rownames"),
+                     mapping = aes_string(
+                       x = ".wavelength", y = "spc",
+                       group = ".rownames"
+                     ),
                      spc.nmax = hy.getOption("ggplot.spc.nmax"),
                      map.lineonly = FALSE,
                      debuglevel = hy.getOption("debuglevel")) {
@@ -44,8 +48,10 @@ qplotspc <- function(x,
   ## cut away everything that isn't asked for before transforming to data.frame
   if (nrow(x) > spc.nmax) {
     if (debuglevel >= 1L) {
-      message("Number of spectra exceeds spc.nmax. Only the first ", spc.nmax,
-              " are plotted.")
+      message(
+        "Number of spectra exceeds spc.nmax. Only the first ", spc.nmax,
+        " are plotted."
+      )
     }
     x <- x[seq_len(spc.nmax)]
   }
@@ -55,7 +61,7 @@ qplotspc <- function(x,
   x <- x[, , unlist(wl.range), wl.index = TRUE]
 
   df <- as.long.df(x, rownames = TRUE, na.rm = FALSE) # with na.rm trouble with
-                                                      # wl.range
+  # wl.range
 
   ## ranges go into facets
   if (length(wl.range) > 1L) {
@@ -114,8 +120,8 @@ qplotspc <- function(x,
 #'
 #'   [ggplot2::ggplot()], [ggplot2::geom_tile()]
 #' @examples
-#' qplotmap (faux_cell)
-#' qplotmap (faux_cell) + scale_fill_gradientn (colours = alois.palette ())
+#' qplotmap(faux_cell)
+#' qplotmap(faux_cell) + scale_fill_gradientn(colours = alois.palette())
 #' @importFrom utils tail
 #' @importFrom rlang as_label
 qplotmap <- function(object,
@@ -191,8 +197,8 @@ qplotmap <- function(object,
 #'
 #'   [ggplot2::ggplot()], [ggplot2::geom_point()]
 #' @examples
-#' qplotc (flu)
-#' qplotc (flu) + geom_smooth (method = "lm")
+#' qplotc(flu)
+#' qplotc(flu) + geom_smooth(method = "lm")
 qplotc <- function(object, mapping = aes_string(x = "c", y = "spc"), ...,
                    func = NULL, func.args = list(),
                    map.pointonly = FALSE) {
@@ -219,8 +225,9 @@ qplotc <- function(object, mapping = aes_string(x = "c", y = "spc"), ...,
 
   ## produce fancy y label
   ylabel <- labels(object, as_label(mapping$y))
-  if (is.null(ylabel))
+  if (is.null(ylabel)) {
     ylabel <- as_label(mapping$y)
+  }
 
   if (!is.null(func)) {
     ylabel <- make.fn.expr(substitute(func), c(ylabel, func.args))
@@ -232,11 +239,11 @@ qplotc <- function(object, mapping = aes_string(x = "c", y = "spc"), ...,
 
   ## if plots should be grouped, faceted, etc. by wavelength, it is better to
   ## have a factor
-  if (any(grepl("[.]wavelength",
-                sapply(mapping[!names(mapping) %in% c("x", "y")], as_label)
-                )
-          )
-      ) {
+  if (any(grepl(
+    "[.]wavelength",
+    sapply(mapping[!names(mapping) %in% c("x", "y")], as_label)
+  ))
+  ) {
     df$.wavelength <- as.factor(df$.wavelength)
   }
 
@@ -249,8 +256,9 @@ qplotc <- function(object, mapping = aes_string(x = "c", y = "spc"), ...,
   }
 
   xlabel <- labels(object)[[as_label(mapping$x)]]
-  if (is.null(xlabel))
+  if (is.null(xlabel)) {
     xlabel <- as_label(mapping$x)
+  }
 
   p + ylab(ylabel) +
     xlab(xlabel)

--- a/hyperSpec/R/qplotmixmap.R
+++ b/hyperSpec/R/qplotmixmap.R
@@ -1,26 +1,26 @@
-##' map plot with colour overlay
-##'
-##'
-##' @title qplotmap with colour mixing for multivariate overlay
-##' @param object hyperSpec object
-##' @param ... handed over to [hyperSpec::qmixlegend()] and
-##'   [hyperSpec::qmixtile()]
-##' @return invisible list with ggplot2 objects map and legend
-##' @seealso [hyperSpec::qmixtile()]
-##' @author Claudia Beleites
-##' @importFrom grid pushViewport viewport popViewport grid.layout unit
-##' @import ggplot2
-##' @export
-##' @md
-##' @examples
-##' faux_cell <- faux_cell - spc.fit.poly.below (faux_cell)
-##' faux_cell <- sweep (faux_cell, 1, apply (faux_cell, 1, mean), "/")
-##' faux_cell <- sweep (faux_cell, 2, apply (faux_cell, 2, quantile, 0.05), "-")
-##'
-##' qplotmixmap (faux_cell [,,c (940, 1002, 1440)],
-##'              purecol = c (colg = "red", Phe = "green", Lipid = "blue"))
-##'
-##' @importFrom lazyeval f_rhs
+#' map plot with colour overlay
+#'
+#'
+#' @title qplotmap with colour mixing for multivariate overlay
+#' @param object hyperSpec object
+#' @param ... handed over to [hyperSpec::qmixlegend()] and
+#'   [hyperSpec::qmixtile()]
+#' @return invisible list with ggplot2 objects map and legend
+#' @seealso [hyperSpec::qmixtile()]
+#' @author Claudia Beleites
+#' @importFrom grid pushViewport viewport popViewport grid.layout unit
+#' @import ggplot2
+#' @export
+#' @md
+#' @examples
+#' faux_cell <- faux_cell - spc.fit.poly.below (faux_cell)
+#' faux_cell <- sweep (faux_cell, 1, apply (faux_cell, 1, mean), "/")
+#' faux_cell <- sweep (faux_cell, 2, apply (faux_cell, 2, quantile, 0.05), "-")
+#'
+#' qplotmixmap (faux_cell [,,c (940, 1002, 1440)],
+#'              purecol = c (colg = "red", Phe = "green", Lipid = "blue"))
+#'
+#' @importFrom lazyeval f_rhs
 qplotmixmap <- function(object, ...) {
   p <- qmixtile(object@data, ...) +
     coord_equal()
@@ -44,17 +44,17 @@ qplotmixmap <- function(object, ...) {
   invisible(list(map = p, legend = l))
 }
 
-##' Plot multivariate data into colour channels
-##'
-##' plot graph with legend right of it
-##'
-##' @param p plot object
-##' @param l legend object
-##' @param legend.width,legend.unit size of legend part
-##' @return invisible `NULL`
-##' @author Claudia Beleites
-##' @rdname qplotmix
-##' @export
+#' Plot multivariate data into colour channels
+#'
+#' plot graph with legend right of it
+#'
+#' @param p plot object
+#' @param l legend object
+#' @param legend.width,legend.unit size of legend part
+#' @return invisible `NULL`
+#' @author Claudia Beleites
+#' @rdname qplotmix
+#' @export
 legendright <- function(p, l, legend.width = 8, legend.unit = "lines") {
   plot.new()
   pushViewport(viewport(layout = grid.layout(1, 2,
@@ -65,18 +65,18 @@ legendright <- function(p, l, legend.width = 8, legend.unit = "lines") {
   popViewport()
 }
 
-##' plot multivariate data into colour channels using [ggplot2::geom_tile()]
-##' @rdname qplotmix
-##' @param object matrix to be plotted with mixed colour channels
-##' @param purecol pure component colours, names determine legend labels
-##' @param mapping see [ggplot2::geom_tile()]
-##' @param ... `qmixtile`: handed to [colmix.rgb()]
-##'
-##'   `qmixlegend()` and `colmix.rgb()` hand further arguments to the
-##'   `normalize` function
-##' @param map.tileonly if `TRUE`, `mapping` will be handed to
-##'   [ggplot2::geom_tile()] instead of [ggplot2::ggplot()].
-##'
+#' plot multivariate data into colour channels using [ggplot2::geom_tile()]
+#' @rdname qplotmix
+#' @param object matrix to be plotted with mixed colour channels
+#' @param purecol pure component colours, names determine legend labels
+#' @param mapping see [ggplot2::geom_tile()]
+#' @param ... `qmixtile`: handed to [colmix.rgb()]
+#'
+#'   `qmixlegend()` and `colmix.rgb()` hand further arguments to the
+#'   `normalize` function
+#' @param map.tileonly if `TRUE`, `mapping` will be handed to
+#'   [ggplot2::geom_tile()] instead of [ggplot2::ggplot()].
+#'
 qmixtile <- function(object,
                      purecol = stop("pure component colors needed."),
                      mapping = aes_string(x = "x", y = "y", fill = "spc"),
@@ -98,16 +98,16 @@ qmixtile <- function(object,
   p + scale_fill_identity() + theme(legend.position = "none")
 }
 
-##' `normalize.colrange()` normalizes the range of each column to [0, 1]
-##' @rdname qplotmix
-##' @export
-##'
-##' @param na.rm see [base::min()]
-##' @param legend should a legend be produced instead of normalized values?
-##' @param n of colours to produce in legend
-##' @return list with components `ymin`, `max` and `fill` to specify value and
-##'   fill colour value (still numeric!) for the legend, otherwise the
-##'   normalized values
+#' `normalize.colrange()` normalizes the range of each column to [0, 1]
+#' @rdname qplotmix
+#' @export
+#'
+#' @param na.rm see [base::min()]
+#' @param legend should a legend be produced instead of normalized values?
+#' @param n of colours to produce in legend
+#' @return list with components `ymin`, `max` and `fill` to specify value and
+#'   fill colour value (still numeric!) for the legend, otherwise the
+#'   normalized values
 normalize.colrange <- function(x, na.rm = TRUE, legend = FALSE, n = 100, ...) {
   ## legend
   if (legend) {
@@ -126,10 +126,10 @@ normalize.colrange <- function(x, na.rm = TRUE, legend = FALSE, n = 100, ...) {
   }
 }
 
-##' `normalize.range()` normalizes the range of all columns to [0, 1]
-##' @rdname qplotmix
-##' @export
-##'
+#' `normalize.range()` normalizes the range of all columns to [0, 1]
+#' @rdname qplotmix
+#' @export
+#'
 normalize.range <- function(x, na.rm = TRUE, legend = FALSE, n = 100, ...) {
   if (legend) {
     y <- matrix(seq(min(x), max(x), length.out = n), nrow = n, ncol = ncol(x))
@@ -146,10 +146,10 @@ normalize.range <- function(x, na.rm = TRUE, legend = FALSE, n = 100, ...) {
   }
 }
 
-##' `normalize.null()` does not touch the values
-##' @rdname qplotmix
-##' @export
-##'
+#' `normalize.null()` does not touch the values
+#' @rdname qplotmix
+#' @export
+#'
 normalize.null <- function(x, na.rm = TRUE, legend = FALSE, n = 100, ...) {
   if (legend) {
     y <- apply(x, 2, function(x) seq(min(x), max(x), length.out = n))
@@ -163,13 +163,13 @@ normalize.null <- function(x, na.rm = TRUE, legend = FALSE, n = 100, ...) {
     x
   }
 }
-##' `normalize.minmax()` normalizes the range of each column j to [min_j, max_j]
-##' @rdname qplotmix
-##' @export
-##' @param min numeric with value corresponding to "lowest" colour for each
-##'   column
-##' @param max numeric with value corresponding to "hightest" colour for each
-##'   column
+#' `normalize.minmax()` normalizes the range of each column j to [min_j, max_j]
+#' @rdname qplotmix
+#' @export
+#' @param min numeric with value corresponding to "lowest" colour for each
+#'   column
+#' @param max numeric with value corresponding to "hightest" colour for each
+#'   column
 normalize.minmax <- function(x, min = 0, max = 1, legend = FALSE, n = 100,
                              ...) {
   if (legend) {
@@ -196,14 +196,14 @@ normalize.minmax <- function(x, min = 0, max = 1, legend = FALSE, n = 100,
   }
 }
 
-##' legends for mixed colour plots
-##' @rdname qplotmix
-##' @param dx width of label bar
-##' @param ny number of colours in legend
-##' @param labels component names
-##' @return ggplot object with legend
-##' @author Claudia Beleites
-##' @export
+#' legends for mixed colour plots
+#' @rdname qplotmix
+#' @param dx width of label bar
+#' @param ny number of colours in legend
+#' @param labels component names
+#' @return ggplot object with legend
+#' @author Claudia Beleites
+#' @export
 qmixlegend <- function(x, purecol, dx = 0.33, ny = 100, labels = names(purecol),
                        normalize = normalize.colrange, ...) {
   if (!is.matrix(x)) {
@@ -256,17 +256,17 @@ qmixlegend <- function(x, purecol, dx = 0.33, ny = 100, labels = names(purecol),
   l
 }
 
-##' @rdname qplotmix
-##' @title multi channel colour mixing
-##' @param x matrix with component intensities in columns
-##' @param against value to mix against
-##'                (for `sub = TRUE` only, 1 = white, 0 = black)
-##' @param sub subtractive color mixing?
-##' @param normalize function to normalize the values.
-##' @return character with colours
-##' @author Claudia Beleites
-##' @export
-##' @importFrom grDevices col2rgb rgb
+#' @rdname qplotmix
+#' @title multi channel colour mixing
+#' @param x matrix with component intensities in columns
+#' @param against value to mix against
+#'                (for `sub = TRUE` only, 1 = white, 0 = black)
+#' @param sub subtractive color mixing?
+#' @param normalize function to normalize the values.
+#' @return character with colours
+#' @author Claudia Beleites
+#' @export
+#' @importFrom grDevices col2rgb rgb
 colmix.rgb <- function(x, purecol, against = 1, sub = TRUE,
                        normalize = normalize.colrange, ...) {
   if (!is.null(normalize)) {

--- a/hyperSpec/R/qplotmixmap.R
+++ b/hyperSpec/R/qplotmixmap.R
@@ -13,25 +13,27 @@
 #' @export
 #' @md
 #' @examples
-#' faux_cell <- faux_cell - spc.fit.poly.below (faux_cell)
-#' faux_cell <- sweep (faux_cell, 1, apply (faux_cell, 1, mean), "/")
-#' faux_cell <- sweep (faux_cell, 2, apply (faux_cell, 2, quantile, 0.05), "-")
+#' faux_cell <- faux_cell - spc.fit.poly.below(faux_cell)
+#' faux_cell <- sweep(faux_cell, 1, apply(faux_cell, 1, mean), "/")
+#' faux_cell <- sweep(faux_cell, 2, apply(faux_cell, 2, quantile, 0.05), "-")
 #'
-#' qplotmixmap (faux_cell [,,c (940, 1002, 1440)],
-#'              purecol = c (colg = "red", Phe = "green", Lipid = "blue"))
-#'
+#' qplotmixmap(faux_cell [, , c(940, 1002, 1440)],
+#'   purecol = c(colg = "red", Phe = "green", Lipid = "blue")
+#' )
 #' @importFrom lazyeval f_rhs
 qplotmixmap <- function(object, ...) {
   p <- qmixtile(object@data, ...) +
     coord_equal()
 
   xlabel <- labels(object)[[as_label(p$mapping$x)]]
-  if (is.null(xlabel))
+  if (is.null(xlabel)) {
     xlabel <- as_label(p$mapping$x)
+  }
 
   ylabel <- labels(object)[[as_label(p$mapping$y)]]
-  if (is.null(ylabel))
+  if (is.null(ylabel)) {
     ylabel <- as_label(p$mapping$y)
+  }
 
   p <- p +
     xlab(xlabel) +
@@ -225,9 +227,9 @@ qmixlegend <- function(x, purecol, dx = 0.33, ny = 100, labels = names(purecol),
 
   df <- data.frame()
   for (column in seq_along(purecol)) {
-
     tmp <- colmix.rgb(l$fill[, column, drop = FALSE], purecol[column],
-                      normalize = NULL, ...)
+      normalize = NULL, ...
+    )
 
     df <- rbind(df, data.frame(
       column = labels[column],
@@ -249,8 +251,10 @@ qmixlegend <- function(x, purecol, dx = 0.33, ny = 100, labels = names(purecol),
     fill = "col", colour = "col"
   ))
 
-  l <- l + theme(plot.margin = unit(c(0.5, 0, 0, 0), "lines"),
-                 legend.position = "none") +
+  l <- l + theme(
+    plot.margin = unit(c(0.5, 0, 0, 0), "lines"),
+    legend.position = "none"
+  ) +
     scale_fill_identity() + scale_colour_identity()
 
   l

--- a/hyperSpec/R/quantile.R
+++ b/hyperSpec/R/quantile.R
@@ -31,5 +31,5 @@
 #' @export
 #' @examples
 #'
-#' plot (quantile (faux_cell))
+#' plot(quantile(faux_cell))
 setMethod("quantile", signature = signature(x = "hyperSpec"), .quantile)

--- a/hyperSpec/R/quantile.R
+++ b/hyperSpec/R/quantile.R
@@ -20,16 +20,16 @@
   x
 }
 
-##' @rdname mean_sd
-##' @return For hyperSpec object, \code{quantile} returns a hyperSpec object containing the
-##' respective quantile spectra.
-##' @param probs the quantiles, see \code{\link[stats]{quantile}}
-##' @param names \code{"pretty"} results in percentages (like \code{\link[stats]{quantile}}'s
-##' \code{names = TRUE}), \code{"num"} results in the row names being \code{as.character (probs)}
-##' (good for ggplot2 getting the order of the quantiles right). Otherwise, no names are assigned.
-##' @seealso  \code{\link[stats]{quantile}}
-##' @export
-##' @examples
-##'
-##' plot (quantile (faux_cell))
+#' @rdname mean_sd
+#' @return For hyperSpec object, \code{quantile} returns a hyperSpec object containing the
+#' respective quantile spectra.
+#' @param probs the quantiles, see \code{\link[stats]{quantile}}
+#' @param names \code{"pretty"} results in percentages (like \code{\link[stats]{quantile}}'s
+#' \code{names = TRUE}), \code{"num"} results in the row names being \code{as.character (probs)}
+#' (good for ggplot2 getting the order of the quantiles right). Otherwise, no names are assigned.
+#' @seealso  \code{\link[stats]{quantile}}
+#' @export
+#' @examples
+#'
+#' plot (quantile (faux_cell))
 setMethod("quantile", signature = signature(x = "hyperSpec"), .quantile)

--- a/hyperSpec/R/rbind.fill.R
+++ b/hyperSpec/R/rbind.fill.R
@@ -2,13 +2,13 @@
 ### dependency, but do not export it anymore.
 
 
-##' Quick data frame.
-##' Experimental version of \code{\link{as.data.frame}} that converts a
-##' list to a data frame, but doesn't do any checks to make sure it's a
-##' valid format. Much faster.
-##'
-##' @param list list to convert to data frame
-##' @keywords internal
+#' Quick data frame.
+#' Experimental version of \code{\link{as.data.frame}} that converts a
+#' list to a data frame, but doesn't do any checks to make sure it's a
+#' valid format. Much faster.
+#'
+#' @param list list to convert to data frame
+#' @keywords internal
 quickdf <- function(list) {
   if (is.matrix(list [[1]])) {
     n <- nrow(list [[1]])
@@ -22,45 +22,45 @@ quickdf <- function(list) {
   )
 }
 
-##' Bind matrices by row, and fill missing columns with NA
-##'
-##' The matrices are bound together using their column names or the column indices (in that order of
-##' precedence.) Numeric columns may be converted to character beforehand, e.g. using format.  If a
-##' matrix doesn't have colnames, the column number is used (via \code{\link[base]{make.names}(unique
-##' = TRUE)}).
-##'
-##' Note that this means that a column with name \code{"X1"} is merged with the first column of a
-##' matrix without name and so on.
-##'
-##' Vectors are converted to 1-column matrices prior to rbind.
-##'
-##' Matrices of factors are not supported. (They are anyways quite inconvenient.) You may convert
-##' them first to either numeric or character matrices. If a character matrix is merged with a
-##' numeric, the result will be character.
-##'
-##' Row names are ignored.
-##'
-##' The return matrix will always have column names.
-##'
-##' @author C. Beleites
-##' @seealso   \code{\link[base]{rbind}}, \code{\link[base]{cbind}}, \code{\link[plyr]{rbind.fill}}
-##' @keywords manip
-##' @rdname rbind.fill
-##' @examples
-##'  A <- matrix (1:4, 2)
-##'  B <- matrix (6:11, 2)
-##'  A
-##'  B
-##'  hyperSpec:::rbind.fill.matrix (A, B)
-##'
-##'  colnames (A) <- c (3, 1)
-##'  A
-##'  hyperSpec:::rbind.fill.matrix (A, B)
-##'
-##'  hyperSpec:::rbind.fill.matrix (A, 99)
-##'
-##' @return a matrix
-##' @method rbind.fill matrix
+#' Bind matrices by row, and fill missing columns with NA
+#'
+#' The matrices are bound together using their column names or the column indices (in that order of
+#' precedence.) Numeric columns may be converted to character beforehand, e.g. using format.  If a
+#' matrix doesn't have colnames, the column number is used (via \code{\link[base]{make.names}(unique
+#' = TRUE)}).
+#'
+#' Note that this means that a column with name \code{"X1"} is merged with the first column of a
+#' matrix without name and so on.
+#'
+#' Vectors are converted to 1-column matrices prior to rbind.
+#'
+#' Matrices of factors are not supported. (They are anyways quite inconvenient.) You may convert
+#' them first to either numeric or character matrices. If a character matrix is merged with a
+#' numeric, the result will be character.
+#'
+#' Row names are ignored.
+#'
+#' The return matrix will always have column names.
+#'
+#' @author C. Beleites
+#' @seealso   \code{\link[base]{rbind}}, \code{\link[base]{cbind}}, \code{\link[plyr]{rbind.fill}}
+#' @keywords manip
+#' @rdname rbind.fill
+#' @examples
+#'  A <- matrix (1:4, 2)
+#'  B <- matrix (6:11, 2)
+#'  A
+#'  B
+#'  hyperSpec:::rbind.fill.matrix (A, B)
+#'
+#'  colnames (A) <- c (3, 1)
+#'  A
+#'  hyperSpec:::rbind.fill.matrix (A, B)
+#'
+#'  hyperSpec:::rbind.fill.matrix (A, 99)
+#'
+#' @return a matrix
+#' @method rbind.fill matrix
 rbind.fill.matrix <- function(...) {
   matrices <- list(...)
 
@@ -110,18 +110,18 @@ rbind.fill.matrix <- function(...) {
   cln
 }
 
-##' Combine objects by row, filling in missing columns.
-##' \code{rbind}s a list of data frames filling missing columns with NA.
-##'
-##' This is an enhancement to \code{\link{rbind}} which adds in columns
-##' that are not present in all inputs, accepts a list of data frames, and
-##' operates substantially faster
-##'
-##' @param ... data frames/matrices to row bind together
-##' @keywords manip
-##' @rdname rbind.fill
-##' @examples
-##' #' rbind.fill(mtcars[c("mpg", "wt")], mtcars[c("wt", "cyl")])
+#' Combine objects by row, filling in missing columns.
+#' \code{rbind}s a list of data frames filling missing columns with NA.
+#'
+#' This is an enhancement to \code{\link{rbind}} which adds in columns
+#' that are not present in all inputs, accepts a list of data frames, and
+#' operates substantially faster
+#'
+#' @param ... data frames/matrices to row bind together
+#' @keywords manip
+#' @rdname rbind.fill
+#' @examples
+#' #' rbind.fill(mtcars[c("mpg", "wt")], mtcars[c("wt", "cyl")])
 rbind.fill <- function(...) {
   dfs <- list(...)
   if (length(dfs) == 0) {

--- a/hyperSpec/R/rbind.fill.R
+++ b/hyperSpec/R/rbind.fill.R
@@ -10,10 +10,10 @@
 #' @param list list to convert to data frame
 #' @keywords internal
 quickdf <- function(list) {
-  if (is.matrix(list [[1]])) {
-    n <- nrow(list [[1]])
+  if (is.matrix(list[[1]])) {
+    n <- nrow(list[[1]])
   } else {
-    n <- length(list [[1]])
+    n <- length(list[[1]])
   }
 
   structure(list,
@@ -93,7 +93,7 @@ rbind.fill.matrix <- function(...) {
   ## fill in the new matrix
   for (i in seq_along(matrices)) {
     icols <- match(lcols[[i]], cols)
-    result [(pos [i] + 1):pos [i + 1], icols] <- matrices [[i]]
+    result [(pos [i] + 1):pos [i + 1], icols] <- matrices[[i]]
   }
 
   colnames(result) <- cols
@@ -180,7 +180,7 @@ rbind.fill <- function(...) {
   # the trick is to supply a n by 0 matrix for input without column of that name
   for (var in matrixcols) {
     df <- lapply(dfs, .get.or.make.matrix, var)
-    output [[var]] <- I(do.call(rbind.fill.matrix, df))
+    output[[var]] <- I(do.call(rbind.fill.matrix, df))
   }
 
   # Compute start and end positions for each data frame
@@ -199,7 +199,7 @@ rbind.fill <- function(...) {
 }
 
 .get.or.make.matrix <- function(df, var) {
-  tmp <- df [[var]]
+  tmp <- df[[var]]
   if (is.null(tmp)) {
     tmp <- I(matrix(integer(), nrow = nrow(df)))
   }

--- a/hyperSpec/R/rbind.fill.R
+++ b/hyperSpec/R/rbind.fill.R
@@ -47,18 +47,17 @@ quickdf <- function(list) {
 #' @keywords manip
 #' @rdname rbind.fill
 #' @examples
-#'  A <- matrix (1:4, 2)
-#'  B <- matrix (6:11, 2)
-#'  A
-#'  B
-#'  hyperSpec:::rbind.fill.matrix (A, B)
+#' A <- matrix(1:4, 2)
+#' B <- matrix(6:11, 2)
+#' A
+#' B
+#' hyperSpec:::rbind.fill.matrix(A, B)
 #'
-#'  colnames (A) <- c (3, 1)
-#'  A
-#'  hyperSpec:::rbind.fill.matrix (A, B)
+#' colnames(A) <- c(3, 1)
+#' A
+#' hyperSpec:::rbind.fill.matrix(A, B)
 #'
-#'  hyperSpec:::rbind.fill.matrix (A, 99)
-#'
+#' hyperSpec:::rbind.fill.matrix(A, 99)
 #' @return a matrix
 #' @method rbind.fill matrix
 rbind.fill.matrix <- function(...) {

--- a/hyperSpec/R/read.ENVI.HySpex.R
+++ b/hyperSpec/R/read.ENVI.HySpex.R
@@ -1,6 +1,6 @@
-##' @describeIn  read.ENVI
-##' @include read.ENVI.R
-##' @export
+#' @describeIn  read.ENVI
+#' @include read.ENVI.R
+#' @export
 read.ENVI.HySpex <- function(file = stop("read.ENVI.HySpex: file name needed"),
                              headerfile = NULL, header = list(), keys.hdr2data = NULL, ...) {
   headerfile <- .find.ENVI.header(file, headerfile)

--- a/hyperSpec/R/read.ENVI.Nicolet.R
+++ b/hyperSpec/R/read.ENVI.Nicolet.R
@@ -1,23 +1,23 @@
-##' @details
-##' Nicolet uses some more keywords in their header file.
-##' They are interpreted as follows:
-##' \tabular{ll}{
-##' description   \tab giving the position of the first spectrum \cr
-##' z plot titles \tab wavelength and intensity axis units, comma separated \cr
-##' pixel size    \tab interpreted as x and y step size
-##'                    (specify \code{x = NA} and \code{y = NA})
-##' }
-##' These parameters can be overwritten by giving a list with the respective
-##' elements in parameter \code{header}.
-##'
-##' The values in header line description seem to be microns while the pixel
-##' size seems to be in microns. If \code{nicolet.correction} is true, the
-##' pixel size values (i.e. the step sizes) are multiplied by 1000.
-##'
-##' @param nicolet.correction see details
-##' @describeIn  read.ENVI
-##' @export
-##' @importFrom utils modifyList
+#' @details
+#' Nicolet uses some more keywords in their header file.
+#' They are interpreted as follows:
+#' \tabular{ll}{
+#' description   \tab giving the position of the first spectrum \cr
+#' z plot titles \tab wavelength and intensity axis units, comma separated \cr
+#' pixel size    \tab interpreted as x and y step size
+#'                    (specify \code{x = NA} and \code{y = NA})
+#' }
+#' These parameters can be overwritten by giving a list with the respective
+#' elements in parameter \code{header}.
+#'
+#' The values in header line description seem to be microns while the pixel
+#' size seems to be in microns. If \code{nicolet.correction} is true, the
+#' pixel size values (i.e. the step sizes) are multiplied by 1000.
+#'
+#' @param nicolet.correction see details
+#' @describeIn  read.ENVI
+#' @export
+#' @importFrom utils modifyList
 read.ENVI.Nicolet <- function(file = stop("read.ENVI: file name needed"),
                               headerfile = NULL, header = list(), ...,
                               x = NA, y = NA,

--- a/hyperSpec/R/read.ENVI.Nicolet.R
+++ b/hyperSpec/R/read.ENVI.Nicolet.R
@@ -78,7 +78,7 @@ read.ENVI.Nicolet <- function(file = stop("read.ENVI: file name needed"),
 
   ## set up regular expressions to extract the values
   p.description <- paste(
-    "^Spectrum position [[:digit:]]+ of [[:digit:]]+ positions,",
+    "^Spectrum position[[:digit:]]+ of[[:digit:]]+ positions,",
     "X = ([[:digit:].-]+), Y = ([[:digit:].-]+)$"
   )
   p.pixel.size <- "^[[:blank:]]*([[:digit:].-]+),[[:blank:]]*([[:digit:].-]+).*$"

--- a/hyperSpec/R/read.ENVI.R
+++ b/hyperSpec/R/read.ENVI.R
@@ -251,98 +251,98 @@ split.line <- function(x, separator, trim.blank = TRUE) {
 
 
 
-##' @title Import of ENVI data as hyperSpec object
-##'
-##' @description
-##' This function allows ENVI data import as \code{hyperSpec} object.
-##'
-##' \code{read.ENVI.Nicolet} should be a good starting point for writing custom
-##' wrappers for \code{read.ENVI} that take into account your manufacturer's
-##' special entries in the header file.
-##'
-##' @details
-##' ENVI data usually consists of two files, an ASCII header and a binary data
-##' file. The header contains all information necessary for correctly reading
-##' the binary file.
-##'
-##' I experienced missing header files (or rather: header files without any
-##' contents) produced by Bruker Opus' ENVI export.
-##'
-##' In this case the necessary information can be given as a list in parameter
-##' \code{header} instead:
-##'
-##' \tabular{lll}{
-##' \code{header$}          \tab values        \tab meaning\cr
-##' \code{samples}          \tab integer       \tab no of columns / spectra in x direction\cr
-##' \code{lines}            \tab integer       \tab no of lines / spectra in y direction\cr
-##' \code{bands}            \tab integer       \tab no of wavelengths / data points per spectrum\cr
-##' \code{`data type`}      \tab               \tab format of the binary file\cr
-##'                         \tab 1             \tab 1 byte unsigned integer \cr
-##'                         \tab 2             \tab 2 byte signed integer \cr
-##'                         \tab 3             \tab 4 byte signed integer \cr
-##'                         \tab 4             \tab 4 byte float \cr
-##'                         \tab 5             \tab 8 byte double \cr
-##'                         \tab 9             \tab 16 (2 x 8) byte complex double \cr
-##'                         \tab 12            \tab 2 byte unsigned integer \cr
-##'  \code{`header offset`} \tab integer       \tab number of bytes to skip before binary data starts\cr
-##'  \code{interleave}      \tab               \tab directions of the data cube \cr
-##'                         \tab "BSQ"         \tab band sequential (indexing: [sample, line, band])\cr
-##'                         \tab "BIL"         \tab band interleave by line (indexing: [sample, line, band])\cr
-##'                         \tab "BIP"         \tab band interleave by pixel (indexing: [band, line, sample])\cr
-##'  \code{`byte order`}    \tab 0 or "little" \tab little endian \cr
-##'                         \tab 1 or "big"    \tab big endian \cr
-##'                         \tab "swap"        \tab swap byte order
-##' }
-##'
-##' Some more information that is not provided by the ENVI files may be given:
-##'
-##' Wavelength axis and axis labels in the respective parameters. For more
-##' information, see \code{\link[hyperSpec]{initialize}}.
-##'
-##' The spatial information is by default a sequence from 0 to
-##' \code{header$samples - 1} and \code{header$lines - 1}, respectively.
-##' \code{x} and \code{y} give offset of the first spectrum and step size.
-##'
-##' Thus, the object's \code{$x} colum is: \code{(0 : header$samples - 1) * x
-##' [2] + x [1]}.  The \code{$y} colum is calculated analogously.
-##'
-##' @aliases read.ENVI read.ENVI.Nicolet read.ENVI.HySpex
-##' @param file complete name of the binary file
-##' @param headerfile name of the ASCII header file. If \code{NULL}, the name
-##'   of the header file is guessed by looking for a second file with the same
-##'   basename as \code{file} but \code{hdr} or \code{HDR} suffix.
-##' @param header list with header information, see details. Overwrites information extracted from the header file.
-##' @param x,y vectors of form c(offset, step size) for the position vectors,
-##'   see details.
-##' @param wavelength,label lists that overwrite the respective information
-##'   from the ENVI header file. These data is then handed to
-##'   \code{\link[hyperSpec]{initialize}}
-##' @param block.lines.skip,block.lines.size BIL and BIP ENVI files may be read in blocks of lines:
-##'   skip the first \code{block.lines.skip} lines, then read a block of \code{block.lines.size}
-##'   lines. If \code{block.lines.NULL}, the whole file is read.
-##'   Blocks are silently truncated at the end of the file (more precisely: to \code{header$lines}).
-##' @param keys.hdr2data determines which fields of the header file should be
-##'   put into the extra data. Defaults to none.
-##'
-##' To specify certain entries, give character vectors containing the lowercase
-##'   names of the header file entries.
-##' @param ... currently unused by \code{read.ENVI},
-##'   \code{read.ENVI.Nicolet} hands those arguements over to \code{read.ENVI}
-##' @param pull.header.lines (internal) flag whether multi-line header entries grouped by curly
-##'   braces should be pulled into one line each.
-##' @return a \code{hyperSpec} object
-##' @author C. Beleites, testing for the Nicolet files C. Dicko
-##' @seealso \code{\link[caTools]{read.ENVI}}
-##'
-##' \code{\link[hyperSpec]{textio}}
-##' @references This function was adapted from
-##'   \code{\link[caTools]{read.ENVI}}:
-##'
-##' Jarek Tuszynski (2008). caTools: Tools: moving window statistics, GIF,
-##'   Base64, ROC AUC, etc.. R package version 1.9.
-##' @export
-##' @keywords IO file
-##' @importFrom utils modifyList
+#' @title Import of ENVI data as hyperSpec object
+#'
+#' @description
+#' This function allows ENVI data import as \code{hyperSpec} object.
+#'
+#' \code{read.ENVI.Nicolet} should be a good starting point for writing custom
+#' wrappers for \code{read.ENVI} that take into account your manufacturer's
+#' special entries in the header file.
+#'
+#' @details
+#' ENVI data usually consists of two files, an ASCII header and a binary data
+#' file. The header contains all information necessary for correctly reading
+#' the binary file.
+#'
+#' I experienced missing header files (or rather: header files without any
+#' contents) produced by Bruker Opus' ENVI export.
+#'
+#' In this case the necessary information can be given as a list in parameter
+#' \code{header} instead:
+#'
+#' \tabular{lll}{
+#' \code{header$}          \tab values        \tab meaning\cr
+#' \code{samples}          \tab integer       \tab no of columns / spectra in x direction\cr
+#' \code{lines}            \tab integer       \tab no of lines / spectra in y direction\cr
+#' \code{bands}            \tab integer       \tab no of wavelengths / data points per spectrum\cr
+#' \code{`data type`}      \tab               \tab format of the binary file\cr
+#'                         \tab 1             \tab 1 byte unsigned integer \cr
+#'                         \tab 2             \tab 2 byte signed integer \cr
+#'                         \tab 3             \tab 4 byte signed integer \cr
+#'                         \tab 4             \tab 4 byte float \cr
+#'                         \tab 5             \tab 8 byte double \cr
+#'                         \tab 9             \tab 16 (2 x 8) byte complex double \cr
+#'                         \tab 12            \tab 2 byte unsigned integer \cr
+#'  \code{`header offset`} \tab integer       \tab number of bytes to skip before binary data starts\cr
+#'  \code{interleave}      \tab               \tab directions of the data cube \cr
+#'                         \tab "BSQ"         \tab band sequential (indexing: [sample, line, band])\cr
+#'                         \tab "BIL"         \tab band interleave by line (indexing: [sample, line, band])\cr
+#'                         \tab "BIP"         \tab band interleave by pixel (indexing: [band, line, sample])\cr
+#'  \code{`byte order`}    \tab 0 or "little" \tab little endian \cr
+#'                         \tab 1 or "big"    \tab big endian \cr
+#'                         \tab "swap"        \tab swap byte order
+#' }
+#'
+#' Some more information that is not provided by the ENVI files may be given:
+#'
+#' Wavelength axis and axis labels in the respective parameters. For more
+#' information, see \code{\link[hyperSpec]{initialize}}.
+#'
+#' The spatial information is by default a sequence from 0 to
+#' \code{header$samples - 1} and \code{header$lines - 1}, respectively.
+#' \code{x} and \code{y} give offset of the first spectrum and step size.
+#'
+#' Thus, the object's \code{$x} colum is: \code{(0 : header$samples - 1) * x
+#' [2] + x [1]}.  The \code{$y} colum is calculated analogously.
+#'
+#' @aliases read.ENVI read.ENVI.Nicolet read.ENVI.HySpex
+#' @param file complete name of the binary file
+#' @param headerfile name of the ASCII header file. If \code{NULL}, the name
+#'   of the header file is guessed by looking for a second file with the same
+#'   basename as \code{file} but \code{hdr} or \code{HDR} suffix.
+#' @param header list with header information, see details. Overwrites information extracted from the header file.
+#' @param x,y vectors of form c(offset, step size) for the position vectors,
+#'   see details.
+#' @param wavelength,label lists that overwrite the respective information
+#'   from the ENVI header file. These data is then handed to
+#'   \code{\link[hyperSpec]{initialize}}
+#' @param block.lines.skip,block.lines.size BIL and BIP ENVI files may be read in blocks of lines:
+#'   skip the first \code{block.lines.skip} lines, then read a block of \code{block.lines.size}
+#'   lines. If \code{block.lines.NULL}, the whole file is read.
+#'   Blocks are silently truncated at the end of the file (more precisely: to \code{header$lines}).
+#' @param keys.hdr2data determines which fields of the header file should be
+#'   put into the extra data. Defaults to none.
+#'
+#' To specify certain entries, give character vectors containing the lowercase
+#'   names of the header file entries.
+#' @param ... currently unused by \code{read.ENVI},
+#'   \code{read.ENVI.Nicolet} hands those arguements over to \code{read.ENVI}
+#' @param pull.header.lines (internal) flag whether multi-line header entries grouped by curly
+#'   braces should be pulled into one line each.
+#' @return a \code{hyperSpec} object
+#' @author C. Beleites, testing for the Nicolet files C. Dicko
+#' @seealso \code{\link[caTools]{read.ENVI}}
+#'
+#' \code{\link[hyperSpec]{textio}}
+#' @references This function was adapted from
+#'   \code{\link[caTools]{read.ENVI}}:
+#'
+#' Jarek Tuszynski (2008). caTools: Tools: moving window statistics, GIF,
+#'   Base64, ROC AUC, etc.. R package version 1.9.
+#' @export
+#' @keywords IO file
+#' @importFrom utils modifyList
 read.ENVI <- function(file = stop("read.ENVI: file name needed"), headerfile = NULL,
                       header = list(),
                       keys.hdr2data = FALSE,

--- a/hyperSpec/R/read.asc.Andor.R
+++ b/hyperSpec/R/read.asc.Andor.R
@@ -1,19 +1,19 @@
-##' Import Raman Spectra/Maps from Andor Cameras/Solis ASCII files
-##'
-##' \code{read.asc.Andor} reads Andor Solis ASCII (\code{.asc}) files where the first column gives the wavelength
-##' axes and the other columns the spectra.
-##'
-##' @title File Import Andor Solis
-##' @param file filename or connection to ASCII file
-##' @param ...,quiet,dec,sep handed to \code{\link[base]{scan}}
-##' @return a hyperSpec object
-##' @author Claudia Beleites
-##' @seealso \code{vignette ("fileio")} for more information on file import and
-##'
-##' \code{\link{options}} for details on options.
-##' @include read.txt.Witec.R
-##' @include fileio.optional.R
-##' @export
+#' Import Raman Spectra/Maps from Andor Cameras/Solis ASCII files
+#'
+#' \code{read.asc.Andor} reads Andor Solis ASCII (\code{.asc}) files where the first column gives the wavelength
+#' axes and the other columns the spectra.
+#'
+#' @title File Import Andor Solis
+#' @param file filename or connection to ASCII file
+#' @param ...,quiet,dec,sep handed to \code{\link[base]{scan}}
+#' @return a hyperSpec object
+#' @author Claudia Beleites
+#' @seealso \code{vignette ("fileio")} for more information on file import and
+#'
+#' \code{\link{options}} for details on options.
+#' @include read.txt.Witec.R
+#' @include fileio.optional.R
+#' @export
 read.asc.Andor <- function(file = stop("filename or connection needed"),
                            ..., quiet = TRUE, dec = ".", sep = ",") {
 

--- a/hyperSpec/R/read.ini.R
+++ b/hyperSpec/R/read.ini.R
@@ -33,7 +33,7 @@ read.ini <- function(con = stop("Connection con needed."), skip = NULL, encoding
   names(ini) <- .sanitize.name(gsub("[[:blank:]]*=.*$", "", content)) # see above: removes in front of equal sign
 
   # try converting to numeric
-  tmp <- lapply(ini, function(x) strsplit(x, ",") [[1]])
+  tmp <- lapply(ini, function(x) strsplit(x, ",")[[1]])
   tmp <- suppressWarnings(lapply(tmp, as.numeric))
   numbers <- !sapply(tmp, function(x) any(is.na(x)))
   ini [numbers] <- tmp [numbers]

--- a/hyperSpec/R/read.ini.R
+++ b/hyperSpec/R/read.ini.R
@@ -1,23 +1,23 @@
-##' Read INI files
-##'
-##' \code{read.ini} reads ini files of the form
-##'
-##' [section]
-##' key = value
-##'
-##' into a list.
-##'
-##' \code{read.ini} sanitizes the element names and tries to convert scalars and comma separated
-##' numeric vectors to numeric.
-##' @export
-##' @rdname read-ini
-##' @param con connection or file name
-##' @param skip number of lines to skip before first \code{[section]} starts
-##' @param encoding see \code{\link[base]{readLines}}
-##' @author C. Beleites
-##' @return a list with one element per section in the .ini file, each containing a list with elements
-##' for the key-value-pairs.
-##' @keywords IO file
+#' Read INI files
+#'
+#' \code{read.ini} reads ini files of the form
+#'
+#' [section]
+#' key = value
+#'
+#' into a list.
+#'
+#' \code{read.ini} sanitizes the element names and tries to convert scalars and comma separated
+#' numeric vectors to numeric.
+#' @export
+#' @rdname read-ini
+#' @param con connection or file name
+#' @param skip number of lines to skip before first \code{[section]} starts
+#' @param encoding see \code{\link[base]{readLines}}
+#' @author C. Beleites
+#' @return a list with one element per section in the .ini file, each containing a list with elements
+#' for the key-value-pairs.
+#' @keywords IO file
 
 read.ini <- function(con = stop("Connection con needed."), skip = NULL, encoding = "unknown") {
   Lines <- readLines(con, encoding = encoding)

--- a/hyperSpec/R/read.jdx.R
+++ b/hyperSpec/R/read.jdx.R
@@ -86,7 +86,7 @@ read.jdx <- function(filename = stop("filename is needed"), encoding = "",
       stop("SQZ, DIF, and DIFDUP forms are not yet supported.")
     }
 
-    spc [[s]] <- switch(hdr$.format,
+    spc[[s]] <- switch(hdr$.format,
       `(X++(Y..Y))` = .jdx.TABULAR.PAC(hdr, jdx [datastart [s]:spcend [s]], ...),
       `(XY..XY)` = .jdx.TABULAR.AFFN(hdr, jdx [datastart [s]:spcend [s]], ...),
 
@@ -94,11 +94,11 @@ read.jdx <- function(filename = stop("filename is needed"), encoding = "",
     )
 
     ## process according to header entries
-    spc [[s]] <- .jdx.processhdr(spc [[s]], hdr, keys.hdr2data, ..., NA.symbols = NA.symbols)
+    spc[[s]] <- .jdx.processhdr(spc[[s]], hdr, keys.hdr2data, ..., NA.symbols = NA.symbols)
   }
 
   if (length(spc) == 1L) {
-    spc <- spc [[1]]
+    spc <- spc[[1]]
   } else if (collapse.multi) {
     spc <- collapse(spc, wl.tolerance = wl.tolerance, collapse.equal = collapse.equal)
   }
@@ -149,7 +149,7 @@ read.jdx <- function(filename = stop("filename is needed"), encoding = "",
     )
   }
 
-  hdr$.format <- format [[1]]
+  hdr$.format <- format[[1]]
 
   hdr
 }

--- a/hyperSpec/R/read.jdx.R
+++ b/hyperSpec/R/read.jdx.R
@@ -1,37 +1,37 @@
-##' JCAMP-DX Import for Shimadzu Library Spectra
-##'
-##' this is a first rough import function for JCAMP-DX spectra.
-##'
-##' So far, AFFN and PAC formats are supported for simple XYDATA, DATA TABLEs and PEAK TABLEs.
-##'
-##' NTUPLES / PAGES are not (yet) supported.
-##'
-##' DIF, DUF, DIFDUP and SQZ data formats are not (yet) supported.
-##'
-##' @note JCAMP-DX support is incomplete and the functions may change without notice. See
-##' `vignette ("fileio")`  and the details section.
-##' @param filename file name and path of the .jdx file
-##' @param encoding encoding of the JCAMP-DX file (used by [base::readLines()])
-##' @param header list with manually set header values
-##' @param keys.hdr2data index vector indicating which header entries should be tranfered into the
-##' extra data. Usually a character vector of labels (lowercase, without and dashes, blanks,
-##' underscores). If `TRUE`, all header entries are read.
-##' @param ... further parameters handed to the data import function, e.g.
-##'
-##' | parameter | meaning                                                                             | default |
-##' | --------- | ----------------------------------------------------------------------------------- | ------- |
-##' | `xtol`    | tolerance for checking calculated x values against checkpoints at beginning of line | XFACTOR |
-##' | `ytol`    | tolerance for checking Y values against MINY and MAXY                               | YFACTOR |
-##'
-##' @param NA.symbols character vector of text values that should be converted to `NA`
-##' @param collapse.multi should hyperSpec objects from multispectra files be collapsed into one
-##' hyperSpec object (if `FALSE`, a list of hyperSpec objects is returned).
-##' @param wl.tolerance,collapse.equal see [collapse]
-##' @return hyperSpec object
-##' @author C. Beleites with contributions by Bryan Hanson
-##' @md
-##' @export
-##' @importFrom utils head modifyList maintainer
+#' JCAMP-DX Import for Shimadzu Library Spectra
+#'
+#' this is a first rough import function for JCAMP-DX spectra.
+#'
+#' So far, AFFN and PAC formats are supported for simple XYDATA, DATA TABLEs and PEAK TABLEs.
+#'
+#' NTUPLES / PAGES are not (yet) supported.
+#'
+#' DIF, DUF, DIFDUP and SQZ data formats are not (yet) supported.
+#'
+#' @note JCAMP-DX support is incomplete and the functions may change without notice. See
+#' `vignette ("fileio")`  and the details section.
+#' @param filename file name and path of the .jdx file
+#' @param encoding encoding of the JCAMP-DX file (used by [base::readLines()])
+#' @param header list with manually set header values
+#' @param keys.hdr2data index vector indicating which header entries should be tranfered into the
+#' extra data. Usually a character vector of labels (lowercase, without and dashes, blanks,
+#' underscores). If `TRUE`, all header entries are read.
+#' @param ... further parameters handed to the data import function, e.g.
+#'
+#' | parameter | meaning                                                                             | default |
+#' | --------- | ----------------------------------------------------------------------------------- | ------- |
+#' | `xtol`    | tolerance for checking calculated x values against checkpoints at beginning of line | XFACTOR |
+#' | `ytol`    | tolerance for checking Y values against MINY and MAXY                               | YFACTOR |
+#'
+#' @param NA.symbols character vector of text values that should be converted to `NA`
+#' @param collapse.multi should hyperSpec objects from multispectra files be collapsed into one
+#' hyperSpec object (if `FALSE`, a list of hyperSpec objects is returned).
+#' @param wl.tolerance,collapse.equal see [collapse]
+#' @return hyperSpec object
+#' @author C. Beleites with contributions by Bryan Hanson
+#' @md
+#' @export
+#' @importFrom utils head modifyList maintainer
 read.jdx <- function(filename = stop("filename is needed"), encoding = "",
                      header = list(), keys.hdr2data = FALSE, ...,
                      NA.symbols = c("NA", "N/A", "N.A."),

--- a/hyperSpec/R/read.mat.Cytospec.R
+++ b/hyperSpec/R/read.mat.Cytospec.R
@@ -60,7 +60,7 @@ read.mat.Cytospec <- function(file, keys2data = FALSE, blocks = TRUE) {
   } else {
     result <- list()
     for (b in blocks) {
-      result [[b]] <- .block2hyperSpec(spc, extra.data, wn, b, file)
+      result[[b]] <- .block2hyperSpec(spc, extra.data, wn, b, file)
     }
   }
 

--- a/hyperSpec/R/read.mat.Cytospec.R
+++ b/hyperSpec/R/read.mat.Cytospec.R
@@ -1,24 +1,24 @@
-##' Import for Cytospec mat files
-##'
-##' These functions allow to import .mat (Matlab V5) files written by Cytospec.
-##'
-##' \code{read.cytomat} has been renamed to \code{read.mat.Cytospec} and is now
-##' deprecated. Use \code{read.mat.Cytospec} instead.
-##'
-##' @param file The complete file name (or a connection to) the .mat file.
-##' @param keys2data specifies which elements of the \code{Info} should be
-##'   transferred into the extra data
-##' @param blocks which blocks should be read? \code{TRUE} reads all blocks.
-##' @param ... \code{read.cytomat} for now hands all arguments to
-##'   \code{read.mat.Cytospec} for backwards compatibility.
-##' @note This function is an ad-hoc implementation and subject to changes.
-##' @return hyperSpec object if the file contains a single spectra block,
-##'   otherwise a list with one hyperSpec object for each block.
-##' @author C. Beleites
-##' @rdname read.mat.Cytospec
-##' @seealso \code{R.matlab::readMat}
-##' @export
-##' @keywords IO file
+#' Import for Cytospec mat files
+#'
+#' These functions allow to import .mat (Matlab V5) files written by Cytospec.
+#'
+#' \code{read.cytomat} has been renamed to \code{read.mat.Cytospec} and is now
+#' deprecated. Use \code{read.mat.Cytospec} instead.
+#'
+#' @param file The complete file name (or a connection to) the .mat file.
+#' @param keys2data specifies which elements of the \code{Info} should be
+#'   transferred into the extra data
+#' @param blocks which blocks should be read? \code{TRUE} reads all blocks.
+#' @param ... \code{read.cytomat} for now hands all arguments to
+#'   \code{read.mat.Cytospec} for backwards compatibility.
+#' @note This function is an ad-hoc implementation and subject to changes.
+#' @return hyperSpec object if the file contains a single spectra block,
+#'   otherwise a list with one hyperSpec object for each block.
+#' @author C. Beleites
+#' @rdname read.mat.Cytospec
+#' @seealso \code{R.matlab::readMat}
+#' @export
+#' @keywords IO file
 read.mat.Cytospec <- function(file, keys2data = FALSE, blocks = TRUE) {
   if (!requireNamespace("R.matlab")) {
     stop("package 'R.matlab' needed.")

--- a/hyperSpec/R/read.mat.Witec.R
+++ b/hyperSpec/R/read.mat.Witec.R
@@ -1,5 +1,5 @@
 ## ' @export
-##' @importFrom utils maintainer
+#' @importFrom utils maintainer
 read.mat.Witec <- function(file = stop("filename or connection needed")) {
   if (!requireNamespace("R.matlab")) {
     stop("package 'R.matlab' needed.")

--- a/hyperSpec/R/read.mat.Witec.R
+++ b/hyperSpec/R/read.mat.Witec.R
@@ -17,7 +17,7 @@ read.mat.Witec <- function(file = stop("filename or connection needed")) {
     )
   }
   spcname <- names(data)
-  data <- data [[1]]
+  data <- data[[1]]
 
   spc <- new("hyperSpec", spc = data$data)
 

--- a/hyperSpec/R/read.spc.Kaiser.R
+++ b/hyperSpec/R/read.spc.Kaiser.R
@@ -65,7 +65,7 @@ read.spc.KaiserMap <- function(files, keys.log2data = NULL, ...) {
 
   colnames(spc@data) <- gsub("Stage_(.)_Position", "\\L\\1", colnames(spc@data), perl = TRUE)
   for (cln in c("x", "y", "z")) {
-    spc@data [[cln]] <- as.numeric(spc@data [[cln]])
+    spc@data[[cln]] <- as.numeric(spc@data[[cln]])
   }
 
   spc@label$x <- expression(`/`(x, micro * m))

--- a/hyperSpec/R/read.spc.Kaiser.R
+++ b/hyperSpec/R/read.spc.Kaiser.R
@@ -16,7 +16,6 @@
 #' @return hyperSpec
 #' @examples
 #' ## for examples, please see `vignette ("fileio", package = "hyperSpec")`.
-
 read.spc.Kaiser <- function(files, ..., glob = TRUE) {
   if (glob) {
     files <- Sys.glob(files)

--- a/hyperSpec/R/read.spc.Kaiser.R
+++ b/hyperSpec/R/read.spc.Kaiser.R
@@ -1,21 +1,21 @@
-##' Import functions for Kaiser Optical Systems .spc files
-##'
-##' \code{read.spc.Kaiser} imports sets of .spc files written by Kaiser Optical Systems' Hologram
-##' software.  It may also serve as an example how to write wrapper functions for \code{read.spc} to
-##' conveniently import specialized sets of .spc files.
-##'
-##' @title read Kaiser .spc files
-##' @export
-##' @rdname read-spc-Kaiser
-##' @param files If \code{glob = TRUE}, \code{filename} can contain wildcards.
-##'   Thus all files matching the name pattern in \code{filename} can be
-##'   specified.
-##' @param glob If \code{TRUE} the filename is interpreted as a wildcard
-##'   containing file name pattern and expanded to all matching file names.
-##' @param keys.log2data,... All further arguments are handed over directly to \code{\link{read.spc}}.
-##' @return hyperSpec
-##' @examples
-##' ## for examples, please see `vignette ("fileio", package = "hyperSpec")`.
+#' Import functions for Kaiser Optical Systems .spc files
+#'
+#' \code{read.spc.Kaiser} imports sets of .spc files written by Kaiser Optical Systems' Hologram
+#' software.  It may also serve as an example how to write wrapper functions for \code{read.spc} to
+#' conveniently import specialized sets of .spc files.
+#'
+#' @title read Kaiser .spc files
+#' @export
+#' @rdname read-spc-Kaiser
+#' @param files If \code{glob = TRUE}, \code{filename} can contain wildcards.
+#'   Thus all files matching the name pattern in \code{filename} can be
+#'   specified.
+#' @param glob If \code{TRUE} the filename is interpreted as a wildcard
+#'   containing file name pattern and expanded to all matching file names.
+#' @param keys.log2data,... All further arguments are handed over directly to \code{\link{read.spc}}.
+#' @return hyperSpec
+#' @examples
+#' ## for examples, please see `vignette ("fileio", package = "hyperSpec")`.
 
 read.spc.Kaiser <- function(files, ..., glob = TRUE) {
   if (glob) {
@@ -53,10 +53,10 @@ read.spc.Kaiser <- function(files, ..., glob = TRUE) {
   .fileio.optional(spc, file.keep.name = FALSE)
 }
 
-##' \code{read.spc.KaiserMap} is a wrapper for \code{read.spc.Kaiser} with predefined \code{log2data}
-##' to fetch the stage position for each file.
-##' @rdname read-spc-Kaiser
-##' @export
+#' \code{read.spc.KaiserMap} is a wrapper for \code{read.spc.Kaiser} with predefined \code{log2data}
+#' to fetch the stage position for each file.
+#' @rdname read-spc-Kaiser
+#' @export
 read.spc.KaiserMap <- function(files, keys.log2data = NULL, ...) {
   keys.log2data <- c("Stage_X_Position", "Stage_Y_Position", "Stage_Z_Position", keys.log2data)
 
@@ -77,14 +77,14 @@ read.spc.KaiserMap <- function(files, keys.log2data = NULL, ...) {
   spc
 }
 
-##' \code{read.spc.KaiserLowHigh} is a wrapper for \code{read.spc.Kaiser} for raw data that is saved
-##' in separate files for low and high wavenumber range.  The wavelength axis holds the pixel
-##' numbers, which repeat for low and high wavenumber ranges.
-##'
-##' @rdname read-spc-Kaiser
-##' @param type what kind of measurement was done? If \code{"map"}, \code{read.spc.KaiserMap} is used
-##' instead of \code{read.spc.Kaiser}.
-##' @export
+#' \code{read.spc.KaiserLowHigh} is a wrapper for \code{read.spc.Kaiser} for raw data that is saved
+#' in separate files for low and high wavenumber range.  The wavelength axis holds the pixel
+#' numbers, which repeat for low and high wavenumber ranges.
+#'
+#' @rdname read-spc-Kaiser
+#' @param type what kind of measurement was done? If \code{"map"}, \code{read.spc.KaiserMap} is used
+#' instead of \code{read.spc.Kaiser}.
+#' @export
 read.spc.KaiserLowHigh <- function(files = stop("file names needed"),
                                    type = c("single", "map"),
                                    ..., glob = TRUE) {

--- a/hyperSpec/R/read.spc.R
+++ b/hyperSpec/R/read.spc.R
@@ -670,16 +670,16 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
 #' ## get the sample .spc files from ftirsearch.com (see above)
 #' \dontrun{
 #' # single spectrum
-#' spc <- read.spc ("BENZENE.SPC")
-#' plot (spc)
+#' spc <- read.spc("BENZENE.SPC")
+#' plot(spc)
 #'
 #' # multi-spectra .spc file with common wavelength axis
-#' spc <- read.spc ('IG_MULTI.SPC')
+#' spc <- read.spc("IG_MULTI.SPC")
 #' spc
 #'
 #' # multi-spectra .spc file with individual wavelength axes
-#' spc <- read.spc ("BARBITUATES.SPC")
-#' plot (spc [[1]], lines.args = list (type = "h"))
+#' spc <- read.spc("BARBITUATES.SPC")
+#' plot(spc [[1]], lines.args = list(type = "h"))
 #' }
 #'
 #' @importFrom utils modifyList

--- a/hyperSpec/R/read.spc.R
+++ b/hyperSpec/R/read.spc.R
@@ -605,7 +605,7 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
   cat("ERROR in read.spc function ", fname, "\n\n")
   for (i in seq_along(objects)) {
     cat(names(objects) [i], ":\n")
-    str(objects [[i]], vec.len = 20)
+    str(objects[[i]], vec.len = 20)
   }
   stop(...)
 }
@@ -679,7 +679,7 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
 #'
 #' # multi-spectra .spc file with individual wavelength axes
 #' spc <- read.spc("BARBITUATES.SPC")
-#' plot(spc [[1]], lines.args = list(type = "h"))
+#' plot(spc[[1]], lines.args = list(type = "h"))
 #' }
 #'
 #' @importFrom utils modifyList
@@ -782,7 +782,7 @@ read.spc <- function(filename,
         )
       }
 
-      spc [[s]] <- new("hyperSpec",
+      spc[[s]] <- new("hyperSpec",
         spc = y$y,
         wavelength = wavelength$x,
         data = data,
@@ -1021,14 +1021,14 @@ read.spc <- function(filename,
 
   vector.entries <- which(sapply(data, length) > 1L)
   for (v in vector.entries) {
-    data [[v]] <- I(t(as.matrix(data [[v]])))
+    data[[v]] <- I(t(as.matrix(data[[v]])))
   }
 
   data <- as.data.frame(data, stringsAsFactors = FALSE)
   data <- data [rep(1L, nsubfiles), ]
 
   for (v in vector.entries) {
-    data [[v]] <- unclass(data [[v]])
+    data[[v]] <- unclass(data[[v]])
   } # remove AsIs protection
 
   data

--- a/hyperSpec/R/read.spc.R
+++ b/hyperSpec/R/read.spc.R
@@ -112,7 +112,7 @@
 
 ## helper functions ---------------------------------------------------------------------------------
 ### raw.split.nul - rawToChar conversion, splitting at \0
-##' @importFrom utils tail
+#' @importFrom utils tail
 raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.collapse = NULL) {
   # todo make better truncation
   trunc <- rep(trunc, length.out = 2)
@@ -162,7 +162,7 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
 ##
 ##
 
-##' @importFrom utils maintainer
+#' @importFrom utils maintainer
 .spc.filehdr <- function(raw.data) {
   ## check file format
 
@@ -503,7 +503,7 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
 
 ## read log block header ............................................................................
 ##
-##' @importFrom utils head tail
+#' @importFrom utils head tail
 .spc.log <- function(raw.data, pos, log.bin, log.disk, log.txt, keys.log2data,
                      replace.nul = as.raw(255), iconv.from = "latin1", iconv.to = "utf8") {
   if (pos == 0) { # no log block exists
@@ -600,7 +600,7 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
 }
 
 ## error .............................................................................................
-##' @importFrom utils str
+#' @importFrom utils str
 .spc.error <- function(fname, objects, ...) {
   cat("ERROR in read.spc function ", fname, "\n\n")
   for (i in seq_along(objects)) {
@@ -622,67 +622,67 @@ raw.split.nul <- function(raw, trunc = c(TRUE, TRUE), firstonly = FALSE, paste.c
 #####################################################################################################
 
 
-##' Import for Thermo Galactic's spc file format
-##' These functions allow to import Thermo Galactic/Grams .spc files.
-##'
-##' @param filename The complete file name of the .spc file.
-##' @param keys.hdr2data,keys.log2data character vectors with the names of parameters in the .spc
-##' file's log block (log2xxx) or header (hdr2xxx) that should go into the extra data (yyy2data) of
-##' the returned hyperSpec object.
-##'
-##' All header fields specified in the .spc file format specification (see
-##'   below) are imported and can be referred to by their de-capitalized names.
-##' @param log.txt Should the text part of the .spc file's log block be read?
-##' @param log.bin,log.disk Should the normal and on-disk binary parts of the
-##'   .spc file's log block be read?  If so, they will be put as raw vectors
-##'   into the hyperSpec object's log.
-##' @param hdr A list with fileheader fields that overwrite the settings of
-##'   actual file's header.
-##'
-##' Use with care, and look into the source code for detailed insight on the
-##'   elements of this list.
-##' @param no.object If \code{TRUE}, a list with wavelengths, spectra, labels,
-##'   log and data are returned instead of a hyperSpec object.
-##'
-##' This parameter will likely be subject to change in future - use with care.
-##' @return If the file contains multiple spectra with individual wavelength
-##'   axes, \code{read.spc} returns a list of hyperSpec objects.  Otherwise the
-##'   result is a hyperSpec object.
-##'
-##' \code{read.spc.KaiserMap} returns a hyperSpec object with data columns x,
-##'   y, and z containing the stage position as recorded in the .spc files'
-##'   log.
-##' @note Only a restricted set of test files was available for development.
-##'   Particularly, the w-planes feature could not be tested.
-##'
-##' If you have .spc files that cannot be read with these function, don't
-##'   hesitate to contact the package maintainer with your code patch or asking
-##'   advice.
-##' @author C. Beleites
-##' @rdname read-spc
-##' @seealso \code{\link[hyperSpec]{textio}}
-##' @references Source development kit and file format specification of .spc
-##'   files.
-##' @export
-##' @keywords IO file
-##' @examples
-##'
-##' ## get the sample .spc files from ftirsearch.com (see above)
-##' \dontrun{
-##' # single spectrum
-##' spc <- read.spc ("BENZENE.SPC")
-##' plot (spc)
-##'
-##' # multi-spectra .spc file with common wavelength axis
-##' spc <- read.spc ('IG_MULTI.SPC')
-##' spc
-##'
-##' # multi-spectra .spc file with individual wavelength axes
-##' spc <- read.spc ("BARBITUATES.SPC")
-##' plot (spc [[1]], lines.args = list (type = "h"))
-##' }
-##'
-##' @importFrom utils modifyList
+#' Import for Thermo Galactic's spc file format
+#' These functions allow to import Thermo Galactic/Grams .spc files.
+#'
+#' @param filename The complete file name of the .spc file.
+#' @param keys.hdr2data,keys.log2data character vectors with the names of parameters in the .spc
+#' file's log block (log2xxx) or header (hdr2xxx) that should go into the extra data (yyy2data) of
+#' the returned hyperSpec object.
+#'
+#' All header fields specified in the .spc file format specification (see
+#'   below) are imported and can be referred to by their de-capitalized names.
+#' @param log.txt Should the text part of the .spc file's log block be read?
+#' @param log.bin,log.disk Should the normal and on-disk binary parts of the
+#'   .spc file's log block be read?  If so, they will be put as raw vectors
+#'   into the hyperSpec object's log.
+#' @param hdr A list with fileheader fields that overwrite the settings of
+#'   actual file's header.
+#'
+#' Use with care, and look into the source code for detailed insight on the
+#'   elements of this list.
+#' @param no.object If \code{TRUE}, a list with wavelengths, spectra, labels,
+#'   log and data are returned instead of a hyperSpec object.
+#'
+#' This parameter will likely be subject to change in future - use with care.
+#' @return If the file contains multiple spectra with individual wavelength
+#'   axes, \code{read.spc} returns a list of hyperSpec objects.  Otherwise the
+#'   result is a hyperSpec object.
+#'
+#' \code{read.spc.KaiserMap} returns a hyperSpec object with data columns x,
+#'   y, and z containing the stage position as recorded in the .spc files'
+#'   log.
+#' @note Only a restricted set of test files was available for development.
+#'   Particularly, the w-planes feature could not be tested.
+#'
+#' If you have .spc files that cannot be read with these function, don't
+#'   hesitate to contact the package maintainer with your code patch or asking
+#'   advice.
+#' @author C. Beleites
+#' @rdname read-spc
+#' @seealso \code{\link[hyperSpec]{textio}}
+#' @references Source development kit and file format specification of .spc
+#'   files.
+#' @export
+#' @keywords IO file
+#' @examples
+#'
+#' ## get the sample .spc files from ftirsearch.com (see above)
+#' \dontrun{
+#' # single spectrum
+#' spc <- read.spc ("BENZENE.SPC")
+#' plot (spc)
+#'
+#' # multi-spectra .spc file with common wavelength axis
+#' spc <- read.spc ('IG_MULTI.SPC')
+#' spc
+#'
+#' # multi-spectra .spc file with individual wavelength axes
+#' spc <- read.spc ("BARBITUATES.SPC")
+#' plot (spc [[1]], lines.args = list (type = "h"))
+#' }
+#'
+#' @importFrom utils modifyList
 read.spc <- function(filename,
                      keys.hdr2data = FALSE, keys.log2data = FALSE,
                      log.txt = TRUE, log.bin = FALSE, log.disk = FALSE,

--- a/hyperSpec/R/read.spe.R
+++ b/hyperSpec/R/read.spe.R
@@ -6,36 +6,36 @@
 # July 2015
 
 
-##' Import WinSpec SPE file
-##'
-##' Import function for WinSpec SPE files (file version up to 3.0). The calibration
-##' data (polynome and calibration data pairs) for x-axis are automatically
-##' read and applied to the spectra. Note that the y-calibration data structure
-##' is not extracted from the file since it is not saved there by WinSpec and is
-##' always empty.
-##'
-##' @param filename Name of the SPE file to read data from
-##' @param xaxis Units of x-axis, e.g. \emph{"file"}, \emph{"px"},
-##' \emph{"nm"}, \emph{"energy"}, \emph{"raman"}, \emph{...}
-##' \code{read.spe} function automatically checks if the x-calibration data are
-##' available and uses them (if possible) to reconstruct the xaxis
-##' in the selected units.
-##' @param acc2avg whether to divide the actual data set by the number of
-##' accumulations, thus transforming \emph{accumulated} spectra to
-##' \emph{averaged} spectra. WinSpec does not do this automatically, so the
-##' spectral intensity is always proportional to the number of accumulations.
-##' The flag \code{@@data$averaged} is automatically set to \code{TRUE}.
-##' @param cts_sec whether to divide the actual data set by the exposure time,
-##' thus going to count per second unit.
-##' @param keys.hdr2data Which metadata from the file header should be saved to
-##' the \code{Data} slot of a newly created hyperSpec object
-##'
-##' @return hyperSpec object
-##'
-##' @rdname read.spe
-##'
-##' @author R. Kiselev, C. Beleites
-##' @export
+#' Import WinSpec SPE file
+#'
+#' Import function for WinSpec SPE files (file version up to 3.0). The calibration
+#' data (polynome and calibration data pairs) for x-axis are automatically
+#' read and applied to the spectra. Note that the y-calibration data structure
+#' is not extracted from the file since it is not saved there by WinSpec and is
+#' always empty.
+#'
+#' @param filename Name of the SPE file to read data from
+#' @param xaxis Units of x-axis, e.g. \emph{"file"}, \emph{"px"},
+#' \emph{"nm"}, \emph{"energy"}, \emph{"raman"}, \emph{...}
+#' \code{read.spe} function automatically checks if the x-calibration data are
+#' available and uses them (if possible) to reconstruct the xaxis
+#' in the selected units.
+#' @param acc2avg whether to divide the actual data set by the number of
+#' accumulations, thus transforming \emph{accumulated} spectra to
+#' \emph{averaged} spectra. WinSpec does not do this automatically, so the
+#' spectral intensity is always proportional to the number of accumulations.
+#' The flag \code{@@data$averaged} is automatically set to \code{TRUE}.
+#' @param cts_sec whether to divide the actual data set by the exposure time,
+#' thus going to count per second unit.
+#' @param keys.hdr2data Which metadata from the file header should be saved to
+#' the \code{Data} slot of a newly created hyperSpec object
+#'
+#' @return hyperSpec object
+#'
+#' @rdname read.spe
+#'
+#' @author R. Kiselev, C. Beleites
+#' @export
 read.spe <- function(filename, xaxis = "file", acc2avg = F, cts_sec = F,
                      keys.hdr2data = c(
                        "exposure_sec",
@@ -192,8 +192,8 @@ read.spe <- function(filename, xaxis = "file", acc2avg = F, cts_sec = F,
 
 
 
-##' @describeIn read.spe Read only header of a WinSpec SPE file (version 2.5)
-##' @return hdr list with \code{key=value} pairs
+#' @describeIn read.spe Read only header of a WinSpec SPE file (version 2.5)
+#' @return hdr list with \code{key=value} pairs
 .read.spe.header <- function(filename) {
   # Read the 4100-byte long binary header from the SPE file and parse it
 
@@ -263,9 +263,9 @@ read.spe <- function(filename, xaxis = "file", acc2avg = F, cts_sec = F,
 }
 
 
-##' @describeIn read.spe Plot the WinSpec SPE file (version 2.5) and show the
-##' calibration points stored inside of it (x-axis calibration)
-##' @export
+#' @describeIn read.spe Plot the WinSpec SPE file (version 2.5) and show the
+#' calibration points stored inside of it (x-axis calibration)
+#' @export
 spe.showcalpoints <- function(filename, xaxis = "file", acc2avg = F, cts_sec = F) {
   hdr <- .read.spe.header(filename)
   xaxis <- .fixunitname(xaxis)

--- a/hyperSpec/R/read.spe.R
+++ b/hyperSpec/R/read.spe.R
@@ -55,7 +55,7 @@ read.spe <- function(filename, xaxis = "file", acc2avg = F, cts_sec = F,
 
   # Convert raw spectral data according to the datatype defined in the header
   spc <- switch(hdr$datatype + 1,
-    readBin(raw.data, "double",  length(raw.data) / 4, 4), # float
+    readBin(raw.data, "double", length(raw.data) / 4, 4), # float
     readBin(raw.data, "integer", length(raw.data) / 4, 4, signed = TRUE), # long
     readBin(raw.data, "integer", length(raw.data) / 2, 2, signed = TRUE), # int
     readBin(raw.data, "integer", length(raw.data) / 2, 2, signed = FALSE) # uint
@@ -202,55 +202,55 @@ read.spe <- function(filename, xaxis = "file", acc2avg = F, cts_sec = F,
 
   # Extract some items from the 4100 bytes-long file header
   hdr <- list(
-     hwVersion       = readBin(raw.data[  1:    2], "integer",   1,   2, signed = TRUE ), # uint16
-     xDimDet         = readBin(raw.data[  7:    8], "integer",   1,   2, signed = FALSE), # uint16
-     mode            = readBin(raw.data[  9:   10], "integer",   1,   2, signed = TRUE ), # uint16
-     exposure_sec    = readBin(raw.data[  11:  14], "double",    1,   4                ), # float32
-     vChipXDim       = readBin(raw.data[  15:  16], "integer",   1,   2, signed = TRUE ), # int8
-     vChipYDim       = readBin(raw.data[  17:  18], "integer",   1,   2, signed = TRUE ), # int8
-     yDimDet         = readBin(raw.data[  19:  20], "integer",   1,   2, signed = FALSE), # uint16
-     date            = readBin(raw.data[  21:  30], "character", 1,  10                ), # char
-     detTemperature  = readBin(raw.data[  37:  40], "double",    1,   4                ), # float32
-     xdim            = readBin(raw.data[  43:  44], "integer",   1,   2, signed = FALSE), # uint16
-     shutterMode     = readBin(raw.data[  51:  52], "integer",   1,   2, signed = FALSE), # uint16
-     specCenterWlNm  = readBin(raw.data[  73:  76], "double",    1,   4                ), # float32
-     datatype        = readBin(raw.data[ 109: 110], "integer",   1,   2, signed = TRUE ), # int8
-     darkSubtracted  = readBin(raw.data[ 151: 152], "integer",   1,   2, signed = FALSE), # int8
-     timeLocal       = readBin(raw.data[ 173: 179], "character", 1,   7                ), # char
-     timeUTC         = readBin(raw.data[ 180: 186], "character", 1,   7                ), # char
-     gain            = readBin(raw.data[ 199: 200], "integer",   1,   2, signed = FALSE), # uint16
-     comments        = readBin(raw.data[ 201: 600], "character", 1, 400                ), # char
-     ydim            = readBin(raw.data[ 657: 658], "integer",   1,   2, signed = FALSE), # uint16
-     accumulCount    = readBin(raw.data[ 669: 672], "integer",   1,   4                ), # uint32
-     readoutTime     = readBin(raw.data[ 673: 676], "double",    1,   4                ), # float32
-     swVersion       = readBin(raw.data[ 688: 704], "character", 1,  16                ), # char
-     kinTrigMode     = readBin(raw.data[ 725: 726], "integer",   1,   2, signed = TRUE ), # int16
-     expRepeatCount  = readBin(raw.data[1419:1422], "integer",   1,   4, signed = TRUE ), # int32
-     expAccumCount   = readBin(raw.data[1423:1426], "integer",   1,   4, signed = TRUE ), # int32
-     hwAccumFlag     = readBin(raw.data[1433:1434], "integer",   1,   2, signed = TRUE ), # int16
-     cosmicApplied   = readBin(raw.data[1439:1440], "integer",   1,   2, signed = TRUE ), # int16
-     cosmicType      = readBin(raw.data[1441:1442], "integer",   1,   2, signed = TRUE ), # int16
-     numFrames       = readBin(raw.data[1447:1450], "integer",   1,   4                ), # int32
-     shutterType     = readBin(raw.data[1475:1476], "integer",   1,   2, signed = TRUE ), # int16
-     readoutMode     = readBin(raw.data[1481:1482], "integer",   1,   2, signed = TRUE ), # int16
-     kinWindowSize   = readBin(raw.data[1483:1484], "integer",   1,   2, signed = TRUE ), # int16
-     clkSpeed        = readBin(raw.data[1485:1486], "integer",   1,   2, signed = TRUE ), # int16
-     computerIface   = readBin(raw.data[1487:1488], "integer",   1,   2, signed = TRUE ), # int16
-     fileFormatVer   = readBin(raw.data[1993:1996], "double",    1,   4, signed = TRUE ), # float32 
+    hwVersion       = readBin(raw.data[1:2], "integer", 1, 2, signed = TRUE), # uint16
+    xDimDet         = readBin(raw.data[7:8], "integer", 1, 2, signed = FALSE), # uint16
+    mode            = readBin(raw.data[9:10], "integer", 1, 2, signed = TRUE), # uint16
+    exposure_sec    = readBin(raw.data[11:14], "double", 1, 4), # float32
+    vChipXDim       = readBin(raw.data[15:16], "integer", 1, 2, signed = TRUE), # int8
+    vChipYDim       = readBin(raw.data[17:18], "integer", 1, 2, signed = TRUE), # int8
+    yDimDet         = readBin(raw.data[19:20], "integer", 1, 2, signed = FALSE), # uint16
+    date            = readBin(raw.data[21:30], "character", 1, 10), # char
+    detTemperature  = readBin(raw.data[37:40], "double", 1, 4), # float32
+    xdim            = readBin(raw.data[43:44], "integer", 1, 2, signed = FALSE), # uint16
+    shutterMode     = readBin(raw.data[51:52], "integer", 1, 2, signed = FALSE), # uint16
+    specCenterWlNm  = readBin(raw.data[73:76], "double", 1, 4), # float32
+    datatype        = readBin(raw.data[109:110], "integer", 1, 2, signed = TRUE), # int8
+    darkSubtracted  = readBin(raw.data[151:152], "integer", 1, 2, signed = FALSE), # int8
+    timeLocal       = readBin(raw.data[173:179], "character", 1, 7), # char
+    timeUTC         = readBin(raw.data[180:186], "character", 1, 7), # char
+    gain            = readBin(raw.data[199:200], "integer", 1, 2, signed = FALSE), # uint16
+    comments        = readBin(raw.data[201:600], "character", 1, 400), # char
+    ydim            = readBin(raw.data[657:658], "integer", 1, 2, signed = FALSE), # uint16
+    accumulCount    = readBin(raw.data[669:672], "integer", 1, 4), # uint32
+    readoutTime     = readBin(raw.data[673:676], "double", 1, 4), # float32
+    swVersion       = readBin(raw.data[688:704], "character", 1, 16), # char
+    kinTrigMode     = readBin(raw.data[725:726], "integer", 1, 2, signed = TRUE), # int16
+    expRepeatCount  = readBin(raw.data[1419:1422], "integer", 1, 4, signed = TRUE), # int32
+    expAccumCount   = readBin(raw.data[1423:1426], "integer", 1, 4, signed = TRUE), # int32
+    hwAccumFlag     = readBin(raw.data[1433:1434], "integer", 1, 2, signed = TRUE), # int16
+    cosmicApplied   = readBin(raw.data[1439:1440], "integer", 1, 2, signed = TRUE), # int16
+    cosmicType      = readBin(raw.data[1441:1442], "integer", 1, 2, signed = TRUE), # int16
+    numFrames       = readBin(raw.data[1447:1450], "integer", 1, 4), # int32
+    shutterType     = readBin(raw.data[1475:1476], "integer", 1, 2, signed = TRUE), # int16
+    readoutMode     = readBin(raw.data[1481:1482], "integer", 1, 2, signed = TRUE), # int16
+    kinWindowSize   = readBin(raw.data[1483:1484], "integer", 1, 2, signed = TRUE), # int16
+    clkSpeed        = readBin(raw.data[1485:1486], "integer", 1, 2, signed = TRUE), # int16
+    computerIface   = readBin(raw.data[1487:1488], "integer", 1, 2, signed = TRUE), # int16
+    fileFormatVer   = readBin(raw.data[1993:1996], "double", 1, 4, signed = TRUE), # float32
 
-     # X Calibration Structure
-     xCalOffset      = readBin(raw.data[3001:3008], "double",    1,   8, signed = TRUE ), # float64
-     xCalFactor      = readBin(raw.data[3009:3016], "double",    1,   8, signed = TRUE ), # float64
-     xCalDisplayUnit = readBin(raw.data[3017],      "integer",   1,   1, signed = FALSE), # uint8
-     xCalValid       = readBin(raw.data[3099],      "integer",   1,   1, signed = FALSE), # uint8
-     xCalInputUnit   = readBin(raw.data[3100],      "integer",   1,   1, signed = FALSE), # uint8
-     xCalPolyUnit    = readBin(raw.data[3101],      "integer",   1,   1, signed = FALSE), # uint8
-     xCalPolyOrder   = readBin(raw.data[3102],      "integer",   1,   1, signed = FALSE), # uint8
-     xCalPointCount  = readBin(raw.data[3103],      "integer",   1,   1, signed = FALSE), # uint8
-     xCalPxPos       = readBin(raw.data[3104:3183], "double",   10,   8, signed = TRUE ), # float64
-     xCalValues      = readBin(raw.data[3184:3263], "double",   10,   8, signed = TRUE ), # float64
-     xCalPolCoeffs   = readBin(raw.data[3264:3311], "double",    6,   8, signed = TRUE ), # float64
-     LaserWavelen    = readBin(raw.data[3312:3319], "double",    1,   8, signed = TRUE )  # float64
+    # X Calibration Structure
+    xCalOffset      = readBin(raw.data[3001:3008], "double", 1, 8, signed = TRUE), # float64
+    xCalFactor      = readBin(raw.data[3009:3016], "double", 1, 8, signed = TRUE), # float64
+    xCalDisplayUnit = readBin(raw.data[3017], "integer", 1, 1, signed = FALSE), # uint8
+    xCalValid       = readBin(raw.data[3099], "integer", 1, 1, signed = FALSE), # uint8
+    xCalInputUnit   = readBin(raw.data[3100], "integer", 1, 1, signed = FALSE), # uint8
+    xCalPolyUnit    = readBin(raw.data[3101], "integer", 1, 1, signed = FALSE), # uint8
+    xCalPolyOrder   = readBin(raw.data[3102], "integer", 1, 1, signed = FALSE), # uint8
+    xCalPointCount  = readBin(raw.data[3103], "integer", 1, 1, signed = FALSE), # uint8
+    xCalPxPos       = readBin(raw.data[3104:3183], "double", 10, 8, signed = TRUE), # float64
+    xCalValues      = readBin(raw.data[3184:3263], "double", 10, 8, signed = TRUE), # float64
+    xCalPolCoeffs   = readBin(raw.data[3264:3311], "double", 6, 8, signed = TRUE), # float64
+    LaserWavelen    = readBin(raw.data[3312:3319], "double", 1, 8, signed = TRUE) # float64
   )
 
   # Convert magic numbers into human-readable unit strings

--- a/hyperSpec/R/read.txt.Horiba.R
+++ b/hyperSpec/R/read.txt.Horiba.R
@@ -1,14 +1,14 @@
-##' Read ASCII (.txt) files exported by Horiba's Labspec software (LabRAM spectrometers)
-##'
-##' \code{read.txt.Horiba.xy} reads maps, i.e. .txt files where the first two columns give x and y coordinates.
-##'
-##' @title Import Horiba Labspec exported ASCII files
-##' @param file connection (file name and path) to the .txt file
-##' @param cols,header,sep,row.names,check.names,... further parameters are handed over to \code{\link[hyperSpec]{read.txt.wide}}
-##' @rdname read.txt.Horiba
-##' @author C. Beleites
-##' @return hyperSpec object
-##' @export
+#' Read ASCII (.txt) files exported by Horiba's Labspec software (LabRAM spectrometers)
+#'
+#' \code{read.txt.Horiba.xy} reads maps, i.e. .txt files where the first two columns give x and y coordinates.
+#'
+#' @title Import Horiba Labspec exported ASCII files
+#' @param file connection (file name and path) to the .txt file
+#' @param cols,header,sep,row.names,check.names,... further parameters are handed over to \code{\link[hyperSpec]{read.txt.wide}}
+#' @rdname read.txt.Horiba
+#' @author C. Beleites
+#' @return hyperSpec object
+#' @export
 read.txt.Horiba <- function(file, cols = c(
                               spc = "I / a.u.",
                               .wavelength = expression(Delta * tilde(nu) / cm^-1)
@@ -27,8 +27,8 @@ read.txt.Horiba <- function(file, cols = c(
   spc
 }
 
-##' @rdname read.txt.Horiba
-##' @export
+#' @rdname read.txt.Horiba
+#' @export
 read.txt.Horiba.xy <- function(file, ...) {
   read.txt.Horiba(
     file = file,
@@ -42,9 +42,9 @@ read.txt.Horiba.xy <- function(file, ...) {
   )
 }
 
-##' \code{read.txt.Horiba.t}  reads time series, i.e. .txt files with the time in the first column
-##' @rdname read.txt.Horiba
-##' @export
+#' \code{read.txt.Horiba.t}  reads time series, i.e. .txt files with the time in the first column
+#' @rdname read.txt.Horiba
+#' @export
 read.txt.Horiba.t <- function(file, header = TRUE, sep = "\t", row.names = NULL,
                               check.names = FALSE, ...) {
   read.txt.Horiba(file,

--- a/hyperSpec/R/read.txt.Renishaw.R
+++ b/hyperSpec/R/read.txt.Renishaw.R
@@ -215,6 +215,8 @@ read.zip.Renishaw <- function(file = stop("filename is required"),
   test_that("compressed files", {
     skip_if_not_fileio_available()
 
-    expect_equal(dim(read.zip.Renishaw("fileio/txt.Renishaw/chondro.zip")), c(nrow = 875L, ncol = 4L, nwl = 1272L))
+    expect_equal(
+      dim(read.zip.Renishaw("fileio/txt.Renishaw/chondro.zip")),
+      c(nrow = 875L, ncol = 4L, nwl = 1272L))
   })
 }

--- a/hyperSpec/R/read.txt.Renishaw.R
+++ b/hyperSpec/R/read.txt.Renishaw.R
@@ -1,47 +1,47 @@
-##' import Raman measurements from Renishaw ASCII-files
-##'
-##' import Raman measurements from Renishaw (possibly compressed) .txt file.
-##'
-##' The file may be of any file type that can be read by
-##' \code{\link[base]{gzfile}} (i.e. text, or zipped by gzip, bzip2, xz or
-##' lzma). .zip zipped files need to be read using \code{read.zip.Renishaw}.
-##'
-##' Renishaw .wxd files are converted to .txt ASCII files by their batch
-##' converter. They come in a "long" format with columns (y x | time | z)?
-##' wavelength intensity.  The first columns depend on the data type.
-##'
-##' The corresponding possibilities for the \code{data} argument are:
-##' \tabular{lll}{ \code{data} \tab columns \tab \cr \code{"spc"} \tab wl int
-##' \tab single spectrum \cr \code{"zspc"}, \code{"depth"} \tab z wl int \tab
-##' depth profile\cr \code{"ts"} \tab t wl int \tab time series\cr
-##' \code{"xyspc"} \tab y x wl int \tab 2d map\cr }
-##'
-##' This function allows reading very large ASCII files, but it does not work
-##' on files with missing values (\code{NA}s are allowed).
-##'
-##' If the file is so large that it sould be read in chunks and \code{nspc} is
-##' not given, \code{read.txt.Renishaw} tries to guess it by using \code{wc}
-##' (if installed).
-##'
-##' @aliases read.txt.Renishaw read.zip.Renishaw
-##' @param file file name or connection
-##' @param data type of file, one of "spc", "xyspc", "zspc", "depth", "ts", see
-##'   details.
-##' @param nlines number of lines to read in each chunk, if 0 or less read
-##'   whole file at once.
-##'
-##' \code{nlines} must cover at least one complete spectrum,i.e. \code{nlines}
-##'   must be at least the number of data points per spectrum. Reasonable
-##'   values start at \code{1e6}.
-##' @param nspc number of spectra in the file
-##' @param ... Arguments for \code{read.txt.Renishaw}
-##' @return the \code{hyperSpec} object
-##' @export
-##' @author C. Beleites
-##' @seealso \code{\link{read.txt.long}}, \code{\link{read.txt.wide}},
-##'   \code{\link[base]{scan}}
-##' @keywords IO file
-##' @importFrom utils head
+#' import Raman measurements from Renishaw ASCII-files
+#'
+#' import Raman measurements from Renishaw (possibly compressed) .txt file.
+#'
+#' The file may be of any file type that can be read by
+#' \code{\link[base]{gzfile}} (i.e. text, or zipped by gzip, bzip2, xz or
+#' lzma). .zip zipped files need to be read using \code{read.zip.Renishaw}.
+#'
+#' Renishaw .wxd files are converted to .txt ASCII files by their batch
+#' converter. They come in a "long" format with columns (y x | time | z)?
+#' wavelength intensity.  The first columns depend on the data type.
+#'
+#' The corresponding possibilities for the \code{data} argument are:
+#' \tabular{lll}{ \code{data} \tab columns \tab \cr \code{"spc"} \tab wl int
+#' \tab single spectrum \cr \code{"zspc"}, \code{"depth"} \tab z wl int \tab
+#' depth profile\cr \code{"ts"} \tab t wl int \tab time series\cr
+#' \code{"xyspc"} \tab y x wl int \tab 2d map\cr }
+#'
+#' This function allows reading very large ASCII files, but it does not work
+#' on files with missing values (\code{NA}s are allowed).
+#'
+#' If the file is so large that it sould be read in chunks and \code{nspc} is
+#' not given, \code{read.txt.Renishaw} tries to guess it by using \code{wc}
+#' (if installed).
+#'
+#' @aliases read.txt.Renishaw read.zip.Renishaw
+#' @param file file name or connection
+#' @param data type of file, one of "spc", "xyspc", "zspc", "depth", "ts", see
+#'   details.
+#' @param nlines number of lines to read in each chunk, if 0 or less read
+#'   whole file at once.
+#'
+#' \code{nlines} must cover at least one complete spectrum,i.e. \code{nlines}
+#'   must be at least the number of data points per spectrum. Reasonable
+#'   values start at \code{1e6}.
+#' @param nspc number of spectra in the file
+#' @param ... Arguments for \code{read.txt.Renishaw}
+#' @return the \code{hyperSpec} object
+#' @export
+#' @author C. Beleites
+#' @seealso \code{\link{read.txt.long}}, \code{\link{read.txt.wide}},
+#'   \code{\link[base]{scan}}
+#' @keywords IO file
+#' @importFrom utils head
 read.txt.Renishaw <- function(file = stop("file is required"),
                               data = "xyspc", nlines = 0, nspc = NULL) {
   cols <- switch(data,
@@ -200,10 +200,10 @@ read.txt.Renishaw <- function(file = stop("file is required"),
   })
 }
 
-##' @export
-##' @param txt.file name of the .txt file in the .zip archive. Defaults to zip
-##'   file's name with suffix .txt instead of .zip
-##' @rdname read.txt.Renishaw
+#' @export
+#' @param txt.file name of the .txt file in the .zip archive. Defaults to zip
+#'   file's name with suffix .txt instead of .zip
+#' @rdname read.txt.Renishaw
 read.zip.Renishaw <- function(file = stop("filename is required"),
                               txt.file = sub("[.]zip", ".txt", basename(file)), ...) {
   read.txt.Renishaw(file = unz(file, filename = txt.file, "r"), ...)

--- a/hyperSpec/R/read.txt.Shimadzu.R
+++ b/hyperSpec/R/read.txt.Shimadzu.R
@@ -1,14 +1,14 @@
-##' Reads Shimadzu GCxGC-qMS - Spectra Files (.txt) as exported by Shimadzu Chrome Solution (v. 2.72)
-##' Mass Spectrometer: Shimadzu GCMS-QP 2010 Ultra (www.shimadzu.com)
-##'
-##' @note This is a first rough import function and the functions may change without notice.
-##' @param filename file name and path of the .txt file
-##' @param encoding encoding of the txt file (used by \code{\link[base]{readLines}})
-##' @param quiet suppress printing of progress
-##' @return list of spectra tables
-##' @author Bjoern Egert
-##' @export
-##' @importFrom utils read.table
+#' Reads Shimadzu GCxGC-qMS - Spectra Files (.txt) as exported by Shimadzu Chrome Solution (v. 2.72)
+#' Mass Spectrometer: Shimadzu GCMS-QP 2010 Ultra (www.shimadzu.com)
+#'
+#' @note This is a first rough import function and the functions may change without notice.
+#' @param filename file name and path of the .txt file
+#' @param encoding encoding of the txt file (used by \code{\link[base]{readLines}})
+#' @param quiet suppress printing of progress
+#' @return list of spectra tables
+#' @author Bjoern Egert
+#' @export
+#' @importFrom utils read.table
 read.txt.Shimadzu <- function(filename, encoding = "", quiet = TRUE) {
 
   # A file consists of several sections ([Headers])

--- a/hyperSpec/R/read.txt.Witec.R
+++ b/hyperSpec/R/read.txt.Witec.R
@@ -393,14 +393,14 @@ read.txt.Witec.Graph <- function(headerfile = stop("filename or connection neede
     hdr <- strsplit(hdr, "\t")
 
     if (length(hdr) == 2) {
-      spc@data$spcname <- hdr [[1]][-1]
-      labels(spc, ".wavelength") <- hdr [[2]] [1]
-      labels(spc, "spc") <- unique(hdr [[2]] [-1])
+      spc@data$spcname <- hdr[[1]][-1]
+      labels(spc, ".wavelength") <- hdr[[2]] [1]
+      labels(spc, "spc") <- unique(hdr[[2]] [-1])
     } else if (length(hdr) == 1 && hdr.label) {
-      spc@data$spcname <- hdr [[1]][-1]
+      spc@data$spcname <- hdr[[1]][-1]
     } else {
-      labels(spc, ".wavelength") <- hdr [[1]] [1]
-      labels(spc, "spc") <- unique(hdr [[1]] [-1])
+      labels(spc, ".wavelength") <- hdr[[1]] [1]
+      labels(spc, "spc") <- unique(hdr[[1]] [-1])
     }
   }
 

--- a/hyperSpec/R/read.txt.Witec.R
+++ b/hyperSpec/R/read.txt.Witec.R
@@ -1,26 +1,26 @@
-##' Import Raman Spectra/Maps from Witec Instrument via ASCII files
-##'
-##' \code{read.txt.Witec} reads Witec ASCII files where the first column gives the wavelength
-##' axes and the other columns the spectra. \code{read.dat.Witec} reads Witec's ASCII exported data
-##' which comes in separate files with x and y data.
-##' @title File Import Witec Raman
-##' @param file filename or connection to ASCII file
-##' @param points.per.line number of spectra in x direction of the map
-##' @param lines.per.image number of spectra in y direction
-##' @param nwl is deprecated and will be removed soon. Number of wavelengths is calculated automatically.
-##' @param remove.zerospc is deprecated and will be removed soon. Use \code{\link{hy.setOptions} (file.remove.emptyspc = TRUE)} instead.
-##' @param type type of spectra: \code{single} for single spectra (including time series), \code{map} for imaging data.
-##' @param hdr.label WITec Project exports the spectra names (contain information of map position or number of spectra) within the \code{file}.
-##' @param hdr.units WITec Project exports the spectra units within the \code{file}.
-##' @param encoding character encoding, see \code{\link[base]{readLines}}
-##' @param ...,quiet handed to \code{\link[base]{scan}}
-##' @return a hyperSpec object
-##' @author Claudia Beleites and Marcel Dahms
-##' @seealso \code{vignette ("fileio")} for more information on file import and
-##'
-##' \code{\link{options}} for details on options.
-##' @export
-##' @importFrom utils head
+#' Import Raman Spectra/Maps from Witec Instrument via ASCII files
+#'
+#' \code{read.txt.Witec} reads Witec ASCII files where the first column gives the wavelength
+#' axes and the other columns the spectra. \code{read.dat.Witec} reads Witec's ASCII exported data
+#' which comes in separate files with x and y data.
+#' @title File Import Witec Raman
+#' @param file filename or connection to ASCII file
+#' @param points.per.line number of spectra in x direction of the map
+#' @param lines.per.image number of spectra in y direction
+#' @param nwl is deprecated and will be removed soon. Number of wavelengths is calculated automatically.
+#' @param remove.zerospc is deprecated and will be removed soon. Use \code{\link{hy.setOptions} (file.remove.emptyspc = TRUE)} instead.
+#' @param type type of spectra: \code{single} for single spectra (including time series), \code{map} for imaging data.
+#' @param hdr.label WITec Project exports the spectra names (contain information of map position or number of spectra) within the \code{file}.
+#' @param hdr.units WITec Project exports the spectra units within the \code{file}.
+#' @param encoding character encoding, see \code{\link[base]{readLines}}
+#' @param ...,quiet handed to \code{\link[base]{scan}}
+#' @return a hyperSpec object
+#' @author Claudia Beleites and Marcel Dahms
+#' @seealso \code{vignette ("fileio")} for more information on file import and
+#'
+#' \code{\link{options}} for details on options.
+#' @export
+#' @importFrom utils head
 read.txt.Witec <- function(file = stop("filename or connection needed"),
                            points.per.line = NULL,
                            lines.per.image = NULL,
@@ -170,10 +170,10 @@ read.txt.Witec <- function(file = stop("filename or connection needed"),
   })
 }
 
-##' @rdname read.txt.Witec
-##' @param filex filename wavelength axis file
-##' @param filey filename intensity file
-##' @export
+#' @rdname read.txt.Witec
+#' @param filex filename wavelength axis file
+#' @param filey filename intensity file
+#' @export
 read.dat.Witec <- function(filex = stop("filename or connection needed"),
                            filey = sub("-x", "-y", filex),
                            points.per.line = NULL,
@@ -251,9 +251,9 @@ read.dat.Witec <- function(filex = stop("filename or connection needed"),
 }
 
 
-##' @rdname read.txt.Witec
-##' @param headerfile filename or connection to ASCII file with header information
-##' @export
+#' @rdname read.txt.Witec
+#' @param headerfile filename or connection to ASCII file with header information
+#' @export
 read.txt.Witec.Graph <- function(headerfile = stop("filename or connection needed"),
                                  filex = gsub("Header", "X-Axis", headerfile),
                                  filey = gsub("Header", "Y-Axis", headerfile),

--- a/hyperSpec/R/read.txt.long.R
+++ b/hyperSpec/R/read.txt.long.R
@@ -65,54 +65,69 @@
 #' @export
 #' @examples
 #'
-#'
-#' \dontrun{vignette  ("file-io")}
+#' \dontrun{
+#' vignette("file-io")
+#' }
 #'
 #' ## export & import matlab files
-#' if (require (R.matlab)) {
-#'    # export to matlab file
-#'    writeMat (paste0 (tempdir(), "/test.mat"),
-#'              x = flu[[]], wavelength = flu@@wavelength,
-#'              label = lapply (flu@@label, as.character))
+#' if (require(R.matlab)) {
+#'   # export to matlab file
+#'   writeMat(paste0(tempdir(), "/test.mat"),
+#'     x = flu[[]], wavelength = flu@wavelength,
+#'     label = lapply(flu@label, as.character)
+#'   )
 #'
-#'    # reading a matlab file
-#'    data <- readMat (paste0 (tempdir(), "/test.mat"))
-#'    print (data)
-#'    mat <- new ("hyperSpec", spc = data$x,
-#'                wavelength = as.numeric(data$wavelength),
-#'                label = data$label[,,1])
+#'   # reading a matlab file
+#'   data <- readMat(paste0(tempdir(), "/test.mat"))
+#'   print(data)
+#'   mat <- new("hyperSpec",
+#'     spc = data$x,
+#'     wavelength = as.numeric(data$wavelength),
+#'     label = data$label[, , 1]
+#'   )
 #' }
 #'
 #' ## ascii export & import
 #'
 #'
-#' write.txt.long (flu,
-#'     file = paste0 (tempdir(), "/flu.txt"),
-#'     cols = c(".wavelength", "spc", "c"),
-#' 		order = c("c", ".wavelength"),
-#' 		decreasing = c(FALSE, TRUE))
+#' write.txt.long(flu,
+#'   file = paste0(tempdir(), "/flu.txt"),
+#'   cols = c(".wavelength", "spc", "c"),
+#'   order = c("c", ".wavelength"),
+#'   decreasing = c(FALSE, TRUE)
+#' )
 #'
-#' read.txt.long (file = paste0 (tempdir(), "/flu.txt"),
-#'       cols = list (.wavelength = expression (lambda / nm),
-#'       spc = "I / a.u", c = expression ("/" (c, (mg/l)))))
+#' read.txt.long(
+#'   file = paste0(tempdir(), "/flu.txt"),
+#'   cols = list(
+#'     .wavelength = expression(lambda / nm),
+#'     spc = "I / a.u", c = expression("/"(c, (mg / l)))
+#'   )
+#' )
 #'
-#' write.txt.wide (flu,  file = paste0 (tempdir(), "/flu.txt"),
-#'     cols = c("c", "spc"),
-#' 		col.labels = TRUE, header.lines = 2, row.names = TRUE)
+#' write.txt.wide(flu,
+#'   file = paste0(tempdir(), "/flu.txt"),
+#'   cols = c("c", "spc"),
+#'   col.labels = TRUE, header.lines = 2, row.names = TRUE
+#' )
 #'
-#' write.txt.wide (flu,  file = paste0 (tempdir(), "/flu.txt"),
-#'                 col.labels = FALSE, row.names = FALSE)
+#' write.txt.wide(flu,
+#'   file = paste0(tempdir(), "/flu.txt"),
+#'   col.labels = FALSE, row.names = FALSE
+#' )
 #'
-#' read.txt.wide (file = paste0 (tempdir(), "/flu.txt"),
-#'     # give columns in same order as they are in the file
-#'     cols = list (spc = "I / a.u",
-#'                  c = expression ("/"("c", "mg/l")),
-#'                  filename = "filename",
-#'                  # plus wavelength label last
-#'                  .wavelength = "lambda / nm"),
-#' 		header = TRUE)
-#'
-#'
+#' read.txt.wide(
+#'   file = paste0(tempdir(), "/flu.txt"),
+#'   # give columns in same order as they are in the file
+#'   cols = list(
+#'     spc = "I / a.u",
+#'     c = expression("/"("c", "mg/l")),
+#'     filename = "filename",
+#'     # plus wavelength label last
+#'     .wavelength = "lambda / nm"
+#'   ),
+#'   header = TRUE
+#' )
 #' @importFrom utils read.table unstack
 read.txt.long <- function(file = stop("file is required"),
                           cols = list(

--- a/hyperSpec/R/read.txt.long.R
+++ b/hyperSpec/R/read.txt.long.R
@@ -6,114 +6,114 @@
 ###  (y x) wl int
 ###
 
-##' Import and Export of hyperSpec objects
-##' Besides \code{\link[base]{save}} and \code{\link[base]{load}}, two general
-##' ways to import and export data into \code{hyperSpec} objects exist.
-##'
-##' Firstly, hyperSpec objects can be imported and exported as ASCII files.
-##'
-##' A second option is using the package \code{\link[R.matlab]{R.matlab}} which
-##' provides the functions \code{\link[R.matlab]{readMat}} and
-##' \code{\link[R.matlab]{writeMat}}.
-##'
-##' hyperSpec comes with a number of pre-defined functions to import
-##' manufacturer specific file formats. For details, see \code{vignette
-##' ("file-io")}.
-##'
-##' \code{\link[hyperSpec]{read.spc}} imports Thermo Galactic's .spc file
-##' format, and ENVI files may be read using
-##' \code{\link[hyperSpec]{read.ENVI}}.
-##'
-##' These functions are very flexible and provide lots of arguments.
-##'
-##' If you use them to read or write manufacturer specific ASCII formats,
-##' please consider writing a wrapper function and contributing this function
-##' to \pkg{hyperSpec}.  An example is in the \dQuote{flu} vignette (see
-##' \code{vignette ("flu", package = "hyperSpec"}).
-##'
-##' Note that R accepts many packed formats for ASCII files, see
-##' \code{\link[base]{connections}}. For .zip files, see
-##' \code{\link[utils]{unzip}}.
-##'
-##' For further information, see the examples below and the documentation of
-##' \code{\link[R.matlab]{R.matlab}}.
-##'
-##' @aliases read.txt.long import export
-##' @param file filename or connection
-##' @param cols the column names specifying the column order.
-##'
-##' For data import, a list with elements \code{colname = label}; for export a
-##'   character vector with the colnames.  Use \code{wavelength} to specify the
-##'   wavelengths.
-##' @param header the file has (shall have) a header line
-##' @param ... arguments handed to \code{\link[utils]{read.table}} and
-##'   \code{\link[utils]{write.table}}, respectively.
-##' @param decreasing logical vector giving the sort order
-##' @author C. Beleites
-##' @seealso \code{\link[utils]{read.table}} and
-##'   \code{\link[utils]{write.table}}
-##'
-##' \code{\link[R.matlab]{R.matlab}} for .mat files
-##'
-##' \code{\link[hyperSpec]{read.ENVI}} for ENVI data
-##'
-##' \code{\link[hyperSpec]{read.spc}} for .spc files
-##'
-##' Manufacturer specific file formats: \code{\link{read.txt.Renishaw}}
-##' @rdname textio
-##' @keywords IO file
-##' @export
-##' @examples
-##'
-##'
-##' \dontrun{vignette  ("file-io")}
-##'
-##' ## export & import matlab files
-##' if (require (R.matlab)) {
-##'    # export to matlab file
-##'    writeMat (paste0 (tempdir(), "/test.mat"),
-##'              x = flu[[]], wavelength = flu@@wavelength,
-##'              label = lapply (flu@@label, as.character))
-##'
-##'    # reading a matlab file
-##'    data <- readMat (paste0 (tempdir(), "/test.mat"))
-##'    print (data)
-##'    mat <- new ("hyperSpec", spc = data$x,
-##'                wavelength = as.numeric(data$wavelength),
-##'                label = data$label[,,1])
-##' }
-##'
-##' ## ascii export & import
-##'
-##'
-##' write.txt.long (flu,
-##'     file = paste0 (tempdir(), "/flu.txt"),
-##'     cols = c(".wavelength", "spc", "c"),
-##' 		order = c("c", ".wavelength"),
-##' 		decreasing = c(FALSE, TRUE))
-##'
-##' read.txt.long (file = paste0 (tempdir(), "/flu.txt"),
-##'       cols = list (.wavelength = expression (lambda / nm),
-##'       spc = "I / a.u", c = expression ("/" (c, (mg/l)))))
-##'
-##' write.txt.wide (flu,  file = paste0 (tempdir(), "/flu.txt"),
-##'     cols = c("c", "spc"),
-##' 		col.labels = TRUE, header.lines = 2, row.names = TRUE)
-##'
-##' write.txt.wide (flu,  file = paste0 (tempdir(), "/flu.txt"),
-##'                 col.labels = FALSE, row.names = FALSE)
-##'
-##' read.txt.wide (file = paste0 (tempdir(), "/flu.txt"),
-##'     # give columns in same order as they are in the file
-##'     cols = list (spc = "I / a.u",
-##'                  c = expression ("/"("c", "mg/l")),
-##'                  filename = "filename",
-##'                  # plus wavelength label last
-##'                  .wavelength = "lambda / nm"),
-##' 		header = TRUE)
-##'
-##'
-##' @importFrom utils read.table unstack
+#' Import and Export of hyperSpec objects
+#' Besides \code{\link[base]{save}} and \code{\link[base]{load}}, two general
+#' ways to import and export data into \code{hyperSpec} objects exist.
+#'
+#' Firstly, hyperSpec objects can be imported and exported as ASCII files.
+#'
+#' A second option is using the package \code{\link[R.matlab]{R.matlab}} which
+#' provides the functions \code{\link[R.matlab]{readMat}} and
+#' \code{\link[R.matlab]{writeMat}}.
+#'
+#' hyperSpec comes with a number of pre-defined functions to import
+#' manufacturer specific file formats. For details, see \code{vignette
+#' ("file-io")}.
+#'
+#' \code{\link[hyperSpec]{read.spc}} imports Thermo Galactic's .spc file
+#' format, and ENVI files may be read using
+#' \code{\link[hyperSpec]{read.ENVI}}.
+#'
+#' These functions are very flexible and provide lots of arguments.
+#'
+#' If you use them to read or write manufacturer specific ASCII formats,
+#' please consider writing a wrapper function and contributing this function
+#' to \pkg{hyperSpec}.  An example is in the \dQuote{flu} vignette (see
+#' \code{vignette ("flu", package = "hyperSpec"}).
+#'
+#' Note that R accepts many packed formats for ASCII files, see
+#' \code{\link[base]{connections}}. For .zip files, see
+#' \code{\link[utils]{unzip}}.
+#'
+#' For further information, see the examples below and the documentation of
+#' \code{\link[R.matlab]{R.matlab}}.
+#'
+#' @aliases read.txt.long import export
+#' @param file filename or connection
+#' @param cols the column names specifying the column order.
+#'
+#' For data import, a list with elements \code{colname = label}; for export a
+#'   character vector with the colnames.  Use \code{wavelength} to specify the
+#'   wavelengths.
+#' @param header the file has (shall have) a header line
+#' @param ... arguments handed to \code{\link[utils]{read.table}} and
+#'   \code{\link[utils]{write.table}}, respectively.
+#' @param decreasing logical vector giving the sort order
+#' @author C. Beleites
+#' @seealso \code{\link[utils]{read.table}} and
+#'   \code{\link[utils]{write.table}}
+#'
+#' \code{\link[R.matlab]{R.matlab}} for .mat files
+#'
+#' \code{\link[hyperSpec]{read.ENVI}} for ENVI data
+#'
+#' \code{\link[hyperSpec]{read.spc}} for .spc files
+#'
+#' Manufacturer specific file formats: \code{\link{read.txt.Renishaw}}
+#' @rdname textio
+#' @keywords IO file
+#' @export
+#' @examples
+#'
+#'
+#' \dontrun{vignette  ("file-io")}
+#'
+#' ## export & import matlab files
+#' if (require (R.matlab)) {
+#'    # export to matlab file
+#'    writeMat (paste0 (tempdir(), "/test.mat"),
+#'              x = flu[[]], wavelength = flu@@wavelength,
+#'              label = lapply (flu@@label, as.character))
+#'
+#'    # reading a matlab file
+#'    data <- readMat (paste0 (tempdir(), "/test.mat"))
+#'    print (data)
+#'    mat <- new ("hyperSpec", spc = data$x,
+#'                wavelength = as.numeric(data$wavelength),
+#'                label = data$label[,,1])
+#' }
+#'
+#' ## ascii export & import
+#'
+#'
+#' write.txt.long (flu,
+#'     file = paste0 (tempdir(), "/flu.txt"),
+#'     cols = c(".wavelength", "spc", "c"),
+#' 		order = c("c", ".wavelength"),
+#' 		decreasing = c(FALSE, TRUE))
+#'
+#' read.txt.long (file = paste0 (tempdir(), "/flu.txt"),
+#'       cols = list (.wavelength = expression (lambda / nm),
+#'       spc = "I / a.u", c = expression ("/" (c, (mg/l)))))
+#'
+#' write.txt.wide (flu,  file = paste0 (tempdir(), "/flu.txt"),
+#'     cols = c("c", "spc"),
+#' 		col.labels = TRUE, header.lines = 2, row.names = TRUE)
+#'
+#' write.txt.wide (flu,  file = paste0 (tempdir(), "/flu.txt"),
+#'                 col.labels = FALSE, row.names = FALSE)
+#'
+#' read.txt.wide (file = paste0 (tempdir(), "/flu.txt"),
+#'     # give columns in same order as they are in the file
+#'     cols = list (spc = "I / a.u",
+#'                  c = expression ("/"("c", "mg/l")),
+#'                  filename = "filename",
+#'                  # plus wavelength label last
+#'                  .wavelength = "lambda / nm"),
+#' 		header = TRUE)
+#'
+#'
+#' @importFrom utils read.table unstack
 read.txt.long <- function(file = stop("file is required"),
                           cols = list(
                             .wavelength = expression(lambda / nm),

--- a/hyperSpec/R/read.txt.wide.R
+++ b/hyperSpec/R/read.txt.wide.R
@@ -5,46 +5,46 @@
 ###  Format:
 ###  x y ... int (wl1)  int (wl2) ... int (wl p) z ...
 ###
-##' Import/export of hyperSpec objects to/from ASCII files
-##' A detailed discussion of hyperSpec's file import and export capabilities is given in vignette \quote{fileio}.
-##'
-##' Besides \code{\link[base]{save}} and \code{\link[base]{load}}, two general ways to import and
-##' export data into \code{hyperSpec} objects exist.
-##'
-##' Firstly, hyperSpec objects can be imported  and exported as ASCII files.
-##'
-##'   A second option is using the package \code{\link[R.matlab]{R.matlab}}
-##'   which provides the functions \code{\link[R.matlab]{readMat}} and
-##'   \code{\link[R.matlab]{writeMat}}.
-##'
-##'   hyperSpec comes with a number of pre-defined functions to import
-##'   manufacturer specific file formats. For details, see \code{vignette
-##'   ("fileio")}.
-##'
-##'   \code{\link[hyperSpec]{read.spc}} imports Thermo Galactic's .spc file
-##'   format, and ENVI files may be read using
-##'   \code{\link[hyperSpec]{read.ENVI}}.
-##'
-##' These functions are very flexible and provide lots of arguments.
-##'
-##' If you use them to read or write manufacturer specific ASCII formats,
-##' please consider writing a wrapper function and contributing this
-##' function to \pkg{hyperSpec}.  An example is in the \dQuote{flu} vignette
-##' (see \code{vignette ("flu", package = "hyperSpec"}).
-##'
-##' Note that R accepts many packed formats for ASCII files, see
-##' \code{\link[base]{connections}}. For .zip files, see \code{\link[utils]{unzip}}.
-##'
-##' For further information, see the examples below, \code{vignette ("fileio")} and the documentation
-##' of \code{\link[R.matlab]{R.matlab}}.
-##' @seealso \code{vignette ("fileio")} and \url{http://hyperspec.r-forge.r-project.org/blob/fileio.pdf},
-##' respectively
-##' @aliases read.txt.wide
-##' @rdname textio
-##' @param check.names handed to \code{\link[utils]{read.table}}. Make sure this is \code{FALSE}, if
-##' the column names of the spectra are the wavelength values.
-##' @export
-##' @importFrom utils read.table head
+#' Import/export of hyperSpec objects to/from ASCII files
+#' A detailed discussion of hyperSpec's file import and export capabilities is given in vignette \quote{fileio}.
+#'
+#' Besides \code{\link[base]{save}} and \code{\link[base]{load}}, two general ways to import and
+#' export data into \code{hyperSpec} objects exist.
+#'
+#' Firstly, hyperSpec objects can be imported  and exported as ASCII files.
+#'
+#'   A second option is using the package \code{\link[R.matlab]{R.matlab}}
+#'   which provides the functions \code{\link[R.matlab]{readMat}} and
+#'   \code{\link[R.matlab]{writeMat}}.
+#'
+#'   hyperSpec comes with a number of pre-defined functions to import
+#'   manufacturer specific file formats. For details, see \code{vignette
+#'   ("fileio")}.
+#'
+#'   \code{\link[hyperSpec]{read.spc}} imports Thermo Galactic's .spc file
+#'   format, and ENVI files may be read using
+#'   \code{\link[hyperSpec]{read.ENVI}}.
+#'
+#' These functions are very flexible and provide lots of arguments.
+#'
+#' If you use them to read or write manufacturer specific ASCII formats,
+#' please consider writing a wrapper function and contributing this
+#' function to \pkg{hyperSpec}.  An example is in the \dQuote{flu} vignette
+#' (see \code{vignette ("flu", package = "hyperSpec"}).
+#'
+#' Note that R accepts many packed formats for ASCII files, see
+#' \code{\link[base]{connections}}. For .zip files, see \code{\link[utils]{unzip}}.
+#'
+#' For further information, see the examples below, \code{vignette ("fileio")} and the documentation
+#' of \code{\link[R.matlab]{R.matlab}}.
+#' @seealso \code{vignette ("fileio")} and \url{http://hyperspec.r-forge.r-project.org/blob/fileio.pdf},
+#' respectively
+#' @aliases read.txt.wide
+#' @rdname textio
+#' @param check.names handed to \code{\link[utils]{read.table}}. Make sure this is \code{FALSE}, if
+#' the column names of the spectra are the wavelength values.
+#' @export
+#' @importFrom utils read.table head
 read.txt.wide <- function(file = stop("file is required"),
                           cols = list(
                             spc = "I / a.u.",

--- a/hyperSpec/R/replace.R
+++ b/hyperSpec/R/replace.R
@@ -13,13 +13,12 @@
 #' ## replacement functions
 #' spc <- flu
 #' spc$.
-#' spc[, "c"] <- 16 : 11
+#' spc[, "c"] <- 16:11
 #' ## be careful:
-#' plot (spc)
-#' spc [] <- 6 : 1
+#' plot(spc)
+#' spc [] <- 6:1
 #' spc$..
-#' plot (spc)
-#'
+#' plot(spc)
 setReplaceMethod("[",
   signature = signature(x = "hyperSpec"),
   function(x, i, j,
@@ -53,31 +52,30 @@ setReplaceMethod("[",
 #' @export
 #' @include wl2i.R
 #' @examples
-#' spc <- flu [,, 405 ~ 410]
+#' spc <- flu [, , 405 ~ 410]
 #' spc [[]]
 #' spc [[3]] <- -spc[[3]]
 #' spc [[]]
-#' spc [[,,405 : 410]] <- -spc[[,,405 : 410]]
+#' spc [[, , 405:410]] <- -spc[[, , 405:410]]
 #' spc [[]]
-#' spc [[,,405 ~ 410]] <- -spc[[,,405 ~ 410]]
+#' spc [[, , 405 ~ 410]] <- -spc[[, , 405 ~ 410]]
 #'
 #' ## indexing with logical matrix
-#' spc <- flu [,, min ~ 410]
+#' spc <- flu [, , min ~ 410]
 #' spc < 125
 #' spc [[spc < 125]] <- NA
 #' spc [[]]
 #'
 #' ## indexing with n by 2 matrix
-#' ind <- matrix (c (1, 2, 4, 406, 405.5, 409), ncol = 2)
+#' ind <- matrix(c(1, 2, 4, 406, 405.5, 409), ncol = 2)
 #' ind
 #' spc [[ind]] <- 3
 #' spc [[]]
 #'
-#' ind <- matrix (c (1, 2, 4, 4:6), ncol = 2)
+#' ind <- matrix(c(1, 2, 4, 4:6), ncol = 2)
 #' ind
 #' spc [[ind, wl.index = TRUE]] <- 9999
 #' spc [[]]
-#'
 setReplaceMethod("[[",
   signature = signature(x = "hyperSpec"),
   function(x, i, j, l, wl.index = FALSE,
@@ -139,11 +137,9 @@ setReplaceMethod("[[",
 #' @export
 #' @examples
 #' spc$.
-#' spc$z <- 1 : 6
+#' spc$z <- 1:6
 #' spc
-#' spc$z <- list (1 : 6, "z / a.u.")
-#'
-
+#' spc$z <- list(1:6, "z / a.u.")
 setReplaceMethod("$",
   signature = signature(x = "hyperSpec"),
   function(x, name, value) {

--- a/hyperSpec/R/replace.R
+++ b/hyperSpec/R/replace.R
@@ -1,25 +1,25 @@
-##' @rdname extractreplace
-##' @name [<-
-##' @usage
-##'
-##' \S4method{[}{hyperSpec}(x, i, j, \dots) <- value
-##'
-##' @aliases [<-,hyperSpec-method
-##' @param value the replacement value
-##' @include wl2i.R
-##' @include paste.row.R
-##' @export
-##' @examples
-##' ## replacement functions
-##' spc <- flu
-##' spc$.
-##' spc[, "c"] <- 16 : 11
-##' ## be careful:
-##' plot (spc)
-##' spc [] <- 6 : 1
-##' spc$..
-##' plot (spc)
-##'
+#' @rdname extractreplace
+#' @name [<-
+#' @usage
+#'
+#' \S4method{[}{hyperSpec}(x, i, j, \dots) <- value
+#'
+#' @aliases [<-,hyperSpec-method
+#' @param value the replacement value
+#' @include wl2i.R
+#' @include paste.row.R
+#' @export
+#' @examples
+#' ## replacement functions
+#' spc <- flu
+#' spc$.
+#' spc[, "c"] <- 16 : 11
+#' ## be careful:
+#' plot (spc)
+#' spc [] <- 6 : 1
+#' spc$..
+#' plot (spc)
+#'
 setReplaceMethod("[",
   signature = signature(x = "hyperSpec"),
   function(x, i, j,
@@ -43,41 +43,41 @@ setReplaceMethod("[",
   }
 )
 
-##' @rdname extractreplace
-##' @usage
-##'
-##' \S4method{[[}{hyperSpec}(x, i, j, l, wl.index = FALSE, \dots) <- value
-##'
-##' @aliases [[<-,hyperSpec-method
-##' @name [[<-
-##' @export
-##' @include wl2i.R
-##' @examples
-##' spc <- flu [,, 405 ~ 410]
-##' spc [[]]
-##' spc [[3]] <- -spc[[3]]
-##' spc [[]]
-##' spc [[,,405 : 410]] <- -spc[[,,405 : 410]]
-##' spc [[]]
-##' spc [[,,405 ~ 410]] <- -spc[[,,405 ~ 410]]
-##'
-##' ## indexing with logical matrix
-##' spc <- flu [,, min ~ 410]
-##' spc < 125
-##' spc [[spc < 125]] <- NA
-##' spc [[]]
-##'
-##' ## indexing with n by 2 matrix
-##' ind <- matrix (c (1, 2, 4, 406, 405.5, 409), ncol = 2)
-##' ind
-##' spc [[ind]] <- 3
-##' spc [[]]
-##'
-##' ind <- matrix (c (1, 2, 4, 4:6), ncol = 2)
-##' ind
-##' spc [[ind, wl.index = TRUE]] <- 9999
-##' spc [[]]
-##'
+#' @rdname extractreplace
+#' @usage
+#'
+#' \S4method{[[}{hyperSpec}(x, i, j, l, wl.index = FALSE, \dots) <- value
+#'
+#' @aliases [[<-,hyperSpec-method
+#' @name [[<-
+#' @export
+#' @include wl2i.R
+#' @examples
+#' spc <- flu [,, 405 ~ 410]
+#' spc [[]]
+#' spc [[3]] <- -spc[[3]]
+#' spc [[]]
+#' spc [[,,405 : 410]] <- -spc[[,,405 : 410]]
+#' spc [[]]
+#' spc [[,,405 ~ 410]] <- -spc[[,,405 ~ 410]]
+#'
+#' ## indexing with logical matrix
+#' spc <- flu [,, min ~ 410]
+#' spc < 125
+#' spc [[spc < 125]] <- NA
+#' spc [[]]
+#'
+#' ## indexing with n by 2 matrix
+#' ind <- matrix (c (1, 2, 4, 406, 405.5, 409), ncol = 2)
+#' ind
+#' spc [[ind]] <- 3
+#' spc [[]]
+#'
+#' ind <- matrix (c (1, 2, 4, 4:6), ncol = 2)
+#' ind
+#' spc [[ind, wl.index = TRUE]] <- 9999
+#' spc [[]]
+#'
 setReplaceMethod("[[",
   signature = signature(x = "hyperSpec"),
   function(x, i, j, l, wl.index = FALSE,
@@ -129,20 +129,20 @@ setReplaceMethod("[[",
   }
 )
 
-##' @rdname extractreplace
-##' @usage
-##'
-##' \S4method{$}{hyperSpec}(x, name) <- value
-##'
-##' @aliases $<-,hyperSpec-method
-##' @name $<-
-##' @export
-##' @examples
-##' spc$.
-##' spc$z <- 1 : 6
-##' spc
-##' spc$z <- list (1 : 6, "z / a.u.")
-##'
+#' @rdname extractreplace
+#' @usage
+#'
+#' \S4method{$}{hyperSpec}(x, name) <- value
+#'
+#' @aliases $<-,hyperSpec-method
+#' @name $<-
+#' @export
+#' @examples
+#' spc$.
+#' spc$z <- 1 : 6
+#' spc
+#' spc$z <- list (1 : 6, "z / a.u.")
+#'
 
 setReplaceMethod("$",
   signature = signature(x = "hyperSpec"),

--- a/hyperSpec/R/replace.R
+++ b/hyperSpec/R/replace.R
@@ -53,29 +53,29 @@ setReplaceMethod("[",
 #' @include wl2i.R
 #' @examples
 #' spc <- flu [, , 405 ~ 410]
-#' spc [[]]
-#' spc [[3]] <- -spc[[3]]
-#' spc [[]]
-#' spc [[, , 405:410]] <- -spc[[, , 405:410]]
-#' spc [[]]
-#' spc [[, , 405 ~ 410]] <- -spc[[, , 405 ~ 410]]
+#' spc[[]]
+#' spc[[3]] <- -spc[[3]]
+#' spc[[]]
+#' spc[[, , 405:410]] <- -spc[[, , 405:410]]
+#' spc[[]]
+#' spc[[, , 405 ~ 410]] <- -spc[[, , 405 ~ 410]]
 #'
 #' ## indexing with logical matrix
 #' spc <- flu [, , min ~ 410]
 #' spc < 125
-#' spc [[spc < 125]] <- NA
-#' spc [[]]
+#' spc[[spc < 125]] <- NA
+#' spc[[]]
 #'
 #' ## indexing with n by 2 matrix
 #' ind <- matrix(c(1, 2, 4, 406, 405.5, 409), ncol = 2)
 #' ind
-#' spc [[ind]] <- 3
-#' spc [[]]
+#' spc[[ind]] <- 3
+#' spc[[]]
 #'
 #' ind <- matrix(c(1, 2, 4, 4:6), ncol = 2)
 #' ind
-#' spc [[ind, wl.index = TRUE]] <- 9999
-#' spc [[]]
+#' spc[[ind, wl.index = TRUE]] <- 9999
+#' spc[[]]
 setReplaceMethod("[[",
   signature = signature(x = "hyperSpec"),
   function(x, i, j, l, wl.index = FALSE,
@@ -152,9 +152,9 @@ setReplaceMethod("$",
         ilabel <- 2
       }
 
-      label <- value [[ilabel]]
+      label <- value[[ilabel]]
 
-      value <- value [[3 - ilabel]] ## the other of the 2 entries
+      value <- value[[3 - ilabel]] ## the other of the 2 entries
     } else {
       label <- name
     }

--- a/hyperSpec/R/sample.R
+++ b/hyperSpec/R/sample.R
@@ -162,8 +162,8 @@ setMethod("sample", signature = signature(x = "matrix"), .sample.matrix)
   context(".sample.matrix")
   test_that("matrix", {
     set.seed(101)
-    tmp <- sample(flu [[]])
-    expect_equal(dim(tmp), dim(flu [[]]))
-    expect_equal(tmp [c(1L, 3L, 4L, 6L, 5L, 2L), ], flu [[]])
+    tmp <- sample(flu[[]])
+    expect_equal(dim(tmp), dim(flu[[]]))
+    expect_equal(tmp [c(1L, 3L, 4L, 6L, 5L, 2L), ], flu[[]])
   })
 }

--- a/hyperSpec/R/sample.R
+++ b/hyperSpec/R/sample.R
@@ -54,15 +54,16 @@
 #' @export
 #' @examples
 #'
-#' sample (flu, 3)
+#' sample(flu, 3)
 #'
-#' plot (flu, col = "darkgray")
-#' plot (sample (flu, 3), col = "red", add = TRUE)
+#' plot(flu, col = "darkgray")
+#' plot(sample(flu, 3), col = "red", add = TRUE)
 #'
-#' plot (flu, col = "darkgray")
-#' plot (sample (flu, 3, replace = TRUE), col = "#0000FF80", add = TRUE,
-#'       lines.args = list (lwd = 2));
-#'
+#' plot(flu, col = "darkgray")
+#' plot(sample(flu, 3, replace = TRUE),
+#'   col = "#0000FF80", add = TRUE,
+#'   lines.args = list(lwd = 2)
+#' )
 setMethod("sample", signature = signature(x = "hyperSpec"), .sample)
 
 #' \code{isample} returns an vector of indices, \code{sample} returns the
@@ -72,10 +73,9 @@ setMethod("sample", signature = signature(x = "hyperSpec"), .sample)
 #' @return vector with indices suitable for row-indexing x
 #' @export
 #' @examples
-#' isample (flu, 3)
-#' isample (flu, 3, replace = TRUE)
-#' isample (flu, 8, replace = TRUE)
-
+#' isample(flu, 3)
+#' isample(flu, 3, replace = TRUE)
+#' isample(flu, 8, replace = TRUE)
 isample <- function(x, size = nrow(x), replace = FALSE, prob = NULL) {
   chk.hy(x)
   validObject(x)
@@ -115,7 +115,7 @@ isample <- function(x, size = nrow(x), replace = FALSE, prob = NULL) {
 #' @param drop see \code{\link[base]{drop}}: by default, do not drop dimensions of the result
 #' @export
 #' @examples
-#' sample (cars, 2)
+#' sample(cars, 2)
 setMethod("sample", signature = signature(x = "data.frame"), .sample.data.frame)
 
 .test(.sample.data.frame) <- function() {
@@ -155,7 +155,7 @@ setMethod("sample", signature = signature(x = "data.frame"), .sample.data.frame)
 #' @rdname sample
 #' @export
 #' @examples
-#' sample (matrix (1:24, 6), 2)
+#' sample(matrix(1:24, 6), 2)
 setMethod("sample", signature = signature(x = "matrix"), .sample.matrix)
 
 .test(.sample.matrix) <- function() {

--- a/hyperSpec/R/sample.R
+++ b/hyperSpec/R/sample.R
@@ -35,46 +35,46 @@
 
 
 
-##' Random Samples and Permutations
-##' Take a sample of the specified size from the elements of x with or without
-##' replacement.
-##'
-##' @rdname sample
-##' @docType methods
-##' @param x The hyperSpec object, data.frame or matrix to sample fromto sample from
-##' @param size positive integer giving the number of spectra (rows) to choose.
-##' @param replace Should sampling be with replacement?
-##' @param prob A vector of probability weights for obtaining the elements of
-##'   the vector being sampled.
-##' @return a hyperSpec object, data.frame or matrix with \code{size} rows for \code{sample}, and an
-##' integer vector for \code{isample} that is suitable for indexing (into the spectra) of x.
-##' @author C. Beleites
-##' @seealso \code{\link[base]{sample}}
-##' @keywords methods distribution
-##' @export
-##' @examples
-##'
-##' sample (flu, 3)
-##'
-##' plot (flu, col = "darkgray")
-##' plot (sample (flu, 3), col = "red", add = TRUE)
-##'
-##' plot (flu, col = "darkgray")
-##' plot (sample (flu, 3, replace = TRUE), col = "#0000FF80", add = TRUE,
-##'       lines.args = list (lwd = 2));
-##'
+#' Random Samples and Permutations
+#' Take a sample of the specified size from the elements of x with or without
+#' replacement.
+#'
+#' @rdname sample
+#' @docType methods
+#' @param x The hyperSpec object, data.frame or matrix to sample fromto sample from
+#' @param size positive integer giving the number of spectra (rows) to choose.
+#' @param replace Should sampling be with replacement?
+#' @param prob A vector of probability weights for obtaining the elements of
+#'   the vector being sampled.
+#' @return a hyperSpec object, data.frame or matrix with \code{size} rows for \code{sample}, and an
+#' integer vector for \code{isample} that is suitable for indexing (into the spectra) of x.
+#' @author C. Beleites
+#' @seealso \code{\link[base]{sample}}
+#' @keywords methods distribution
+#' @export
+#' @examples
+#'
+#' sample (flu, 3)
+#'
+#' plot (flu, col = "darkgray")
+#' plot (sample (flu, 3), col = "red", add = TRUE)
+#'
+#' plot (flu, col = "darkgray")
+#' plot (sample (flu, 3, replace = TRUE), col = "#0000FF80", add = TRUE,
+#'       lines.args = list (lwd = 2));
+#'
 setMethod("sample", signature = signature(x = "hyperSpec"), .sample)
 
-##' \code{isample} returns an vector of indices, \code{sample} returns the
-##' corresponding hyperSpec object.
-##'
-##' @rdname sample
-##' @return vector with indices suitable for row-indexing x
-##' @export
-##' @examples
-##' isample (flu, 3)
-##' isample (flu, 3, replace = TRUE)
-##' isample (flu, 8, replace = TRUE)
+#' \code{isample} returns an vector of indices, \code{sample} returns the
+#' corresponding hyperSpec object.
+#'
+#' @rdname sample
+#' @return vector with indices suitable for row-indexing x
+#' @export
+#' @examples
+#' isample (flu, 3)
+#' isample (flu, 3, replace = TRUE)
+#' isample (flu, 8, replace = TRUE)
 
 isample <- function(x, size = nrow(x), replace = FALSE, prob = NULL) {
   chk.hy(x)
@@ -111,11 +111,11 @@ isample <- function(x, size = nrow(x), replace = FALSE, prob = NULL) {
   x [sample.int(nrow(x), size = size, replace = replace, prob = prob), , drop = drop]
 }
 
-##' @rdname sample
-##' @param drop see \code{\link[base]{drop}}: by default, do not drop dimensions of the result
-##' @export
-##' @examples
-##' sample (cars, 2)
+#' @rdname sample
+#' @param drop see \code{\link[base]{drop}}: by default, do not drop dimensions of the result
+#' @export
+#' @examples
+#' sample (cars, 2)
 setMethod("sample", signature = signature(x = "data.frame"), .sample.data.frame)
 
 .test(.sample.data.frame) <- function() {
@@ -152,10 +152,10 @@ setMethod("sample", signature = signature(x = "data.frame"), .sample.data.frame)
   x [sample.int(nrow(x), size = size, replace = replace, prob = prob), , drop = drop]
 }
 
-##' @rdname sample
-##' @export
-##' @examples
-##' sample (matrix (1:24, 6), 2)
+#' @rdname sample
+#' @export
+#' @examples
+#' sample (matrix (1:24, 6), 2)
 setMethod("sample", signature = signature(x = "matrix"), .sample.matrix)
 
 .test(.sample.matrix) <- function() {

--- a/hyperSpec/R/scale.R
+++ b/hyperSpec/R/scale.R
@@ -27,20 +27,19 @@
 #' @examples
 #'
 #' ## mean center & variance scale
-#' tmp <- scale (faux_cell)
-#' plot (tmp, "spcmeansd")
-#' plot (sample (tmp, 5), add = TRUE, col = 2)
+#' tmp <- scale(faux_cell)
+#' plot(tmp, "spcmeansd")
+#' plot(sample(tmp, 5), add = TRUE, col = 2)
 #'
 #' ## mean center only
-#' tmp <- scale (faux_cell, scale = FALSE)
-#' plot (tmp, "spcmeansd")
-#' plot (sample (tmp, 5), add = TRUE, col = 2)
+#' tmp <- scale(faux_cell, scale = FALSE)
+#' plot(tmp, "spcmeansd")
+#' plot(sample(tmp, 5), add = TRUE, col = 2)
 #'
 #' ## custom center
-#' tmp <- sweep (faux_cell, 1, mean, `/`)
-#' plot (tmp, "spcmeansd")
-#' tmp <- scale (tmp, center = quantile (tmp, .05), scale = FALSE)
-#'
+#' tmp <- sweep(faux_cell, 1, mean, `/`)
+#' plot(tmp, "spcmeansd")
+#' tmp <- scale(tmp, center = quantile(tmp, .05), scale = FALSE)
 setMethod("scale",
   signature = signature(x = "hyperSpec"),
   function(x, center = TRUE, scale = TRUE) {

--- a/hyperSpec/R/scale.R
+++ b/hyperSpec/R/scale.R
@@ -1,46 +1,46 @@
-##' Center and scale hyperSpec object
-##'
-##' \code{link[base]{scale}}s the spectra matrix. \code{scale (x, scale = FALSE)} centers the data.
-##'
-##' Package \code{scale} provides a fast alternative for \code{base::\link[base]{scale}}
-##'
-##' @name scale,hyperSpec-method
-##' @rdname scale
-##' @aliases scale scale-methods scale,hyperSpec-method
-##' @docType methods
-##' @param x the \code{hyperSpec} object
-##' @param center if \code{TRUE}, the data is centered to \code{colMeans (x)}, \code{FALSE}
-##' suppresses centering. Alternatively, an object that can be converted to numeric of length
-##' \code{nwl (x)} by \code{\link[base]{as.matrix}} (e.g. hyperSpec object containing 1 spectrum) can
-##' specify the center spectrum.
-##' @param scale if \code{TRUE}, the data is scaled to have unit variance at each wavelength,
-##' \code{FALSE} suppresses scaling. Alternatively, an object that can be converted to numeric of
-##' length \code{nwl (x)} by \code{\link[base]{as.matrix}} (e.g. hyperSpec object containing 1 spectrum)
-##' can specify the center spectrum.
-##' @return the centered & scaled \code{hyperSpec} object
-##' @author C. Beleites
-##' @seealso \code{\link[base]{scale}}
-##'
-##' package scale.
-##' @keywords methods
-##' @export
-##' @examples
-##'
-##' ## mean center & variance scale
-##' tmp <- scale (faux_cell)
-##' plot (tmp, "spcmeansd")
-##' plot (sample (tmp, 5), add = TRUE, col = 2)
-##'
-##' ## mean center only
-##' tmp <- scale (faux_cell, scale = FALSE)
-##' plot (tmp, "spcmeansd")
-##' plot (sample (tmp, 5), add = TRUE, col = 2)
-##'
-##' ## custom center
-##' tmp <- sweep (faux_cell, 1, mean, `/`)
-##' plot (tmp, "spcmeansd")
-##' tmp <- scale (tmp, center = quantile (tmp, .05), scale = FALSE)
-##'
+#' Center and scale hyperSpec object
+#'
+#' \code{link[base]{scale}}s the spectra matrix. \code{scale (x, scale = FALSE)} centers the data.
+#'
+#' Package \code{scale} provides a fast alternative for \code{base::\link[base]{scale}}
+#'
+#' @name scale,hyperSpec-method
+#' @rdname scale
+#' @aliases scale scale-methods scale,hyperSpec-method
+#' @docType methods
+#' @param x the \code{hyperSpec} object
+#' @param center if \code{TRUE}, the data is centered to \code{colMeans (x)}, \code{FALSE}
+#' suppresses centering. Alternatively, an object that can be converted to numeric of length
+#' \code{nwl (x)} by \code{\link[base]{as.matrix}} (e.g. hyperSpec object containing 1 spectrum) can
+#' specify the center spectrum.
+#' @param scale if \code{TRUE}, the data is scaled to have unit variance at each wavelength,
+#' \code{FALSE} suppresses scaling. Alternatively, an object that can be converted to numeric of
+#' length \code{nwl (x)} by \code{\link[base]{as.matrix}} (e.g. hyperSpec object containing 1 spectrum)
+#' can specify the center spectrum.
+#' @return the centered & scaled \code{hyperSpec} object
+#' @author C. Beleites
+#' @seealso \code{\link[base]{scale}}
+#'
+#' package scale.
+#' @keywords methods
+#' @export
+#' @examples
+#'
+#' ## mean center & variance scale
+#' tmp <- scale (faux_cell)
+#' plot (tmp, "spcmeansd")
+#' plot (sample (tmp, 5), add = TRUE, col = 2)
+#'
+#' ## mean center only
+#' tmp <- scale (faux_cell, scale = FALSE)
+#' plot (tmp, "spcmeansd")
+#' plot (sample (tmp, 5), add = TRUE, col = 2)
+#'
+#' ## custom center
+#' tmp <- sweep (faux_cell, 1, mean, `/`)
+#' plot (tmp, "spcmeansd")
+#' tmp <- scale (tmp, center = quantile (tmp, .05), scale = FALSE)
+#'
 setMethod("scale",
   signature = signature(x = "hyperSpec"),
   function(x, center = TRUE, scale = TRUE) {

--- a/hyperSpec/R/seq.R
+++ b/hyperSpec/R/seq.R
@@ -27,16 +27,16 @@
 #' @keywords manip
 #' @examples
 #'
-#' seq (flu, index = TRUE)
-#' seq_along (flu)
-#' seq (flu, length.out = 3, index = TRUE) # return value is numeric, not integer!
-#' seq (flu, by = 2, index = TRUE) 		    # return value is numeric, not integer!
+#' seq(flu, index = TRUE)
+#' seq_along(flu)
+#' seq(flu, length.out = 3, index = TRUE) # return value is numeric, not integer!
+#' seq(flu, by = 2, index = TRUE) # return value is numeric, not integer!
 #'
-#' plot (flu, col = "darkgray")
-#' plot (seq (flu, by = 2), add = TRUE, col= "red")
-#' plot (seq (flu, length.out = 2), add = TRUE, col= "blue")
+#' plot(flu, col = "darkgray")
+#' plot(seq(flu, by = 2), add = TRUE, col = "red")
+#' plot(seq(flu, length.out = 2), add = TRUE, col = "blue")
 #'
-### needs to be an S3 function as S4 ... dispatch has to have the same signature for all parameters
+#' ### needs to be an S3 function as S4 ... dispatch has to have the same signature for all parameters
 seq.hyperSpec <- function(x, from = 1, to = nrow(x),
                           ..., index = FALSE) {
   validObject(x)

--- a/hyperSpec/R/seq.R
+++ b/hyperSpec/R/seq.R
@@ -1,41 +1,41 @@
 
-##' Sequence generation along spectra or wavelengths
-##' This function generates sequences along the spectra (rows) or wavelengths of hyperSpec objects.
-##'
-##' Note that \code{\link{wl2i}} generates sequences of indices along the wavelength axis.
-##'
-##' \code{seq} had to be implemented as S3 method as the generic has only \dots{} arguments (on which
-##' no dispatch with differing types is possible).
-##'
-##' \code{\link[base]{seq_along}} is not generic, but returns a sequence of the \code{length} of the
-##' object. As hyperSpec provides a Method \code{\link{length}}, it can be used. The result is a
-##' sequence of indices for the spectra.
-##'
-##' @aliases seq seq,hyperSpec-method
-##' @param x the hyperSpec object
-##' @param from,to arguments handed to \code{\link[base]{seq.int}}
-##' @param ... arguments for \code{\link[base]{seq}}, namely \code{by}, \code{length.out}
-##' @param index should a vector with indices be returned rather than a hyperSpec object?
-##' @return a numeric or hyperSpec object, depending on \code{index}.
-##' @author C. Beleites
-##' @seealso \code{\link{wl2i}} to construct sequences of wavelength indices.
-##'
-##' \code{\link[base]{seq}}
-##' @rdname seq
-##' @export
-##' @method seq hyperSpec
-##' @keywords manip
-##' @examples
-##'
-##' seq (flu, index = TRUE)
-##' seq_along (flu)
-##' seq (flu, length.out = 3, index = TRUE) # return value is numeric, not integer!
-##' seq (flu, by = 2, index = TRUE) 		    # return value is numeric, not integer!
-##'
-##' plot (flu, col = "darkgray")
-##' plot (seq (flu, by = 2), add = TRUE, col= "red")
-##' plot (seq (flu, length.out = 2), add = TRUE, col= "blue")
-##'
+#' Sequence generation along spectra or wavelengths
+#' This function generates sequences along the spectra (rows) or wavelengths of hyperSpec objects.
+#'
+#' Note that \code{\link{wl2i}} generates sequences of indices along the wavelength axis.
+#'
+#' \code{seq} had to be implemented as S3 method as the generic has only \dots{} arguments (on which
+#' no dispatch with differing types is possible).
+#'
+#' \code{\link[base]{seq_along}} is not generic, but returns a sequence of the \code{length} of the
+#' object. As hyperSpec provides a Method \code{\link{length}}, it can be used. The result is a
+#' sequence of indices for the spectra.
+#'
+#' @aliases seq seq,hyperSpec-method
+#' @param x the hyperSpec object
+#' @param from,to arguments handed to \code{\link[base]{seq.int}}
+#' @param ... arguments for \code{\link[base]{seq}}, namely \code{by}, \code{length.out}
+#' @param index should a vector with indices be returned rather than a hyperSpec object?
+#' @return a numeric or hyperSpec object, depending on \code{index}.
+#' @author C. Beleites
+#' @seealso \code{\link{wl2i}} to construct sequences of wavelength indices.
+#'
+#' \code{\link[base]{seq}}
+#' @rdname seq
+#' @export
+#' @method seq hyperSpec
+#' @keywords manip
+#' @examples
+#'
+#' seq (flu, index = TRUE)
+#' seq_along (flu)
+#' seq (flu, length.out = 3, index = TRUE) # return value is numeric, not integer!
+#' seq (flu, by = 2, index = TRUE) 		    # return value is numeric, not integer!
+#'
+#' plot (flu, col = "darkgray")
+#' plot (seq (flu, by = 2), add = TRUE, col= "red")
+#' plot (seq (flu, length.out = 2), add = TRUE, col= "blue")
+#'
 ### needs to be an S3 function as S4 ... dispatch has to have the same signature for all parameters
 seq.hyperSpec <- function(x, from = 1, to = nrow(x),
                           ..., index = FALSE) {

--- a/hyperSpec/R/show.R
+++ b/hyperSpec/R/show.R
@@ -89,12 +89,11 @@ setMethod("as.character",
 #'
 #' faux_cell
 #'
-#' show (faux_cell)
+#' show(faux_cell)
 #'
-#' summary (faux_cell)
+#' summary(faux_cell)
 #'
-#' print (faux_cell, range = TRUE)
-#'
+#' print(faux_cell, range = TRUE)
 setMethod("show", signature = signature(object = "hyperSpec"), function(object) {
   print(object, range = TRUE)
   invisible(NULL)

--- a/hyperSpec/R/show.R
+++ b/hyperSpec/R/show.R
@@ -1,20 +1,20 @@
-##' @rdname show
-##' @docType methods
-##' @import methods
-##' @aliases as.character
-##' @param digits number of digits handed over to \code{format}
-##' @param range should the values be indicated as range rather then first and
-##'   last elements?
-##' @param max.print maximum number of elements to be printed (of a variable)
-##' @param shorten.to if a vector is longer than \code{max.print}, only the
-##'   first \code{shorten.to[1]} and the last \code{shorten.to[2]} elements are
-##'   printed
-##' @return \code{as.character} returns a character vector fit to be printed by
-##'   \code{cat} with \code{sep = "\n"}.
-##'
-##' @seealso \code{\link[base]{as.character}}
-##' @include paste.row.R
-##' @export
+#' @rdname show
+#' @docType methods
+#' @import methods
+#' @aliases as.character
+#' @param digits number of digits handed over to \code{format}
+#' @param range should the values be indicated as range rather then first and
+#'   last elements?
+#' @param max.print maximum number of elements to be printed (of a variable)
+#' @param shorten.to if a vector is longer than \code{max.print}, only the
+#'   first \code{shorten.to[1]} and the last \code{shorten.to[2]} elements are
+#'   printed
+#' @return \code{as.character} returns a character vector fit to be printed by
+#'   \code{cat} with \code{sep = "\n"}.
+#'
+#' @seealso \code{\link[base]{as.character}}
+#' @include paste.row.R
+#' @export
 
 setMethod("as.character",
   signature = signature(x = "hyperSpec"),
@@ -72,45 +72,45 @@ setMethod("as.character",
   }
 )
 
-##' Convert a hyperSpec object to character strings for Display
-##' \code{print}, \code{show}, and \code{summary} show the result of
-##' \code{as.character}.
-##'
-##' \code{print}, \code{show}, and \code{summary} differ only in the defaults.
-##' \code{show} displays the range of values instead,
-##' @name show
-##' @rdname show
-##' @aliases show show,hyperSpec-method
-##' @param object a \code{hyperSpec} object
-##' @seealso \code{\link[methods]{show}}
-##' @keywords methods print
-##' @export
-##' @examples
-##'
-##' faux_cell
-##'
-##' show (faux_cell)
-##'
-##' summary (faux_cell)
-##'
-##' print (faux_cell, range = TRUE)
-##'
+#' Convert a hyperSpec object to character strings for Display
+#' \code{print}, \code{show}, and \code{summary} show the result of
+#' \code{as.character}.
+#'
+#' \code{print}, \code{show}, and \code{summary} differ only in the defaults.
+#' \code{show} displays the range of values instead,
+#' @name show
+#' @rdname show
+#' @aliases show show,hyperSpec-method
+#' @param object a \code{hyperSpec} object
+#' @seealso \code{\link[methods]{show}}
+#' @keywords methods print
+#' @export
+#' @examples
+#'
+#' faux_cell
+#'
+#' show (faux_cell)
+#'
+#' summary (faux_cell)
+#'
+#' print (faux_cell, range = TRUE)
+#'
 setMethod("show", signature = signature(object = "hyperSpec"), function(object) {
   print(object, range = TRUE)
   invisible(NULL)
 })
 
-##'
-##' \code{print} shows the overview giving the first and last values of each
-##' data column (fastest).
-##' @aliases print print,hyperSpec-method
-##' @param x a \code{hyperSpec} object
-##' @param ... \code{print} and \code{summary}  hand further arguments to \code{as.character}
-##' @return \code{print} invisibly returns \code{x} after printing, \code{show} returns
-##'   an invisible \code{NULL}.
-##' @rdname show
-##' @export
-##' @seealso \code{\link[base]{print}}
+#'
+#' \code{print} shows the overview giving the first and last values of each
+#' data column (fastest).
+#' @aliases print print,hyperSpec-method
+#' @param x a \code{hyperSpec} object
+#' @param ... \code{print} and \code{summary}  hand further arguments to \code{as.character}
+#' @return \code{print} invisibly returns \code{x} after printing, \code{show} returns
+#'   an invisible \code{NULL}.
+#' @rdname show
+#' @export
+#' @seealso \code{\link[base]{print}}
 setMethod("print", signature = signature(x = "hyperSpec"), function(x, range = FALSE, ...) {
   validObject(x)
   cat(as.character(x, range = FALSE, ...), sep = "\n")
@@ -118,13 +118,13 @@ setMethod("print", signature = signature(x = "hyperSpec"), function(x, range = F
 })
 
 
-##'
-##' \code{summary} displays the logbook in addition.
-##'
-##' @aliases summary summary,hyperSpec-method
-##' @seealso \code{\link[base]{summary}}
-##' @export
-##' @rdname show
+#'
+#' \code{summary} displays the logbook in addition.
+#'
+#' @aliases summary summary,hyperSpec-method
+#' @seealso \code{\link[base]{summary}}
+#' @export
+#' @rdname show
 setMethod("summary",
   signature = signature(object = "hyperSpec"),
   function(object, ...) {

--- a/hyperSpec/R/spc.NA.approx.R
+++ b/hyperSpec/R/spc.NA.approx.R
@@ -15,9 +15,9 @@
 #' @author Claudia Beleites
 #' @examples
 #' fluNA <- hyperSpec:::fluNA
-#' spc.NA.approx (fluNA [,, min ~ 410], debuglevel = 1)
-#' spc.NA.approx (fluNA [1,, min ~ 410], debuglevel = 2)
-#' spc.NA.approx (fluNA [4,, min ~ 410], neighbours = 3, df = 4, debuglevel = 2)
+#' spc.NA.approx(fluNA [, , min ~ 410], debuglevel = 1)
+#' spc.NA.approx(fluNA [1, , min ~ 410], debuglevel = 2)
+#' spc.NA.approx(fluNA [4, , min ~ 410], neighbours = 3, df = 4, debuglevel = 2)
 spc.NA.approx <- function(spc, neighbours = 1, w = rep(1, 2 * neighbours), df = 1 + .Machine$double.eps, spar = NULL,
                           debuglevel = hy.getOption("debuglevel")) {
   chk.hy(spc)

--- a/hyperSpec/R/spc.NA.approx.R
+++ b/hyperSpec/R/spc.NA.approx.R
@@ -118,12 +118,12 @@ spc.NA.linapprox <- function(...) {
 
   test_that("linear interpolation", {
     tmp <- spc.NA.approx(fluNA [-2, , min ~ 410])
-    expect_equivalent(as.numeric(tmp [[, , 406]]), rowMeans(fluNA [[-2, , 405.5 ~ 406.5]], na.rm = TRUE))
+    expect_equivalent(as.numeric(tmp[[, , 406]]), rowMeans(fluNA[[-2, , 405.5 ~ 406.5]], na.rm = TRUE))
   })
 
   test_that("spline interpolation", {
     tmp <- spc.NA.approx(fluNA [-2, , min ~ 410], neighbours = 2)
-    expect_true(all(abs(tmp [[, , 406]] - rowMeans(fluNA [[-2, , 405 ~ 407]], na.rm = TRUE)) <= 1e-5))
+    expect_true(all(abs(tmp[[, , 406]] - rowMeans(fluNA[[-2, , 405 ~ 407]], na.rm = TRUE)) <= 1e-5))
     # version on CRAN throws error on `expect_equal (tolerance = 1e-5)`
     # TODO => change back ASAP
   })
@@ -133,13 +133,13 @@ spc.NA.linapprox <- function(...) {
     for (d in 0:2) {
       for (r in ranges) {
         tmp <- spc.NA.approx(fluNA [-2, , r], neighbours = 3, debuglevel = d)
-        # expect_equal (round (as.numeric (tmp [[,, 406]]), 5),
-        #               round (rowMeans (fluNA [[-2,, r]], na.rm = TRUE), 5),
+        # expect_equal (round (as.numeric (tmp[[,, 406]]), 5),
+        #               round (rowMeans (fluNA[[-2,, r]], na.rm = TRUE), 5),
         #               tolerance = 1e-5,
         #               info = paste0 ("debuglevel = ", d, ", range = ", paste0 (r [c (2, 1, 3)], collapse = "")))
         # version on CRAN throws error on `expect_equal (tolerance = 1e-5)`
         # TODO => change back ASAP
-        expect_true(all(abs(tmp [[, , 406]] - rowMeans(fluNA [[-2, , r]], na.rm = TRUE)) <= 1e-5),
+        expect_true(all(abs(tmp[[, , 406]] - rowMeans(fluNA[[-2, , r]], na.rm = TRUE)) <= 1e-5),
           info = paste0("debuglevel = ", d, ", range = ", paste0(r [c(2, 1, 3)], collapse = ""))
         )
       }

--- a/hyperSpec/R/spc.NA.approx.R
+++ b/hyperSpec/R/spc.NA.approx.R
@@ -1,23 +1,23 @@
-##' Impute missing data points
-##'
-##' Replace \code{NA}s in the spectra matrix by interpolation. With
-##' less than 4 points available linear interpolation of the 2 neighbour points is used. For larger numbers of
-##' neighbour points, smoothing interpolation is performed by
-##' \code{\link[stats]{smooth.spline}}.
-##' @note  The function has been renamed from \code{spc.NA.linapprox} to  \code{spc.NA.approx}
-##' @param spc hyperSpec object with spectra matrix containing \code{NA}s
-##' @param neighbours how many neighbour data points should be used to fit the
-##'   line
-##' @param w,df,spar see \code{\link[stats]{smooth.spline}}
-##' @param debuglevel  see \code{\link[hyperSpec]{options}}
-##' @return hyperSpec object
-##' @export
-##' @author Claudia Beleites
-##' @examples
-##' fluNA <- hyperSpec:::fluNA
-##' spc.NA.approx (fluNA [,, min ~ 410], debuglevel = 1)
-##' spc.NA.approx (fluNA [1,, min ~ 410], debuglevel = 2)
-##' spc.NA.approx (fluNA [4,, min ~ 410], neighbours = 3, df = 4, debuglevel = 2)
+#' Impute missing data points
+#'
+#' Replace \code{NA}s in the spectra matrix by interpolation. With
+#' less than 4 points available linear interpolation of the 2 neighbour points is used. For larger numbers of
+#' neighbour points, smoothing interpolation is performed by
+#' \code{\link[stats]{smooth.spline}}.
+#' @note  The function has been renamed from \code{spc.NA.linapprox} to  \code{spc.NA.approx}
+#' @param spc hyperSpec object with spectra matrix containing \code{NA}s
+#' @param neighbours how many neighbour data points should be used to fit the
+#'   line
+#' @param w,df,spar see \code{\link[stats]{smooth.spline}}
+#' @param debuglevel  see \code{\link[hyperSpec]{options}}
+#' @return hyperSpec object
+#' @export
+#' @author Claudia Beleites
+#' @examples
+#' fluNA <- hyperSpec:::fluNA
+#' spc.NA.approx (fluNA [,, min ~ 410], debuglevel = 1)
+#' spc.NA.approx (fluNA [1,, min ~ 410], debuglevel = 2)
+#' spc.NA.approx (fluNA [4,, min ~ 410], neighbours = 3, df = 4, debuglevel = 2)
 spc.NA.approx <- function(spc, neighbours = 1, w = rep(1, 2 * neighbours), df = 1 + .Machine$double.eps, spar = NULL,
                           debuglevel = hy.getOption("debuglevel")) {
   chk.hy(spc)
@@ -107,8 +107,8 @@ spc.NA.approx <- function(spc, neighbours = 1, w = rep(1, 2 * neighbours), df = 
   spc
 }
 
-##' @rdname spc.NA.approx
-##' @param ... ignored
+#' @rdname spc.NA.approx
+#' @param ... ignored
 spc.NA.linapprox <- function(...) {
   stop("spc.NA.linapprox has been renamed to spc.NA.approx")
 }

--- a/hyperSpec/R/spc.bin.R
+++ b/hyperSpec/R/spc.bin.R
@@ -28,14 +28,13 @@
 #' @keywords manip datagen
 #' @examples
 #'
-#'  spc <- spc.bin (flu, 5)
+#' spc <- spc.bin(flu, 5)
 #'
-#'  plot (flu[1,,425:475])
-#'  plot (spc[1,,425:475], add = TRUE, col = "blue")
+#' plot(flu[1, , 425:475])
+#' plot(spc[1, , 425:475], add = TRUE, col = "blue")
 #'
-#'  nwl (flu)
-#'  nwl (spc)
-#'
+#' nwl(flu)
+#' nwl(spc)
 spc.bin <- function(spc, by = stop("reduction factor needed"), na.rm = TRUE, ...) {
   chk.hy(spc)
   validObject(spc)

--- a/hyperSpec/R/spc.bin.R
+++ b/hyperSpec/R/spc.bin.R
@@ -1,41 +1,41 @@
-##' Wavelength Binning
-##' In order to reduce the spectral resolution and thus gain signal to noise
-##' ratio or to reduce the dimensionality of the spectral data set, the
-##' spectral resolution can be reduced.
-##'
-##' The mean of every \code{by} data points in the spectra is calculated.
-##'
-##' Using \code{na.rm = TRUE} always takes about twice as long as \code{na.rm = FALSE}.
-##'
-##' If the spectra matrix does not contain too many \code{NA}s, \code{na.rm = 2} is faster than
-##' \code{na.rm = TRUE}.
-##'
-##' @param spc the \code{hyperSpec} object
-##' @param by reduction factor
-##' @param na.rm decides about the treatment of \code{NA}s:
-##'
-##' if \code{FALSE} or \code{0}, the binning is done using \code{na.rm = FALSE}
-##'
-##' if \code{TRUE} or \code{1}, the binning is done using \code{na.rm = TRUE}
-##'
-##' if \code{2}, the binning is done using \code{na.rm = FALSE}, and resulting \code{NA}s are
-##' corrected with \code{mean(\dots{}, na.rm = TRUE)}.
-##' @param ... ignored
-##' @return A \code{hyperSpec} object with \code{ceiling (nwl (spc) / by)} data points per spectrum.
-##' @rdname spc-bin
-##' @export
-##' @author C. Beleites
-##' @keywords manip datagen
-##' @examples
-##'
-##'  spc <- spc.bin (flu, 5)
-##'
-##'  plot (flu[1,,425:475])
-##'  plot (spc[1,,425:475], add = TRUE, col = "blue")
-##'
-##'  nwl (flu)
-##'  nwl (spc)
-##'
+#' Wavelength Binning
+#' In order to reduce the spectral resolution and thus gain signal to noise
+#' ratio or to reduce the dimensionality of the spectral data set, the
+#' spectral resolution can be reduced.
+#'
+#' The mean of every \code{by} data points in the spectra is calculated.
+#'
+#' Using \code{na.rm = TRUE} always takes about twice as long as \code{na.rm = FALSE}.
+#'
+#' If the spectra matrix does not contain too many \code{NA}s, \code{na.rm = 2} is faster than
+#' \code{na.rm = TRUE}.
+#'
+#' @param spc the \code{hyperSpec} object
+#' @param by reduction factor
+#' @param na.rm decides about the treatment of \code{NA}s:
+#'
+#' if \code{FALSE} or \code{0}, the binning is done using \code{na.rm = FALSE}
+#'
+#' if \code{TRUE} or \code{1}, the binning is done using \code{na.rm = TRUE}
+#'
+#' if \code{2}, the binning is done using \code{na.rm = FALSE}, and resulting \code{NA}s are
+#' corrected with \code{mean(\dots{}, na.rm = TRUE)}.
+#' @param ... ignored
+#' @return A \code{hyperSpec} object with \code{ceiling (nwl (spc) / by)} data points per spectrum.
+#' @rdname spc-bin
+#' @export
+#' @author C. Beleites
+#' @keywords manip datagen
+#' @examples
+#'
+#'  spc <- spc.bin (flu, 5)
+#'
+#'  plot (flu[1,,425:475])
+#'  plot (spc[1,,425:475], add = TRUE, col = "blue")
+#'
+#'  nwl (flu)
+#'  nwl (spc)
+#'
 spc.bin <- function(spc, by = stop("reduction factor needed"), na.rm = TRUE, ...) {
   chk.hy(spc)
   validObject(spc)

--- a/hyperSpec/R/spc.bin.R
+++ b/hyperSpec/R/spc.bin.R
@@ -62,7 +62,7 @@ spc.bin <- function(spc, by = stop("reduction factor needed"), na.rm = TRUE, ...
       bin <- split(wl.seq(spc), bin)
 
       for (i in seq_len(nrow(na))) {
-        tmp [na [i, 1], na [i, 2]] <- mean(spc@data$spc [na [i, 1], bin [[na[i, 2]]]], na.rm = TRUE)
+        tmp [na [i, 1], na [i, 2]] <- mean(spc@data$spc [na [i, 1], bin[[na[i, 2]]]], na.rm = TRUE)
       }
       spc@data$spc <- tmp
     }

--- a/hyperSpec/R/spc.fit.poly.R
+++ b/hyperSpec/R/spc.fit.poly.R
@@ -1,40 +1,40 @@
-##' Polynomial Baseline Fitting
-##' These functions fit polynomal baselines.
-##'
-##' Both functions fit polynomials to be used as baselines. If `apply.to`
-##' is `NULL`, a hyperSpec object with the polynomial coefficients
-##' is returned, otherwise the polynomials are evaluated on the spectral range
-##' of `apply.to`.
-##'
-##' `spc.fit.poly()` calculates the least squares fit of order
-##' `poly.order` to the *complete* spectra given in `fit.to`.
-##' Thus `fit.to` needs to be cut appropriately.
-##'
-##' @rdname baselines
-##' @concept baseline
-##' @param fit.to hyperSpec object on which the baselines are fitted
-##' @param apply.to hyperSpec object on which the baselines are evaluted
-##'   If `NULL`, a hyperSpec object containing the polynomial
-##'   coefficients rather than evaluted baselines is returned.
-##' @param poly.order order of the polynomial to be used
-##' @param offset.wl should the wavelength range be mapped to -> \[0, delta wl\]?
-##' This enhances numerical stability.
-##' @return hyperSpec object containing the baselines in the spectra
-##'   matrix, either as polynomial coefficients or as polynomials evaluted on
-##'   the spectral range of `apply.to`
-##' @author C. Beleites
-##' @md
-##' @seealso `vignette ("baseline", package = "hyperSpec")`
-##' @keywords manip datagen
-##' @export
-##' @examples
-##'
-##' \dontrun{vignette ("baseline", package = "hyperSpec")}
-##'
-##' spc <- faux_cell[1 : 10]
-##' baselines <- spc.fit.poly(spc[,, c (625 ~ 640, 1785 ~ 1800)], spc)
-##' plot(spc - baselines)
-##'
+#' Polynomial Baseline Fitting
+#' These functions fit polynomal baselines.
+#'
+#' Both functions fit polynomials to be used as baselines. If `apply.to`
+#' is `NULL`, a hyperSpec object with the polynomial coefficients
+#' is returned, otherwise the polynomials are evaluated on the spectral range
+#' of `apply.to`.
+#'
+#' `spc.fit.poly()` calculates the least squares fit of order
+#' `poly.order` to the *complete* spectra given in `fit.to`.
+#' Thus `fit.to` needs to be cut appropriately.
+#'
+#' @rdname baselines
+#' @concept baseline
+#' @param fit.to hyperSpec object on which the baselines are fitted
+#' @param apply.to hyperSpec object on which the baselines are evaluted
+#'   If `NULL`, a hyperSpec object containing the polynomial
+#'   coefficients rather than evaluted baselines is returned.
+#' @param poly.order order of the polynomial to be used
+#' @param offset.wl should the wavelength range be mapped to -> \[0, delta wl\]?
+#' This enhances numerical stability.
+#' @return hyperSpec object containing the baselines in the spectra
+#'   matrix, either as polynomial coefficients or as polynomials evaluted on
+#'   the spectral range of `apply.to`
+#' @author C. Beleites
+#' @md
+#' @seealso `vignette ("baseline", package = "hyperSpec")`
+#' @keywords manip datagen
+#' @export
+#' @examples
+#'
+#' \dontrun{vignette ("baseline", package = "hyperSpec")}
+#'
+#' spc <- faux_cell[1 : 10]
+#' baselines <- spc.fit.poly(spc[,, c (625 ~ 640, 1785 ~ 1800)], spc)
+#' plot(spc - baselines)
+#'
 spc.fit.poly <- function(fit.to, apply.to = NULL, poly.order = 1,
                          offset.wl = !(is.null(apply.to))) {
   chk.hy(fit.to)
@@ -121,34 +121,34 @@ spc.fit.poly <- function(fit.to, apply.to = NULL, poly.order = 1,
   })
 }
 
-##'
-##' `spc.fit.poly.below()` tries to fit the baseline on appropriate spectral
-##' ranges of the spectra in `fit.to`.  For details, see the 
-##' `vignette("baseline")`.
-##' @rdname baselines
-##' @param npts.min minimal number of points used for fitting the polynomial
-##' @param noise noise level to be considered during the fit. It may be given as
-##'   one value for all the spectra, or for each spectrum separately.
-##' @param max.iter stop at the latest after so many iterations.
-##' @param stop.on.increase additional stopping rule: stop if the number of
-##'   support points would increase, regardless whether npts.min was reached or
-##'   not.
-##' @param debuglevel  additional output: `1` shows `npts.min`,
-##'   `2` plots support points for the final baseline of 1st spectrum,
-##'   `3` plots support points for 1st spectrum, `4` plots support
-##'   points for all spectra.
-##' @seealso  see [hyperSpec::options()] for more on `debuglevel`
-##' @export
-##' @examples
-##'
-##' baselines <- spc.fit.poly.below (spc)
-##' plot (spc - baselines)
-##'
-##' spc.fit.poly.below(faux_cell[1:3], debuglevel = 1)
-##' spc.fit.poly.below(faux_cell[1:3], debuglevel = 2)
-##' spc.fit.poly.below(faux_cell[1:3], debuglevel = 3,
-##'                    noise = sqrt (rowMeans (faux_cell[[1:3]])))
-##'
+#'
+#' `spc.fit.poly.below()` tries to fit the baseline on appropriate spectral
+#' ranges of the spectra in `fit.to`.  For details, see the 
+#' `vignette("baseline")`.
+#' @rdname baselines
+#' @param npts.min minimal number of points used for fitting the polynomial
+#' @param noise noise level to be considered during the fit. It may be given as
+#'   one value for all the spectra, or for each spectrum separately.
+#' @param max.iter stop at the latest after so many iterations.
+#' @param stop.on.increase additional stopping rule: stop if the number of
+#'   support points would increase, regardless whether npts.min was reached or
+#'   not.
+#' @param debuglevel  additional output: `1` shows `npts.min`,
+#'   `2` plots support points for the final baseline of 1st spectrum,
+#'   `3` plots support points for 1st spectrum, `4` plots support
+#'   points for all spectra.
+#' @seealso  see [hyperSpec::options()] for more on `debuglevel`
+#' @export
+#' @examples
+#'
+#' baselines <- spc.fit.poly.below (spc)
+#' plot (spc - baselines)
+#'
+#' spc.fit.poly.below(faux_cell[1:3], debuglevel = 1)
+#' spc.fit.poly.below(faux_cell[1:3], debuglevel = 2)
+#' spc.fit.poly.below(faux_cell[1:3], debuglevel = 3,
+#'                    noise = sqrt (rowMeans (faux_cell[[1:3]])))
+#'
 spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
                                npts.min = max(round(nwl(fit.to) * 0.05),
                                               3 * (poly.order + 1)),

--- a/hyperSpec/R/spc.fit.poly.R
+++ b/hyperSpec/R/spc.fit.poly.R
@@ -29,12 +29,13 @@
 #' @export
 #' @examples
 #'
-#' \dontrun{vignette ("baseline", package = "hyperSpec")}
+#' \dontrun{
+#' vignette("baseline", package = "hyperSpec")
+#' }
 #'
-#' spc <- faux_cell[1 : 10]
-#' baselines <- spc.fit.poly(spc[,, c (625 ~ 640, 1785 ~ 1800)], spc)
+#' spc <- faux_cell[1:10]
+#' baselines <- spc.fit.poly(spc[, , c(625 ~ 640, 1785 ~ 1800)], spc)
 #' plot(spc - baselines)
-#'
 spc.fit.poly <- function(fit.to, apply.to = NULL, poly.order = 1,
                          offset.wl = !(is.null(apply.to))) {
   chk.hy(fit.to)
@@ -89,9 +90,11 @@ spc.fit.poly <- function(fit.to, apply.to = NULL, poly.order = 1,
   context("spc.fit.poly")
 
   test_that(
-    "no normalization", {
-    bl.nonorm <- spc.fit.poly(flu, flu, poly.order = 3, offset.wl = FALSE)
-  })
+    "no normalization",
+    {
+      bl.nonorm <- spc.fit.poly(flu, flu, poly.order = 3, offset.wl = FALSE)
+    }
+  )
 
   # test effect of wavelength axis normalization
   # was issue 1 on github
@@ -123,7 +126,7 @@ spc.fit.poly <- function(fit.to, apply.to = NULL, poly.order = 1,
 
 #'
 #' `spc.fit.poly.below()` tries to fit the baseline on appropriate spectral
-#' ranges of the spectra in `fit.to`.  For details, see the 
+#' ranges of the spectra in `fit.to`.  For details, see the
 #' `vignette("baseline")`.
 #' @rdname baselines
 #' @param npts.min minimal number of points used for fitting the polynomial
@@ -141,17 +144,20 @@ spc.fit.poly <- function(fit.to, apply.to = NULL, poly.order = 1,
 #' @export
 #' @examples
 #'
-#' baselines <- spc.fit.poly.below (spc)
-#' plot (spc - baselines)
+#' baselines <- spc.fit.poly.below(spc)
+#' plot(spc - baselines)
 #'
 #' spc.fit.poly.below(faux_cell[1:3], debuglevel = 1)
 #' spc.fit.poly.below(faux_cell[1:3], debuglevel = 2)
-#' spc.fit.poly.below(faux_cell[1:3], debuglevel = 3,
-#'                    noise = sqrt (rowMeans (faux_cell[[1:3]])))
-#'
+#' spc.fit.poly.below(faux_cell[1:3],
+#'   debuglevel = 3,
+#'   noise = sqrt(rowMeans(faux_cell[[1:3]]))
+#' )
 spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
-                               npts.min = max(round(nwl(fit.to) * 0.05),
-                                              3 * (poly.order + 1)),
+                               npts.min = max(
+                                 round(nwl(fit.to) * 0.05),
+                                 3 * (poly.order + 1)
+                               ),
                                noise = 0, offset.wl = FALSE,
                                max.iter = nwl(fit.to),
                                stop.on.increase = FALSE,
@@ -209,28 +215,29 @@ spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
       use <- y[, i] < bl + noise[i] & !is.na(y[, i])
 
       if (debuglevel == 3L && i == 1L || debuglevel >= 4L) {
-
-        plot(fit.to[i, , use], add = TRUE,
-             lines.args = list(pch = 20, type = "p"), col = cols[iter])
+        plot(fit.to[i, , use],
+          add = TRUE,
+          lines.args = list(pch = 20, type = "p"), col = cols[iter]
+        )
 
         lines(fit.to@wavelength, bl, col = cols[iter])
         lines(fit.to@wavelength, bl + noise, col = cols[iter], lty = 2)
 
-        message("Iteration ", iter, ": ", sum(use, na.rm = TRUE),
-                " support points")
+        message(
+          "Iteration ", iter, ": ", sum(use, na.rm = TRUE),
+          " support points"
+        )
       }
 
       if ((sum(use, na.rm = TRUE) < npts.min) ||
-          all(use == use.old, na.rm = TRUE)) {
-
+        all(use == use.old, na.rm = TRUE)) {
         break
       }
 
       if (sum(use, na.rm = TRUE) > sum(use.old, na.rm = TRUE) &&
-          stop.on.increase) {
-
+        stop.on.increase) {
         warning(
-          "Iteration ", iter,": ",
+          "Iteration ", iter, ": ",
           "Number of support points is about to increase again. ",
           "Stopping with ", sum(use.old, na.rm = TRUE),
           " support points, but this may be a local minimum."
@@ -241,30 +248,33 @@ spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
     }
 
     if (iter == max.iter) {
-
       if ((sum(use.old, na.rm = TRUE) == npts.min) &&
         !all(use == use.old, na.rm = TRUE) &&
         !sum(use, na.rm = TRUE) < npts.min) {
-
-        warning("Reached npts.min, but the solution is not stable. ",
-          "Stopped after ", iter, " iterations.")
-
+        warning(
+          "Reached npts.min, but the solution is not stable. ",
+          "Stopped after ", iter, " iterations."
+        )
       } else if (sum(use, na.rm = TRUE) >= npts.min) {
-
-        warning("Stopped after ", iter, " iterations with ",
-                sum(use.old, na.rm = TRUE), " support points.")
+        warning(
+          "Stopped after ", iter, " iterations with ",
+          sum(use.old, na.rm = TRUE), " support points."
+        )
       }
-
     }
 
     if (debuglevel >= 1L) {
-      message(sprintf("spectrum % 6i: % 5i support points, noise = %0.1f, %3i iterations",
-                      i, sum(use.old, na.rm = TRUE), noise[i], iter))
+      message(sprintf(
+        "spectrum % 6i: % 5i support points, noise = %0.1f, %3i iterations",
+        i, sum(use.old, na.rm = TRUE), noise[i], iter
+      ))
     }
 
     if ((debuglevel == 2L) && (i == 1L)) {
-      plot(fit.to[i, , use.old], add = TRUE,
-           lines.args = list(pch = 20, type = "p"), col = cols[iter])
+      plot(fit.to[i, , use.old],
+        add = TRUE,
+        lines.args = list(pch = 20, type = "p"), col = cols[iter]
+      )
 
       lines(fit.to@wavelength, bl, col = cols[iter])
 
@@ -299,10 +309,14 @@ spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
   context("spc.fit.poly.below")
 
   test_that(
-    "no normalization", {
-    bl.nonorm <- spc.fit.poly.below(flu, flu, poly.order = 3, offset.wl = FALSE,
-                                    npts.min = 25)
-  })
+    "no normalization",
+    {
+      bl.nonorm <- spc.fit.poly.below(flu, flu,
+        poly.order = 3, offset.wl = FALSE,
+        npts.min = 25
+      )
+    }
+  )
 
   # test effect of wavelength axis normalization
   # was issue 1 on github
@@ -310,14 +324,20 @@ spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
   wl(tmp) <- wl(tmp) + 1e4
 
   test_that("normalization/offset wavelengths", {
-    expect_error(spc.fit.poly.below(tmp, poly.order = 3, offset.wl = FALSE,
-                                    npts.min = 25))
+    expect_error(spc.fit.poly.below(tmp,
+      poly.order = 3, offset.wl = FALSE,
+      npts.min = 25
+    ))
 
-    bl.1e4 <- spc.fit.poly.below(tmp, tmp, poly.order = 3, offset.wl = TRUE,
-                                 npts.min = 25)
+    bl.1e4 <- spc.fit.poly.below(tmp, tmp,
+      poly.order = 3, offset.wl = TRUE,
+      npts.min = 25
+    )
 
-    bl.nonorm <- spc.fit.poly.below(flu, flu, poly.order = 3, offset.wl = FALSE,
-                                    npts.min = 25)
+    bl.nonorm <- spc.fit.poly.below(flu, flu,
+      poly.order = 3, offset.wl = FALSE,
+      npts.min = 25
+    )
 
     expect_equal(bl.nonorm[[]], bl.1e4[[]])
   })
@@ -327,21 +347,29 @@ spc.fit.poly.below <- function(fit.to, apply.to = fit.to, poly.order = 1,
     # tmp <- chondro[103,,c(600 ~ 700, 1650 ~ 1800)]
     # tmp[[]] <- round(tmp[[]], digits = 1)
 
-    tmp <- t(c(331.8, 336.7, 325.3, 313.2, 328.6, 348.5, 304.6, 286.8, 283.9,
-               294.2, 323.3, 312.2, 298.8, 299.8, 299.7, 301.8, 305.2, 308.4,
-               311.2, 318.2, 321, 322.1, 323, 336.7, 362.1, 776.9, 835.3, 902,
-               967, 1019.3, 1020.5, 942.3, 848.8, 774.8, 701.1, 612.1, 514.4,
-               420.8, 340.1, 282.5, 242.7, 220, 206, 196.8, 192.1, 189.1, 185.3,
-               184, 181.8, 178.7, 178.8, 174.8, 175.6, 173.2, 174.3, 173.1,
-               173.2, 171.4, 171.5, 171.9, 171.3, 171.1, 171.8))
+    tmp <- t(c(
+      331.8, 336.7, 325.3, 313.2, 328.6, 348.5, 304.6, 286.8, 283.9,
+      294.2, 323.3, 312.2, 298.8, 299.8, 299.7, 301.8, 305.2, 308.4,
+      311.2, 318.2, 321, 322.1, 323, 336.7, 362.1, 776.9, 835.3, 902,
+      967, 1019.3, 1020.5, 942.3, 848.8, 774.8, 701.1, 612.1, 514.4,
+      420.8, 340.1, 282.5, 242.7, 220, 206, 196.8, 192.1, 189.1, 185.3,
+      184, 181.8, 178.7, 178.8, 174.8, 175.6, 173.2, 174.3, 173.1,
+      173.2, 171.4, 171.5, 171.9, 171.3, 171.1, 171.8
+    ))
     tmp <- as.hyperSpec(tmp)
     wl(tmp) <- c(seq(602, 698, by = 4), seq(1650, 1798, by = 4))
 
-    expect_warning(spc.fit.poly.below(tmp, npts.min = 2),
-                   "Reached npts.min, but the solution is not stable.")
-    expect_warning(spc.fit.poly.below(tmp, npts.min = 2,
-                                      stop.on.increase = TRUE),
-                   "Number of support points is about to increase again.")
+    expect_warning(
+      spc.fit.poly.below(tmp, npts.min = 2),
+      "Reached npts.min, but the solution is not stable."
+    )
+    expect_warning(
+      spc.fit.poly.below(tmp,
+        npts.min = 2,
+        stop.on.increase = TRUE
+      ),
+      "Number of support points is about to increase again."
+    )
   })
 
   test_that("spectrum containing NA", {

--- a/hyperSpec/R/spc.identify.R
+++ b/hyperSpec/R/spc.identify.R
@@ -1,115 +1,115 @@
-##' Identifying Spectra and Spectral Data Points
-##' This function allows to identify the spectrum and the wavelength of a point
-##' in a plot produced by \code{\link{plotspc}}.
-##'
-##' This function first finds the spectrum with a point closest to the clicked
-##' position (see \code{\link[graphics]{locator}}). The distance to the clicked
-##' point is evaluated relative to the size of the tolerance window.
-##'
-##' In a second step, \code{max.fn} searches for the actual point to label
-##' within the specified wavelength window of that spectrum. This allows to
-##' label maxima (or minima) without demanding too precise clicks. Currently,
-##' the following functions to determine the precise point: \tabular{ll}{
-##' spc.point.default \tab uses the clicked wavelength together with its
-##' spectral intensity\cr spc.point.max \tab the point with the highest
-##' intensity in the wavelength window \cr spc.point.min \tab the point with
-##' the lowest intensity in the wavelength window \cr spc.point.sqr \tab
-##' maximum of a parabola fit throug the point with highest intensity and the
-##' two surrounding points \cr } \code{point.fn} is called with the arguments
-##' \code{wl} containing the considered wavelength window, \code{spc} the
-##' respective intensities of the closest spectrum, and \code{wlclick} the
-##' wavelength that was clicked. They return a vector of two elements
-##' (wavelength and intensity).
-##'
-##' As a last step, a label for the point produced by \code{formatter} and
-##' plotted using \code{\link[graphics]{text}}. Currently, the following
-##' \code{formatter}s are available: \tabular{ll}{ spc.label.default \tab
-##' spectrum number, wavelength \cr spc.label.wlonly \tab wavelength\cr }
-##' \code{formatter} functions receive the number of the spectrum \code{ispc},
-##' the wavelength \code{wl}, and the spectral intensity \code{spc} and produce
-##' a character variable suitable for labelling. The predefined formatters
-##' surround the label text by spaces in order to easily have an appropriate
-##' offset from the point of the spectrum.
-##'
-##' The warning issued if no spectral point is inside the tolerance window may
-##' be switched of by \code{warn = FALSE}. In that case, the click will produce
-##' a row of \code{NA}s in the resulting data.frame.
-##'
-##' \code{spc.identify} uses option \code{debuglevel} to determine whether debugging output should be
-##' produced. \code{debuglevel == 2} will plot the tolerance window for every clicked point,
-##' \code{debuglevel == 1} will plot the tolerance window only if no data point was inside.  See
-##' \code{\link[hyperSpec:options]{hyperSpec options}} for details about retrieving and setting
-##' options.
-##'
-##' You may want to adjust the plot's \code{ylim} to ensure that the labels are
-##' not clipped. As a dirty shortcut, \code{xpd = NA} may help.
-##'
-##' @aliases spc.identify spc.label.default spc.label.wlonly spc.point.default
-##'   spc.point.max spc.point.min spc.point.sqr
-##' @param x either the abscissa coordinates or the list returned by
-##'   \code{\link{plotspc}}
-##' @param y the ordinate values. Giving \code{y} will override any values from
-##'   \code{x$y}.
-##' @param wavelengths the wavelengths for the data points. Giving
-##'   \code{wavelengths} will override any values from \code{x$wavelengths}.
-##' @param tol.wl,tol.spc tolerance in wavelength and spectral intensity to
-##'   search around the clicked point. See details.
-##' @param point.fn \code{function (wl, spc, wlclick)} to determine the actual
-##'   point to label, see details.
-##' @param formatter \code{function (i, wl, spc)} that produces the labels. If
-##'   \code{NULL}, no labels are displayed.
-##' @param ... passed to \code{\link[graphics]{text}} in order to produce the
-##'   labels
-##' @param  cex,adj,srt see \code{\link[graphics]{par}}
-##' @param warn Should the user be warned if no point is in the considered
-##'   window? In addition, see the discussion of option \code{debuglevel} in
-##'   the details.
-##'
-##' If \code{FALSE}, the resulting data.frame will have a row of \code{NA}s
-##'   instead.
-##' @param delta \code{spc.point.sqr} fits the parabola in the window wlclick
-##'   \eqn{\pm}{+-} delta points.
-##' @return a \code{data.frame} with columns \item{ispc}{spectra indices of the
-##'   identified points, i.e. the rows of the \code{hyperSpec} object that was
-##'   plotted.
-##'
-##' If \code{ispc} is given, \code{ispc [i]} is returned rather than \code{i}.
-##'   } \item{wavelengths}{the wavelengths of the identified points}
-##'   \item{spc}{the intensities of the identified points}
-##' @author C. Beleites
-##' @seealso \code{\link[graphics]{locator}}, \code{\link{plotspc}},
-##'   \code{\link[hyperSpec:options]{hyperSpec options}}
-##'
-##' \code{\link{map.identify}} \code{\link{map.sel.poly}}
-##' @keywords iplot
-##' @rdname spc-identify
-##' @export
-##' @examples
-##'
-##' if (interactive ()){
-##' ispc <- sample (nrow (laser), 10)
-##' ispc
-##'
-##' identified <- spc.identify (plotspc (laser[ispc]))
-##'
-##' ## convert to the "real" spectra indices
-##' ispc [identified$ispc]
-##' identified$wl
-##' identified$spc
-##'
-##' ## allow the labels to be plotted into the plot margin
-##' spc.identify (plotspc (laser[ispc]), ispc = ispc, xpd = NA)
-##'
-##' spc.identify (plotspc (paracetamol, xoffset = 1100,
-##'               wl.range = c (600 ~ 1700, 2900 ~ 3150)),
-##'               formatter = spc.label.wlonly)
-##'
-##' ## looking for minima
-##' spc.identify (plot (-paracetamol, wl.reverse = TRUE),
-##'               point.fn = spc.point.min, adj = c (1, 0.5))
-##'
-##' }
-##'
+#' Identifying Spectra and Spectral Data Points
+#' This function allows to identify the spectrum and the wavelength of a point
+#' in a plot produced by \code{\link{plotspc}}.
+#'
+#' This function first finds the spectrum with a point closest to the clicked
+#' position (see \code{\link[graphics]{locator}}). The distance to the clicked
+#' point is evaluated relative to the size of the tolerance window.
+#'
+#' In a second step, \code{max.fn} searches for the actual point to label
+#' within the specified wavelength window of that spectrum. This allows to
+#' label maxima (or minima) without demanding too precise clicks. Currently,
+#' the following functions to determine the precise point: \tabular{ll}{
+#' spc.point.default \tab uses the clicked wavelength together with its
+#' spectral intensity\cr spc.point.max \tab the point with the highest
+#' intensity in the wavelength window \cr spc.point.min \tab the point with
+#' the lowest intensity in the wavelength window \cr spc.point.sqr \tab
+#' maximum of a parabola fit throug the point with highest intensity and the
+#' two surrounding points \cr } \code{point.fn} is called with the arguments
+#' \code{wl} containing the considered wavelength window, \code{spc} the
+#' respective intensities of the closest spectrum, and \code{wlclick} the
+#' wavelength that was clicked. They return a vector of two elements
+#' (wavelength and intensity).
+#'
+#' As a last step, a label for the point produced by \code{formatter} and
+#' plotted using \code{\link[graphics]{text}}. Currently, the following
+#' \code{formatter}s are available: \tabular{ll}{ spc.label.default \tab
+#' spectrum number, wavelength \cr spc.label.wlonly \tab wavelength\cr }
+#' \code{formatter} functions receive the number of the spectrum \code{ispc},
+#' the wavelength \code{wl}, and the spectral intensity \code{spc} and produce
+#' a character variable suitable for labelling. The predefined formatters
+#' surround the label text by spaces in order to easily have an appropriate
+#' offset from the point of the spectrum.
+#'
+#' The warning issued if no spectral point is inside the tolerance window may
+#' be switched of by \code{warn = FALSE}. In that case, the click will produce
+#' a row of \code{NA}s in the resulting data.frame.
+#'
+#' \code{spc.identify} uses option \code{debuglevel} to determine whether debugging output should be
+#' produced. \code{debuglevel == 2} will plot the tolerance window for every clicked point,
+#' \code{debuglevel == 1} will plot the tolerance window only if no data point was inside.  See
+#' \code{\link[hyperSpec:options]{hyperSpec options}} for details about retrieving and setting
+#' options.
+#'
+#' You may want to adjust the plot's \code{ylim} to ensure that the labels are
+#' not clipped. As a dirty shortcut, \code{xpd = NA} may help.
+#'
+#' @aliases spc.identify spc.label.default spc.label.wlonly spc.point.default
+#'   spc.point.max spc.point.min spc.point.sqr
+#' @param x either the abscissa coordinates or the list returned by
+#'   \code{\link{plotspc}}
+#' @param y the ordinate values. Giving \code{y} will override any values from
+#'   \code{x$y}.
+#' @param wavelengths the wavelengths for the data points. Giving
+#'   \code{wavelengths} will override any values from \code{x$wavelengths}.
+#' @param tol.wl,tol.spc tolerance in wavelength and spectral intensity to
+#'   search around the clicked point. See details.
+#' @param point.fn \code{function (wl, spc, wlclick)} to determine the actual
+#'   point to label, see details.
+#' @param formatter \code{function (i, wl, spc)} that produces the labels. If
+#'   \code{NULL}, no labels are displayed.
+#' @param ... passed to \code{\link[graphics]{text}} in order to produce the
+#'   labels
+#' @param  cex,adj,srt see \code{\link[graphics]{par}}
+#' @param warn Should the user be warned if no point is in the considered
+#'   window? In addition, see the discussion of option \code{debuglevel} in
+#'   the details.
+#'
+#' If \code{FALSE}, the resulting data.frame will have a row of \code{NA}s
+#'   instead.
+#' @param delta \code{spc.point.sqr} fits the parabola in the window wlclick
+#'   \eqn{\pm}{+-} delta points.
+#' @return a \code{data.frame} with columns \item{ispc}{spectra indices of the
+#'   identified points, i.e. the rows of the \code{hyperSpec} object that was
+#'   plotted.
+#'
+#' If \code{ispc} is given, \code{ispc [i]} is returned rather than \code{i}.
+#'   } \item{wavelengths}{the wavelengths of the identified points}
+#'   \item{spc}{the intensities of the identified points}
+#' @author C. Beleites
+#' @seealso \code{\link[graphics]{locator}}, \code{\link{plotspc}},
+#'   \code{\link[hyperSpec:options]{hyperSpec options}}
+#'
+#' \code{\link{map.identify}} \code{\link{map.sel.poly}}
+#' @keywords iplot
+#' @rdname spc-identify
+#' @export
+#' @examples
+#'
+#' if (interactive ()){
+#' ispc <- sample (nrow (laser), 10)
+#' ispc
+#'
+#' identified <- spc.identify (plotspc (laser[ispc]))
+#'
+#' ## convert to the "real" spectra indices
+#' ispc [identified$ispc]
+#' identified$wl
+#' identified$spc
+#'
+#' ## allow the labels to be plotted into the plot margin
+#' spc.identify (plotspc (laser[ispc]), ispc = ispc, xpd = NA)
+#'
+#' spc.identify (plotspc (paracetamol, xoffset = 1100,
+#'               wl.range = c (600 ~ 1700, 2900 ~ 3150)),
+#'               formatter = spc.label.wlonly)
+#'
+#' ## looking for minima
+#' spc.identify (plot (-paracetamol, wl.reverse = TRUE),
+#'               point.fn = spc.point.min, adj = c (1, 0.5))
+#'
+#' }
+#'
 spc.identify <- function(x, y = NULL, wavelengths = NULL, ispc = NULL,
                          tol.wl = diff(range(x)) / 200,
                          tol.spc = diff(range(y)) / 50,
@@ -214,32 +214,32 @@ spc.identify <- function(x, y = NULL, wavelengths = NULL, ispc = NULL,
   pts [seq_len(pos - 1), ]
 }
 
-##' @rdname spc-identify
-##' @param wl the wavelength to label
-##' @param spc the intensity to label
-##' @param wlclick the clicked wavelength
-##' @export
+#' @rdname spc-identify
+#' @param wl the wavelength to label
+#' @param spc the intensity to label
+#' @param wlclick the clicked wavelength
+#' @export
 spc.point.max <- function(wl, spc, wlclick) {
   i <- which.max(spc)
   c(wl = wl [i], spc = spc [i])
 }
 
-##' @rdname spc-identify
-##' @export
+#' @rdname spc-identify
+#' @export
 spc.point.default <- function(wl, spc, wlclick) {
   i <- round(approx(wl, seq_along(wl), wlclick, rule = 2)$y)
   c(wl = wl [], spc = spc [i])
 }
 
-##' @rdname spc-identify
-##' @export
+#' @rdname spc-identify
+#' @export
 spc.point.min <- function(wl, spc, wlclick) {
   i <- which.min(spc)
   c(wl = wl [i], spc = spc [i])
 }
 
-##' @rdname spc-identify
-##' @export
+#' @rdname spc-identify
+#' @export
 spc.point.sqr <- function(wl, spc, wlclick, delta = 1L) {
   i <- which.max(spc)
 
@@ -260,18 +260,18 @@ spc.point.sqr <- function(wl, spc, wlclick, delta = 1L) {
   }
 }
 
-##' @param ispc if a selection of spectra was plotted, their indices can be
-##'   given in \code{ispc}. In this case \code{ispc [i]} is returned rather
-##'   than \code{i}.
-##' @param digits how many digits of the wavelength should be displayed?
-##' @rdname spc-identify
-##' @export
+#' @param ispc if a selection of spectra was plotted, their indices can be
+#'   given in \code{ispc}. In this case \code{ispc [i]} is returned rather
+#'   than \code{i}.
+#' @param digits how many digits of the wavelength should be displayed?
+#' @rdname spc-identify
+#' @export
 spc.label.default <- function(ispc, wl, spc, digits = 3) {
   sprintf(" %i, %s ", ispc, format(wl, digits = digits))
 }
 
-##' @rdname spc-identify
-##' @export
+#' @rdname spc-identify
+#' @export
 spc.label.wlonly <- function(ispc, wl, spc, digits = 3) {
   sprintf(" %s ", format(wl, digits = digits))
 }

--- a/hyperSpec/R/spc.identify.R
+++ b/hyperSpec/R/spc.identify.R
@@ -86,30 +86,32 @@
 #' @export
 #' @examples
 #'
-#' if (interactive ()){
-#' ispc <- sample (nrow (laser), 10)
-#' ispc
+#' if (interactive()) {
+#'   ispc <- sample(nrow(laser), 10)
+#'   ispc
 #'
-#' identified <- spc.identify (plotspc (laser[ispc]))
+#'   identified <- spc.identify(plotspc(laser[ispc]))
 #'
-#' ## convert to the "real" spectra indices
-#' ispc [identified$ispc]
-#' identified$wl
-#' identified$spc
+#'   ## convert to the "real" spectra indices
+#'   ispc [identified$ispc]
+#'   identified$wl
+#'   identified$spc
 #'
-#' ## allow the labels to be plotted into the plot margin
-#' spc.identify (plotspc (laser[ispc]), ispc = ispc, xpd = NA)
+#'   ## allow the labels to be plotted into the plot margin
+#'   spc.identify(plotspc(laser[ispc]), ispc = ispc, xpd = NA)
 #'
-#' spc.identify (plotspc (paracetamol, xoffset = 1100,
-#'               wl.range = c (600 ~ 1700, 2900 ~ 3150)),
-#'               formatter = spc.label.wlonly)
+#'   spc.identify(plotspc(paracetamol,
+#'     xoffset = 1100,
+#'     wl.range = c(600 ~ 1700, 2900 ~ 3150)
+#'   ),
+#'   formatter = spc.label.wlonly
+#'   )
 #'
-#' ## looking for minima
-#' spc.identify (plot (-paracetamol, wl.reverse = TRUE),
-#'               point.fn = spc.point.min, adj = c (1, 0.5))
-#'
+#'   ## looking for minima
+#'   spc.identify(plot(-paracetamol, wl.reverse = TRUE),
+#'     point.fn = spc.point.min, adj = c(1, 0.5)
+#'   )
 #' }
-#'
 spc.identify <- function(x, y = NULL, wavelengths = NULL, ispc = NULL,
                          tol.wl = diff(range(x)) / 200,
                          tol.spc = diff(range(y)) / 50,

--- a/hyperSpec/R/spc.loess.R
+++ b/hyperSpec/R/spc.loess.R
@@ -1,32 +1,32 @@
-##' loess smoothing interpolation for spectra
-##' Spectra can be smoothed and interpolated on a new wavelength axis using
-##' \code{\link[stats]{loess}}.
-##'
-##' Applying \code{\link[stats]{loess}} to each of the spectra, an interpolation onto a new
-##' wavelength axis is performed.  At the same time, the specta are smoothed in order to increase the
-##' signal : noise ratio. See \code{\link[stats]{loess}} and \code{\link[stats]{loess.control}} on
-##' the parameters that control the amount of smoothing.
-##'
-##' @param spc the \code{hyperSpec} object
-##' @param newx wavelengh axis to interpolate on
-##' @param enp.target,surface,... parameters for \code{\link[stats]{loess}} and
-##' \code{\link[stats]{loess.control}}.
-##' @return a new \code{hyperspec} object.
-##' @rdname spc-loess
-##' @export
-##' @author C. Beleites
-##' @seealso \code{\link[stats]{loess}}, \code{\link[stats]{loess.control}}
-##' @keywords manip datagen
-##' @examples
-##'
-##' plot (flu, col = "darkgray")
-##' plot (spc.loess(flu, seq (420, 470, 5)), add = TRUE, col = "red")
-##'
-##' flu [[3, ]] <- NA_real_
-##' smooth <- spc.loess(flu, seq (420, 470, 5))
-##' smooth [[, ]]
-##' plot (smooth, add = TRUE, col = "blue")
-##'
+#' loess smoothing interpolation for spectra
+#' Spectra can be smoothed and interpolated on a new wavelength axis using
+#' \code{\link[stats]{loess}}.
+#'
+#' Applying \code{\link[stats]{loess}} to each of the spectra, an interpolation onto a new
+#' wavelength axis is performed.  At the same time, the specta are smoothed in order to increase the
+#' signal : noise ratio. See \code{\link[stats]{loess}} and \code{\link[stats]{loess.control}} on
+#' the parameters that control the amount of smoothing.
+#'
+#' @param spc the \code{hyperSpec} object
+#' @param newx wavelengh axis to interpolate on
+#' @param enp.target,surface,... parameters for \code{\link[stats]{loess}} and
+#' \code{\link[stats]{loess.control}}.
+#' @return a new \code{hyperspec} object.
+#' @rdname spc-loess
+#' @export
+#' @author C. Beleites
+#' @seealso \code{\link[stats]{loess}}, \code{\link[stats]{loess.control}}
+#' @keywords manip datagen
+#' @examples
+#'
+#' plot (flu, col = "darkgray")
+#' plot (spc.loess(flu, seq (420, 470, 5)), add = TRUE, col = "red")
+#'
+#' flu [[3, ]] <- NA_real_
+#' smooth <- spc.loess(flu, seq (420, 470, 5))
+#' smooth [[, ]]
+#' plot (smooth, add = TRUE, col = "blue")
+#'
 spc.loess <- function(spc, newx, enp.target = nwl(spc) / 4,
                       surface = "direct", ...) {
   .loess <- function(y, x) {

--- a/hyperSpec/R/spc.loess.R
+++ b/hyperSpec/R/spc.loess.R
@@ -22,9 +22,9 @@
 #' plot(flu, col = "darkgray")
 #' plot(spc.loess(flu, seq(420, 470, 5)), add = TRUE, col = "red")
 #'
-#' flu [[3, ]] <- NA_real_
+#' flu[[3, ]] <- NA_real_
 #' smooth <- spc.loess(flu, seq(420, 470, 5))
-#' smooth [[, ]]
+#' smooth[[, ]]
 #' plot(smooth, add = TRUE, col = "blue")
 spc.loess <- function(spc, newx, enp.target = nwl(spc) / 4,
                       surface = "direct", ...) {

--- a/hyperSpec/R/spc.loess.R
+++ b/hyperSpec/R/spc.loess.R
@@ -19,14 +19,13 @@
 #' @keywords manip datagen
 #' @examples
 #'
-#' plot (flu, col = "darkgray")
-#' plot (spc.loess(flu, seq (420, 470, 5)), add = TRUE, col = "red")
+#' plot(flu, col = "darkgray")
+#' plot(spc.loess(flu, seq(420, 470, 5)), add = TRUE, col = "red")
 #'
 #' flu [[3, ]] <- NA_real_
-#' smooth <- spc.loess(flu, seq (420, 470, 5))
+#' smooth <- spc.loess(flu, seq(420, 470, 5))
 #' smooth [[, ]]
-#' plot (smooth, add = TRUE, col = "blue")
-#'
+#' plot(smooth, add = TRUE, col = "blue")
 spc.loess <- function(spc, newx, enp.target = nwl(spc) / 4,
                       surface = "direct", ...) {
   .loess <- function(y, x) {

--- a/hyperSpec/R/spc.rubberband.R
+++ b/hyperSpec/R/spc.rubberband.R
@@ -1,32 +1,32 @@
-##' Rubberband baseline
-##'
-##' Baseline with support points determined from a convex hull of the spectrum.
-##'
-##' Use \code{debuglevel >= 1} to obtain debug plots, either directly via function argument or by setting hyperSpec's \code{debuglevel} option.
-##' @title Rubberband baseline correction
-##' @param spc hyperSpec object
-##' @param ... further parameters handed to \code{\link[stats]{smooth.spline}}
-##' @param upper logical indicating whether the lower or upper part of the hull should be used
-##' @param noise noise level to be taken into account
-##' @param spline logical indicating whether the baseline should be an interpolating spline through
-##' the support points or piecewise linear.
-##' @return hyperSpec object containing the baselines
-##' @rdname spc-rubberband
-##' @author Claudia Beleites
-##' @seealso \code{\link[hyperSpec]{spc.fit.poly}}, \code{\link[hyperSpec]{spc.fit.poly.below}}
-##'
-##' \code{vignette ("baseline")}
-##'
-##' \code{\link[hyperSpec]{hy.setOptions}}
-##'
-##' @note This function is still experimental
-##' @export
-##' @examples
-##' plot (paracetamol [,, 175 ~ 1800])
-##' bl <- spc.rubberband (paracetamol [,, 175 ~ 1800], noise = 300, df = 20)
-##' plot (bl, add = TRUE, col = 2)
-##'
-##' plot (paracetamol [,, 175 ~ 1800] - bl)
+#' Rubberband baseline
+#'
+#' Baseline with support points determined from a convex hull of the spectrum.
+#'
+#' Use \code{debuglevel >= 1} to obtain debug plots, either directly via function argument or by setting hyperSpec's \code{debuglevel} option.
+#' @title Rubberband baseline correction
+#' @param spc hyperSpec object
+#' @param ... further parameters handed to \code{\link[stats]{smooth.spline}}
+#' @param upper logical indicating whether the lower or upper part of the hull should be used
+#' @param noise noise level to be taken into account
+#' @param spline logical indicating whether the baseline should be an interpolating spline through
+#' the support points or piecewise linear.
+#' @return hyperSpec object containing the baselines
+#' @rdname spc-rubberband
+#' @author Claudia Beleites
+#' @seealso \code{\link[hyperSpec]{spc.fit.poly}}, \code{\link[hyperSpec]{spc.fit.poly.below}}
+#'
+#' \code{vignette ("baseline")}
+#'
+#' \code{\link[hyperSpec]{hy.setOptions}}
+#'
+#' @note This function is still experimental
+#' @export
+#' @examples
+#' plot (paracetamol [,, 175 ~ 1800])
+#' bl <- spc.rubberband (paracetamol [,, 175 ~ 1800], noise = 300, df = 20)
+#' plot (bl, add = TRUE, col = 2)
+#'
+#' plot (paracetamol [,, 175 ~ 1800] - bl)
 
 spc.rubberband <- function(spc, ..., upper = FALSE, noise = 0, spline = TRUE) {
   spc <- orderwl(spc)
@@ -42,7 +42,7 @@ spc.rubberband <- function(spc, ..., upper = FALSE, noise = 0, spline = TRUE) {
   spc
 }
 
-##' @importFrom grDevices chull
+#' @importFrom grDevices chull
 .rubberband <- function(x, y, noise, spline, ..., debuglevel = hy.getOption("debuglevel")) {
   for (s in seq_len(nrow(y))) {
     use <- which(!is.na(y [s, ]))

--- a/hyperSpec/R/spc.rubberband.R
+++ b/hyperSpec/R/spc.rubberband.R
@@ -108,37 +108,37 @@ spc.rubberband <- function(spc, ..., upper = FALSE, noise = 0, spline = TRUE) {
 
   test_that("spectrum containing NA inside", {
     tmp <- paracetamol
-    tmp [[, , 400]] <- NA
+    tmp[[, , 400]] <- NA
 
     coefs <- spc.rubberband(tmp)
     expect_equal(
-      coefs [[, , !is.na(tmp)]],
-      spc.rubberband(paracetamol [, , !is.na(tmp)]) [[]]
+      coefs[[, , !is.na(tmp)]],
+      spc.rubberband(paracetamol [, , !is.na(tmp)])[[]]
     )
 
     ## bug was: all coefficients were silently 0
-    expect_true(all(abs(coefs [[]]) > sqrt(.Machine$double.eps)))
+    expect_true(all(abs(coefs[[]]) > sqrt(.Machine$double.eps)))
   })
 
   test_that("spectrum containing NA at first wavelength (issue #95)", {
     tmp <- paracetamol
-    tmp [[, , 1, wl.index = TRUE]] <- NA
+    tmp[[, , 1, wl.index = TRUE]] <- NA
 
     coefs <- spc.rubberband(tmp)
     expect_equal(
-      coefs [[, , !is.na(tmp)]],
-      spc.rubberband(paracetamol [, , !is.na(tmp)]) [[]]
+      coefs[[, , !is.na(tmp)]],
+      spc.rubberband(paracetamol [, , !is.na(tmp)])[[]]
     )
   })
 
   test_that("spectrum containing NA at end", {
     tmp <- paracetamol [1]
-    tmp [[, , nwl(paracetamol), wl.index = TRUE]] <- NA
+    tmp[[, , nwl(paracetamol), wl.index = TRUE]] <- NA
 
     coefs <- spc.rubberband(tmp)
     expect_equal(
-      coefs [[, , !is.na(tmp)]],
-      spc.rubberband(paracetamol [1, , !is.na(tmp)]) [[]]
+      coefs[[, , !is.na(tmp)]],
+      spc.rubberband(paracetamol [1, , !is.na(tmp)])[[]]
     )
   })
 }

--- a/hyperSpec/R/spc.rubberband.R
+++ b/hyperSpec/R/spc.rubberband.R
@@ -22,12 +22,11 @@
 #' @note This function is still experimental
 #' @export
 #' @examples
-#' plot (paracetamol [,, 175 ~ 1800])
-#' bl <- spc.rubberband (paracetamol [,, 175 ~ 1800], noise = 300, df = 20)
-#' plot (bl, add = TRUE, col = 2)
+#' plot(paracetamol [, , 175 ~ 1800])
+#' bl <- spc.rubberband(paracetamol [, , 175 ~ 1800], noise = 300, df = 20)
+#' plot(bl, add = TRUE, col = 2)
 #'
-#' plot (paracetamol [,, 175 ~ 1800] - bl)
-
+#' plot(paracetamol [, , 175 ~ 1800] - bl)
 spc.rubberband <- function(spc, ..., upper = FALSE, noise = 0, spline = TRUE) {
   spc <- orderwl(spc)
 

--- a/hyperSpec/R/spc.spline.R
+++ b/hyperSpec/R/spc.spline.R
@@ -14,15 +14,15 @@
 #' @note This function is still experimental
 #' @export
 #' @examples
-#' p <- paracetamol [,,2200 ~ max]
-#' plot (p, col = "gray")
-#' smooth <- spc.smooth.spline (p [,, c (2200 ~ 2400, 2500 ~ 2825, 3150 ~ max)],
-#'                              wl (paracetamol [,, 2200 ~ max]),
-#'                              df = 4, spar = 1)
-#' plot (smooth, col = "red", add = TRUE)
+#' p <- paracetamol [, , 2200 ~ max]
+#' plot(p, col = "gray")
+#' smooth <- spc.smooth.spline(p [, , c(2200 ~ 2400, 2500 ~ 2825, 3150 ~ max)],
+#'   wl(paracetamol [, , 2200 ~ max]),
+#'   df = 4, spar = 1
+#' )
+#' plot(smooth, col = "red", add = TRUE)
 #'
-#' plot (p - smooth)
-#'
+#' plot(p - smooth)
 spc.smooth.spline <- function(spc, newx = wl(spc), ...) {
   .spline <- function(x, y, newx) {
     pts <- !is.na(y)

--- a/hyperSpec/R/spc.spline.R
+++ b/hyperSpec/R/spc.spline.R
@@ -1,28 +1,28 @@
-##' Smoothing splines
-##'
-##' Spectral smoothing by splines
-##' @title Spectral smoothing by splines
-##' @param spc hyperSpec object
-##' @param newx  wavelengh axis to interpolate on
-##' @param ... further parameters handed to \code{\link[stats]{smooth.spline}}
-##' @return hyperSpec object containing smoothed spectra
-##' @rdname spc-spline
-##' @author Claudia Beleites
-##' @seealso \code{\link[hyperSpec]{spc.loess}}
-##'
-##' \code{\link[stats]{smooth.spline}}
-##' @note This function is still experimental
-##' @export
-##' @examples
-##' p <- paracetamol [,,2200 ~ max]
-##' plot (p, col = "gray")
-##' smooth <- spc.smooth.spline (p [,, c (2200 ~ 2400, 2500 ~ 2825, 3150 ~ max)],
-##'                              wl (paracetamol [,, 2200 ~ max]),
-##'                              df = 4, spar = 1)
-##' plot (smooth, col = "red", add = TRUE)
-##'
-##' plot (p - smooth)
-##'
+#' Smoothing splines
+#'
+#' Spectral smoothing by splines
+#' @title Spectral smoothing by splines
+#' @param spc hyperSpec object
+#' @param newx  wavelengh axis to interpolate on
+#' @param ... further parameters handed to \code{\link[stats]{smooth.spline}}
+#' @return hyperSpec object containing smoothed spectra
+#' @rdname spc-spline
+#' @author Claudia Beleites
+#' @seealso \code{\link[hyperSpec]{spc.loess}}
+#'
+#' \code{\link[stats]{smooth.spline}}
+#' @note This function is still experimental
+#' @export
+#' @examples
+#' p <- paracetamol [,,2200 ~ max]
+#' plot (p, col = "gray")
+#' smooth <- spc.smooth.spline (p [,, c (2200 ~ 2400, 2500 ~ 2825, 3150 ~ max)],
+#'                              wl (paracetamol [,, 2200 ~ max]),
+#'                              df = 4, spar = 1)
+#' plot (smooth, col = "red", add = TRUE)
+#'
+#' plot (p - smooth)
+#'
 spc.smooth.spline <- function(spc, newx = wl(spc), ...) {
   .spline <- function(x, y, newx) {
     pts <- !is.na(y)

--- a/hyperSpec/R/split.R
+++ b/hyperSpec/R/split.R
@@ -33,17 +33,13 @@
 #' @export
 #' @examples
 #'
-#' dist <- pearson.dist (faux_cell[[]])
-#' dend <- hclust (dist, method = "ward")
-#' z <- cutree (dend, h = 0.15)
+#' dist <- pearson.dist(faux_cell[[]])
+#' dend <- hclust(dist, method = "ward")
+#' z <- cutree(dend, h = 0.15)
 #'
-#' region <- split (faux_cell, z)
-#' length (region)
+#' region <- split(faux_cell, z)
+#' length(region)
 #'
 #' # difference in cluster mean spectra
-#' plot (apply (region[[2]], 2, mean) - apply (region[[1]], 2, mean))
-#'
-#'
-
-
+#' plot(apply(region[[2]], 2, mean) - apply(region[[1]], 2, mean))
 setMethod("split", signature = signature(x = "hyperSpec"), .split)

--- a/hyperSpec/R/split.R
+++ b/hyperSpec/R/split.R
@@ -4,7 +4,7 @@
   hyperlist <- split(seq(x, index = TRUE), f, drop)
 
   for (i in seq_along(hyperlist)) {
-    hyperlist [[i]] <- x [hyperlist [[i]], ]
+    hyperlist[[i]] <- x[hyperlist[[i]], ]
   }
 
   hyperlist

--- a/hyperSpec/R/split.R
+++ b/hyperSpec/R/split.R
@@ -10,40 +10,40 @@
   hyperlist
 }
 
-##' Split a hyperSpec object according to groups
-##' \code{split} divides the \code{hyperSpec} object into a list of
-##' \code{hyperSpec} objects according to the groups given by \code{f}.
-##'
-##' The \code{hyperSpec} objects in the list may be bound together again by
-##' \code{\link{bind} ("r", list_of_hyperSpec_objects)}.
-##'
-##' @name split
-##' @rdname split
-##' @aliases split split-methods split,ANY-method split,hyperSpec-method
-##' @docType methods
-##' @param x the \code{hyperSpec} object
-##' @param f a factor giving the grouping (or a variable that can be converted
-##'   into a factor by \code{as.factor})
-##' @param drop if \code{TRUE}, levels of\code{f} that do not occur are
-##'   dropped.
-##' @return A list of \code{hyperSpec} objects.
-##' @author C. Beleites
-##' @seealso \code{\link[base]{split}}
-##' @keywords methods
-##' @export
-##' @examples
-##'
-##' dist <- pearson.dist (faux_cell[[]])
-##' dend <- hclust (dist, method = "ward")
-##' z <- cutree (dend, h = 0.15)
-##'
-##' region <- split (faux_cell, z)
-##' length (region)
-##'
-##' # difference in cluster mean spectra
-##' plot (apply (region[[2]], 2, mean) - apply (region[[1]], 2, mean))
-##'
-##'
+#' Split a hyperSpec object according to groups
+#' \code{split} divides the \code{hyperSpec} object into a list of
+#' \code{hyperSpec} objects according to the groups given by \code{f}.
+#'
+#' The \code{hyperSpec} objects in the list may be bound together again by
+#' \code{\link{bind} ("r", list_of_hyperSpec_objects)}.
+#'
+#' @name split
+#' @rdname split
+#' @aliases split split-methods split,ANY-method split,hyperSpec-method
+#' @docType methods
+#' @param x the \code{hyperSpec} object
+#' @param f a factor giving the grouping (or a variable that can be converted
+#'   into a factor by \code{as.factor})
+#' @param drop if \code{TRUE}, levels of\code{f} that do not occur are
+#'   dropped.
+#' @return A list of \code{hyperSpec} objects.
+#' @author C. Beleites
+#' @seealso \code{\link[base]{split}}
+#' @keywords methods
+#' @export
+#' @examples
+#'
+#' dist <- pearson.dist (faux_cell[[]])
+#' dend <- hclust (dist, method = "ward")
+#' z <- cutree (dend, h = 0.15)
+#'
+#' region <- split (faux_cell, z)
+#' length (region)
+#'
+#' # difference in cluster mean spectra
+#' plot (apply (region[[2]], 2, mean) - apply (region[[1]], 2, mean))
+#'
+#'
 
 
 setMethod("split", signature = signature(x = "hyperSpec"), .split)

--- a/hyperSpec/R/split.string.R
+++ b/hyperSpec/R/split.string.R
@@ -6,11 +6,11 @@
 
 split.string <- function(x, separator, trim.blank = TRUE, remove.empty = TRUE) {
   pos <- gregexpr(separator, x)
-  if (length(pos) == 1 && pos [[1]] == -1) {
+  if (length(pos) == 1 && pos[[1]] == -1) {
     return(x)
   }
 
-  pos <- pos [[1]]
+  pos <- pos[[1]]
 
   pos <- matrix(c(
     1, pos + attr(pos, "match.length"),

--- a/hyperSpec/R/splitdots.R
+++ b/hyperSpec/R/splitdots.R
@@ -1,7 +1,7 @@
 ## experimental splitting of dots arguments into arg lists for different functions.
 ##
 
-##' @noRd
+#' @noRd
 .split.dots <- function(dots, functions, drop = TRUE) {
   fun.names <- paste("^", names(functions), "[.]", sep = "")
   dot.names <- names(dots)

--- a/hyperSpec/R/subset.R
+++ b/hyperSpec/R/subset.R
@@ -8,16 +8,16 @@
 }
 
 
-##' subset for hyperSpec object
-##'
-##' @title subset
-##' @name subset
-##' @param x hyperSpec object
-##' @param ... handed to \code{\link[base]{subset}} (data.frame method)
-##' @docType methods
-##' @aliases subset subset,hyperSpec-method
-##' @return hyperSpec object containing the respective subset of spectra.
-##' @author Claudia Beleites
-##' @seealso \code{\link[base]{subset}}
-##' @export
+#' subset for hyperSpec object
+#'
+#' @title subset
+#' @name subset
+#' @param x hyperSpec object
+#' @param ... handed to \code{\link[base]{subset}} (data.frame method)
+#' @docType methods
+#' @aliases subset subset,hyperSpec-method
+#' @return hyperSpec object containing the respective subset of spectra.
+#' @author Claudia Beleites
+#' @seealso \code{\link[base]{subset}}
+#' @export
 setMethod("subset", signature = signature(x = "hyperSpec"), .subset)

--- a/hyperSpec/R/sweep.R
+++ b/hyperSpec/R/sweep.R
@@ -17,65 +17,65 @@
   x
 }
 
-##' Sweep Summary Statistic out of an hyperSpec Object
-##' \code{\link[base]{sweep}} for \code{hyperSpec} objects.
-##'
-##' Calls \code{\link[base]{sweep}} for the spectra matrix.
-##'
-##' \code{sweep} is useful for some spectra preprocessing, like offset
-##' correction, substraction of background spectra, and normalization of the
-##' spectra.
-##'
-##' @name sweep
-##' @rdname sweep
-##' @aliases sweep-methods sweep,hyperSpec-method
-##' @docType methods
-##' @param x a \code{hyperSpec object.}
-##' @param MARGIN direction of the spectra matrix that \code{STATS} goees
-##'   along.
-##' @param STATS the summary statistic to sweep out. Either a vector or a
-##'   \code{hyperSpec} object.
-##'
-##' hyperSpec offers a non-standard convenience function: if \code{STATS} is a
-##'   function, this function is applied first (with the same \code{MARGIN}) to
-##'   compute the statistic. However, no further arguments to the apply
-##'   function can be given.  See the examples.
-##' @param FUN the function to do the sweeping, e.g. `-` or `/`.
-##' @param check.margin If \code{TRUE} (the default), warn if the length or
-##'   dimensions of \code{STATS} do not match the specified dimensions of
-##'   \code{x}.  Set to \code{FALSE} for a small speed gain when you
-##'   \emph{know} that dimensions match.
-##' @param ... further arguments for \code{FUN}
-##' @return A \code{hyperSpec} object.
-##' @author C. Beleites
-##' @seealso \code{\link[base]{sweep}}
-##' @keywords methods
-##' @export
-##' @examples
-##'
-##' ## Substract the background / slide / blank spectrum
-##' # the example data does not have spectra of the empty slide,
-##' # so instead the overall composition of the sample is substracted
-##' background <- apply (faux_cell, 2, quantile, probs = 0.05)
-##' corrected <- sweep (faux_cell, 2, background, "-")
-##' plot (corrected, "spcprctl5")
-##'
-##' ## Offset correction
-##' offsets <- apply (faux_cell, 1, min)
-##' corrected <- sweep (faux_cell, 1, offsets, "-")
-##' plot (corrected, "spcprctl5")
-##'
-##' ## Min-max normalization (on max amide I)
-##' # the minimum is set to zero by the offset correction.
-##' factor <- apply (corrected, 1, max)
-##' mm.corrected <- sweep (corrected, 1, factor, "/")
-##' plot (mm.corrected, "spcprctl5")
-##'
-##' ## convenience: give function to compute STATS:
-##' mm.corrected2 <- sweep (corrected, 1, max, "/")
-##' plot (mm.corrected2)
-##'
-##' ## checking
-##' stopifnot (all (mm.corrected2 == mm.corrected))
-##'
+#' Sweep Summary Statistic out of an hyperSpec Object
+#' \code{\link[base]{sweep}} for \code{hyperSpec} objects.
+#'
+#' Calls \code{\link[base]{sweep}} for the spectra matrix.
+#'
+#' \code{sweep} is useful for some spectra preprocessing, like offset
+#' correction, substraction of background spectra, and normalization of the
+#' spectra.
+#'
+#' @name sweep
+#' @rdname sweep
+#' @aliases sweep-methods sweep,hyperSpec-method
+#' @docType methods
+#' @param x a \code{hyperSpec object.}
+#' @param MARGIN direction of the spectra matrix that \code{STATS} goees
+#'   along.
+#' @param STATS the summary statistic to sweep out. Either a vector or a
+#'   \code{hyperSpec} object.
+#'
+#' hyperSpec offers a non-standard convenience function: if \code{STATS} is a
+#'   function, this function is applied first (with the same \code{MARGIN}) to
+#'   compute the statistic. However, no further arguments to the apply
+#'   function can be given.  See the examples.
+#' @param FUN the function to do the sweeping, e.g. `-` or `/`.
+#' @param check.margin If \code{TRUE} (the default), warn if the length or
+#'   dimensions of \code{STATS} do not match the specified dimensions of
+#'   \code{x}.  Set to \code{FALSE} for a small speed gain when you
+#'   \emph{know} that dimensions match.
+#' @param ... further arguments for \code{FUN}
+#' @return A \code{hyperSpec} object.
+#' @author C. Beleites
+#' @seealso \code{\link[base]{sweep}}
+#' @keywords methods
+#' @export
+#' @examples
+#'
+#' ## Substract the background / slide / blank spectrum
+#' # the example data does not have spectra of the empty slide,
+#' # so instead the overall composition of the sample is substracted
+#' background <- apply (faux_cell, 2, quantile, probs = 0.05)
+#' corrected <- sweep (faux_cell, 2, background, "-")
+#' plot (corrected, "spcprctl5")
+#'
+#' ## Offset correction
+#' offsets <- apply (faux_cell, 1, min)
+#' corrected <- sweep (faux_cell, 1, offsets, "-")
+#' plot (corrected, "spcprctl5")
+#'
+#' ## Min-max normalization (on max amide I)
+#' # the minimum is set to zero by the offset correction.
+#' factor <- apply (corrected, 1, max)
+#' mm.corrected <- sweep (corrected, 1, factor, "/")
+#' plot (mm.corrected, "spcprctl5")
+#'
+#' ## convenience: give function to compute STATS:
+#' mm.corrected2 <- sweep (corrected, 1, max, "/")
+#' plot (mm.corrected2)
+#'
+#' ## checking
+#' stopifnot (all (mm.corrected2 == mm.corrected))
+#'
 setMethod("sweep", signature = signature(x = "hyperSpec"), .sweep)

--- a/hyperSpec/R/sweep.R
+++ b/hyperSpec/R/sweep.R
@@ -56,26 +56,25 @@
 #' ## Substract the background / slide / blank spectrum
 #' # the example data does not have spectra of the empty slide,
 #' # so instead the overall composition of the sample is substracted
-#' background <- apply (faux_cell, 2, quantile, probs = 0.05)
-#' corrected <- sweep (faux_cell, 2, background, "-")
-#' plot (corrected, "spcprctl5")
+#' background <- apply(faux_cell, 2, quantile, probs = 0.05)
+#' corrected <- sweep(faux_cell, 2, background, "-")
+#' plot(corrected, "spcprctl5")
 #'
 #' ## Offset correction
-#' offsets <- apply (faux_cell, 1, min)
-#' corrected <- sweep (faux_cell, 1, offsets, "-")
-#' plot (corrected, "spcprctl5")
+#' offsets <- apply(faux_cell, 1, min)
+#' corrected <- sweep(faux_cell, 1, offsets, "-")
+#' plot(corrected, "spcprctl5")
 #'
 #' ## Min-max normalization (on max amide I)
 #' # the minimum is set to zero by the offset correction.
-#' factor <- apply (corrected, 1, max)
-#' mm.corrected <- sweep (corrected, 1, factor, "/")
-#' plot (mm.corrected, "spcprctl5")
+#' factor <- apply(corrected, 1, max)
+#' mm.corrected <- sweep(corrected, 1, factor, "/")
+#' plot(mm.corrected, "spcprctl5")
 #'
 #' ## convenience: give function to compute STATS:
-#' mm.corrected2 <- sweep (corrected, 1, max, "/")
-#' plot (mm.corrected2)
+#' mm.corrected2 <- sweep(corrected, 1, max, "/")
+#' plot(mm.corrected2)
 #'
 #' ## checking
-#' stopifnot (all (mm.corrected2 == mm.corrected))
-#'
+#' stopifnot(all(mm.corrected2 == mm.corrected))
 setMethod("sweep", signature = signature(x = "hyperSpec"), .sweep)

--- a/hyperSpec/R/trellis.factor.key.R
+++ b/hyperSpec/R/trellis.factor.key.R
@@ -16,22 +16,24 @@
 #' @importFrom lattice level.colors
 #' @examples
 #'
-#' faux_cell$z <- factor (rep (c("a", "a", "d", "c"),
-#'                           length.out = nrow (faux_cell)),
-#'                      levels = letters [1 : 4])
+#' faux_cell$z <- factor(rep(c("a", "a", "d", "c"),
+#'   length.out = nrow(faux_cell)
+#' ),
+#' levels = letters [1:4]
+#' )
 #'
-#' str (trellis.factor.key (faux_cell$z))
+#' str(trellis.factor.key(faux_cell$z))
 #'
-#' plotmap (faux_cell, z ~ x * y)
+#' plotmap(faux_cell, z ~ x * y)
 #'
 #' ## switch off using trellis.factor.key:
 #' ## note that the factor levels are collapsed to c(1, 2, 3) rather than
 #' ## c (1, 3, 4)
-#' plotmap (faux_cell, z ~ x * y, transform.factor = FALSE)
+#' plotmap(faux_cell, z ~ x * y, transform.factor = FALSE)
 #'
-#' plotmap (faux_cell, z ~ x * y,
-#'          col.regions = c ("gray", "red", "blue", "dark green"))
-#'
+#' plotmap(faux_cell, z ~ x * y,
+#'   col.regions = c("gray", "red", "blue", "dark green")
+#' )
 #' @importFrom utils modifyList
 trellis.factor.key <- function(f, levelplot.args = list()) {
   at <- seq(0, nlevels(f)) + .5

--- a/hyperSpec/R/trellis.factor.key.R
+++ b/hyperSpec/R/trellis.factor.key.R
@@ -1,38 +1,38 @@
-##' Color coding legend for factors
-##' Modifies a list of lattice arguments (as for \code{\link[lattice]{levelplot}}, etc.) according to
-##' the factor levels. The colorkey will shows all levels (including unused), and the drawing colors
-##' will be set accordingly.
-##'
-##' \code{trellis.factor.key} is used during \code{levelplot}-based plotting of factors (for
-##' hyperSpec objects) unless \code{transform.factor = FALSE} is specified.
-##'
-##' @param f the factor that will be color-coded
-##' @param levelplot.args a list with levelplot arguments
-##' @return the modified list with levelplot arguments.
-##' @author C. Beleites
-##' @seealso \code{\link[lattice]{levelplot}}
-##' @keywords aplot
-##' @export
-##' @importFrom lattice level.colors
-##' @examples
-##'
-##' faux_cell$z <- factor (rep (c("a", "a", "d", "c"),
-##'                           length.out = nrow (faux_cell)),
-##'                      levels = letters [1 : 4])
-##'
-##' str (trellis.factor.key (faux_cell$z))
-##'
-##' plotmap (faux_cell, z ~ x * y)
-##'
-##' ## switch off using trellis.factor.key:
-##' ## note that the factor levels are collapsed to c(1, 2, 3) rather than
-##' ## c (1, 3, 4)
-##' plotmap (faux_cell, z ~ x * y, transform.factor = FALSE)
-##'
-##' plotmap (faux_cell, z ~ x * y,
-##'          col.regions = c ("gray", "red", "blue", "dark green"))
-##'
-##' @importFrom utils modifyList
+#' Color coding legend for factors
+#' Modifies a list of lattice arguments (as for \code{\link[lattice]{levelplot}}, etc.) according to
+#' the factor levels. The colorkey will shows all levels (including unused), and the drawing colors
+#' will be set accordingly.
+#'
+#' \code{trellis.factor.key} is used during \code{levelplot}-based plotting of factors (for
+#' hyperSpec objects) unless \code{transform.factor = FALSE} is specified.
+#'
+#' @param f the factor that will be color-coded
+#' @param levelplot.args a list with levelplot arguments
+#' @return the modified list with levelplot arguments.
+#' @author C. Beleites
+#' @seealso \code{\link[lattice]{levelplot}}
+#' @keywords aplot
+#' @export
+#' @importFrom lattice level.colors
+#' @examples
+#'
+#' faux_cell$z <- factor (rep (c("a", "a", "d", "c"),
+#'                           length.out = nrow (faux_cell)),
+#'                      levels = letters [1 : 4])
+#'
+#' str (trellis.factor.key (faux_cell$z))
+#'
+#' plotmap (faux_cell, z ~ x * y)
+#'
+#' ## switch off using trellis.factor.key:
+#' ## note that the factor levels are collapsed to c(1, 2, 3) rather than
+#' ## c (1, 3, 4)
+#' plotmap (faux_cell, z ~ x * y, transform.factor = FALSE)
+#'
+#' plotmap (faux_cell, z ~ x * y,
+#'          col.regions = c ("gray", "red", "blue", "dark green"))
+#'
+#' @importFrom utils modifyList
 trellis.factor.key <- function(f, levelplot.args = list()) {
   at <- seq(0, nlevels(f)) + .5
 

--- a/hyperSpec/R/unittest.R
+++ b/hyperSpec/R/unittest.R
@@ -1,20 +1,20 @@
-##' hyperSpec unit tests
-##'
-##' If \code{\link[testthat]{testthat}} is available, run the unit tests and
-##' display the results.
-##'
-##' @rdname unittests
-##' @return Invisibly returns a data frame with the test results
-##'
-##' @author Claudia Beleites
-##'
-##' @keywords programming utilities
-##' @import testthat
-##' @export
-##' @examples
-##'
-##' hy.unittest ()
-##'
+#' hyperSpec unit tests
+#'
+#' If \code{\link[testthat]{testthat}} is available, run the unit tests and
+#' display the results.
+#'
+#' @rdname unittests
+#' @return Invisibly returns a data frame with the test results
+#'
+#' @author Claudia Beleites
+#'
+#' @keywords programming utilities
+#' @import testthat
+#' @export
+#' @examples
+#'
+#' hy.unittest ()
+#'
 hy.unittest <- function() {
   if (!requireNamespace("testthat", quietly = TRUE)) {
     warning("testthat required to run the unit tests.")
@@ -42,7 +42,7 @@ hy.unittest <- function() {
   invisible(lister$get_results())
 }
 
-##' @noRd
+#' @noRd
 {
   `.test<-` <- function(f, value) {
     attr(f, "test") <- value
@@ -54,8 +54,8 @@ hy.unittest <- function() {
   }
 }
 
-##' get test that is attached to object as "test" attribute
-##' @noRd
+#' get test that is attached to object as "test" attribute
+#' @noRd
 get.test <- function(object) {
   attr(object, "test")
 }

--- a/hyperSpec/R/unittest.R
+++ b/hyperSpec/R/unittest.R
@@ -33,7 +33,7 @@ hy.unittest <- function() {
   with_reporter(reporter = reporter, start_end_reporter = TRUE, {
     for (t in seq_along(tests)) {
       lister$start_file(names(tests [t]))
-      tests [[t]]()
+      tests[[t]]()
     }
     get_reporter()$.end_context()
   })

--- a/hyperSpec/R/unittest.R
+++ b/hyperSpec/R/unittest.R
@@ -13,8 +13,7 @@
 #' @export
 #' @examples
 #'
-#' hy.unittest ()
-#'
+#' hy.unittest()
 hy.unittest <- function() {
   if (!requireNamespace("testthat", quietly = TRUE)) {
     warning("testthat required to run the unit tests.")

--- a/hyperSpec/R/vandermonde.R
+++ b/hyperSpec/R/vandermonde.R
@@ -16,14 +16,15 @@
 #' @export
 #' @include unittest.R
 vanderMonde <- function(x, order, ...) {
-  if (nargs() > 2)
-    stop('Unknown arguments: ', names(c (...)))
+  if (nargs() > 2) {
+    stop("Unknown arguments: ", names(c(...)))
+  }
 
   outer(x, 0:order, `^`)
 }
 
 #' @noRd
-setGeneric ("vanderMonde")
+setGeneric("vanderMonde")
 
 #' @param normalize.wl function to transorm the wavelengths before evaluating the polynomial (or
 #' other function). `hyperSpec::normalize01()` maps the wavelength range to the interval
@@ -38,25 +39,29 @@ setGeneric ("vanderMonde")
 #' @examples
 #' plot(vanderMonde(flu, 2))
 #' plot(vanderMonde(flu, 2, normalize.wl = I))
-#'
-setMethod("vanderMonde", signature = signature (x = "hyperSpec"),
-           function(x, order, ..., normalize.wl = normalize01) {
-             validObject (x)
+setMethod("vanderMonde",
+  signature = signature(x = "hyperSpec"),
+  function(x, order, ..., normalize.wl = normalize01) {
+    validObject(x)
 
-             wl <- normalize.wl(x@wavelength)
+    wl <- normalize.wl(x@wavelength)
 
-             x <- decomposition(x, t(vanderMonde(wl, order)),
-                                scores = FALSE, ...)
-             x$.vdm.order <- 0:order
-             x
-           })
+    x <- decomposition(x, t(vanderMonde(wl, order)),
+      scores = FALSE, ...
+    )
+    x$.vdm.order <- 0:order
+    x
+  }
+)
 
-.test (vanderMonde) <- function () {
-  context ("vanderMonde")
+.test(vanderMonde) <- function() {
+  context("vanderMonde")
 
   test_that("vector against manual calculation", {
-    expect_equal(vanderMonde(c (1:3, 5), 2),
-                  matrix(c(1, 1, 1, 1, 1, 2, 3, 5, 1, 4, 9, 25), nrow = 4))
+    expect_equal(
+      vanderMonde(c(1:3, 5), 2),
+      matrix(c(1, 1, 1, 1, 1, 2, 3, 5, 1, 4, 9, 25), nrow = 4)
+    )
   })
 
   test_that("default method doesn't provide normalization", {
@@ -64,19 +69,17 @@ setMethod("vanderMonde", signature = signature (x = "hyperSpec"),
   })
 
   test_that("hyperSpec objects", {
-    expect_true(chk.hy (vanderMonde (flu, 0)))
-    expect_true(validObject (vanderMonde (flu, 0)))
+    expect_true(chk.hy(vanderMonde(flu, 0)))
+    expect_true(validObject(vanderMonde(flu, 0)))
 
-    tmp <- vanderMonde (paracetamol, 3, normalize.wl = I)
-    dimnames (tmp$spc) <- NULL
-    expect_equal (tmp [[]], t (vanderMonde (wl (paracetamol), 3)))
+    tmp <- vanderMonde(paracetamol, 3, normalize.wl = I)
+    dimnames(tmp$spc) <- NULL
+    expect_equal(tmp [[]], t(vanderMonde(wl(paracetamol), 3)))
 
-    tmp <- vanderMonde (paracetamol, 3, normalize.wl = normalize01)
-    dimnames (tmp$spc) <- NULL
-    expect_equal (tmp[[]], t (vanderMonde (normalize01 (
-      wl (paracetamol)
+    tmp <- vanderMonde(paracetamol, 3, normalize.wl = normalize01)
+    dimnames(tmp$spc) <- NULL
+    expect_equal(tmp[[]], t(vanderMonde(normalize01(
+      wl(paracetamol)
     ), 3)))
   })
 }
-
-

--- a/hyperSpec/R/vandermonde.R
+++ b/hyperSpec/R/vandermonde.R
@@ -1,20 +1,20 @@
-##' Function evaluation on hyperSpec objects
-##'
-##' `vandermonde()` generates Vandermonde matrices, the hyperSpec method
-##' generates a hyperSpec object containing the van der Monde matrix of the
-##' wavelengths of a hyperSpec object.
-##'
-##' It is often numerically preferrable to map `wl(x)` to \[0, 1\], see the
-##' example.
-##'
-##' @param x object to evaluate the polynomial on
-##' @param order of the polynomial
-##' @md
-##' @rdname vanderMonde
-##' @return Vandermonde matrix
-##' @author C. Beleites
-##' @export
-##' @include unittest.R
+#' Function evaluation on hyperSpec objects
+#'
+#' `vandermonde()` generates Vandermonde matrices, the hyperSpec method
+#' generates a hyperSpec object containing the van der Monde matrix of the
+#' wavelengths of a hyperSpec object.
+#'
+#' It is often numerically preferrable to map `wl(x)` to \[0, 1\], see the
+#' example.
+#'
+#' @param x object to evaluate the polynomial on
+#' @param order of the polynomial
+#' @md
+#' @rdname vanderMonde
+#' @return Vandermonde matrix
+#' @author C. Beleites
+#' @export
+#' @include unittest.R
 vanderMonde <- function(x, order, ...) {
   if (nargs() > 2)
     stop('Unknown arguments: ', names(c (...)))
@@ -22,23 +22,23 @@ vanderMonde <- function(x, order, ...) {
   outer(x, 0:order, `^`)
 }
 
-##' @noRd
+#' @noRd
 setGeneric ("vanderMonde")
 
-##' @param normalize.wl function to transorm the wavelengths before evaluating the polynomial (or
-##' other function). `hyperSpec::normalize01()` maps the wavelength range to the interval
-##' [0, 1]. Use `base::I()` to turn off.
-##' @param ... hyperSpec method: further arguments to `hyperSpec::decomposition()`
-##' @return hyperSpec method: hyperSpec object containing van der Monde matrix as spectra and an additional column `$.vdm.order$ giving the order of each spectrum (term).
-##' @rdname vanderMonde
-##' @seealso `hyperSpec::wl.eval()` for calculating arbitrary functions of the wavelength,
-##'
-##' `hyperSpec::normalize01()`
-##' @export
-##' @examples
-##' plot(vanderMonde(flu, 2))
-##' plot(vanderMonde(flu, 2, normalize.wl = I))
-##'
+#' @param normalize.wl function to transorm the wavelengths before evaluating the polynomial (or
+#' other function). `hyperSpec::normalize01()` maps the wavelength range to the interval
+#' [0, 1]. Use `base::I()` to turn off.
+#' @param ... hyperSpec method: further arguments to `hyperSpec::decomposition()`
+#' @return hyperSpec method: hyperSpec object containing van der Monde matrix as spectra and an additional column `$.vdm.order$ giving the order of each spectrum (term).
+#' @rdname vanderMonde
+#' @seealso `hyperSpec::wl.eval()` for calculating arbitrary functions of the wavelength,
+#'
+#' `hyperSpec::normalize01()`
+#' @export
+#' @examples
+#' plot(vanderMonde(flu, 2))
+#' plot(vanderMonde(flu, 2, normalize.wl = I))
+#'
 setMethod("vanderMonde", signature = signature (x = "hyperSpec"),
            function(x, order, ..., normalize.wl = normalize01) {
              validObject (x)

--- a/hyperSpec/R/vandermonde.R
+++ b/hyperSpec/R/vandermonde.R
@@ -74,7 +74,7 @@ setMethod("vanderMonde",
 
     tmp <- vanderMonde(paracetamol, 3, normalize.wl = I)
     dimnames(tmp$spc) <- NULL
-    expect_equal(tmp [[]], t(vanderMonde(wl(paracetamol), 3)))
+    expect_equal(tmp[[]], t(vanderMonde(wl(paracetamol), 3)))
 
     tmp <- vanderMonde(paracetamol, 3, normalize.wl = normalize01)
     dimnames(tmp$spc) <- NULL

--- a/hyperSpec/R/wc.R
+++ b/hyperSpec/R/wc.R
@@ -1,17 +1,17 @@
-##' line/word/character count of ASCII files
-##'
-##' `wc()` uses the system command `wc`. Use at your own risk.
-##' @note `wc()` now is deprecated and will be removed from hyperSpec in future. Consider using [count_lines()] instead for line counting.
-##'
-##' @param file the file name or pattern
-##' @param flags the parameters to count, character vector with the long form
-##'   of the parameters
-##' @return data.frame with the counts and file names, or `NULL` if wc is
-##'   not available on the system.
-##' @seealso [count_lines()]
-##' @export
-##' @author C. Beleites
-##' @importFrom utils read.table
+#' line/word/character count of ASCII files
+#'
+#' `wc()` uses the system command `wc`. Use at your own risk.
+#' @note `wc()` now is deprecated and will be removed from hyperSpec in future. Consider using [count_lines()] instead for line counting.
+#'
+#' @param file the file name or pattern
+#' @param flags the parameters to count, character vector with the long form
+#'   of the parameters
+#' @return data.frame with the counts and file names, or `NULL` if wc is
+#'   not available on the system.
+#' @seealso [count_lines()]
+#' @export
+#' @author C. Beleites
+#' @importFrom utils read.table
 wc <- function(file, flags = c("lines", "words", "bytes")) {
   .Deprecated(
     new = "count_lines",

--- a/hyperSpec/R/wl.R
+++ b/hyperSpec/R/wl.R
@@ -1,38 +1,38 @@
-##' Getting and Setting the Wavelength Axis
-##' \code{wl} returns the wavelength axis, \code{wl<-} sets it.
-##'
-##' The wavelength axis of a \code{hyperSpec} object can be retrieved and
-##' replaced with \code{wl} and \code{wl<-}, respectively.
-##'
-##' When the wavelength axis is replaced, the colnames of \code{x@@data$spc} are
-##' replaced by the rounded new wavelengths.  \code{digits} specifies the how
-##' many significant digits should be used.
-##'
-##' There are two ways to set the label of the new wavelength axis, see the
-##' examples.  If no label is given, a warning will be issued.
-##'
-##' @aliases wl
-##' @param x a \code{hyperSpec} object
-##' @return a numeric vector
-##' @note \code{wl<-} always sets the complete wavelength axis, without
-##'   changing the columns of the spectra matrix. If you rather want to cut the
-##'   spectral range, use \code{\link[hyperSpec:extractreplace]{[}}, for
-##'   interpolation along the spectral axis see
-##'   \code{\link[hyperSpec]{spc.loess}} and for spectral binning
-##'   \code{\link[hyperSpec]{spc.bin}}.
-##' @author C. Beleites
-##' @export
-##' @seealso \code{\link[base]{signif}}
-##'
-##' cutting the spectral range: \code{\link[hyperSpec:extractreplace]{[}}
-##'
-##' interpolation along the spectral axis: \code{\link[hyperSpec]{spc.loess}}
-##'
-##' spectral binning: \code{\link[hyperSpec]{spc.bin}}
-##' @examples
-##'
-##' 	wl (laser)
-##'
+#' Getting and Setting the Wavelength Axis
+#' \code{wl} returns the wavelength axis, \code{wl<-} sets it.
+#'
+#' The wavelength axis of a \code{hyperSpec} object can be retrieved and
+#' replaced with \code{wl} and \code{wl<-}, respectively.
+#'
+#' When the wavelength axis is replaced, the colnames of \code{x@@data$spc} are
+#' replaced by the rounded new wavelengths.  \code{digits} specifies the how
+#' many significant digits should be used.
+#'
+#' There are two ways to set the label of the new wavelength axis, see the
+#' examples.  If no label is given, a warning will be issued.
+#'
+#' @aliases wl
+#' @param x a \code{hyperSpec} object
+#' @return a numeric vector
+#' @note \code{wl<-} always sets the complete wavelength axis, without
+#'   changing the columns of the spectra matrix. If you rather want to cut the
+#'   spectral range, use \code{\link[hyperSpec:extractreplace]{[}}, for
+#'   interpolation along the spectral axis see
+#'   \code{\link[hyperSpec]{spc.loess}} and for spectral binning
+#'   \code{\link[hyperSpec]{spc.bin}}.
+#' @author C. Beleites
+#' @export
+#' @seealso \code{\link[base]{signif}}
+#'
+#' cutting the spectral range: \code{\link[hyperSpec:extractreplace]{[}}
+#'
+#' interpolation along the spectral axis: \code{\link[hyperSpec]{spc.loess}}
+#'
+#' spectral binning: \code{\link[hyperSpec]{spc.bin}}
+#' @examples
+#'
+#' 	wl (laser)
+#'
 wl <- function(x) {
   chk.hy(x)
   validObject(x)
@@ -52,32 +52,32 @@ wl <- function(x) {
   x
 }
 
-##' @rdname wl
-##' @export "wl<-"
-##' @aliases wl<-
-##' @usage
-##' wl (x, label=NULL, digits=6) <- value
-##'
-##' @param value either a numeric containing the new wavelength vector, or a
-##'   list with \code{value$wl} containing the new wavelength vector and
-##'   \code{value$label} holding the corresponding \code{label}.
-##' @param label The label for the new wavelength axis. See \link{initialize}
-##'   for details.
-##' @param digits handed to \code{\link[base]{signif}}. See details.
-##' @return \code{hyperSpec} object
-##' @examples
-##' 	# convert from wavelength to frequency
-##' 	plot (laser)
-##' 	wl (laser, "f / Hz") <- 2.998e8 * wl (laser) * 1e9
-##' 	plot (laser)
-##'
-##' 	# convert from Raman shift to wavelength
-##' 	# excitation was at 785 nm
-##' 	plot (faux_cell [1])
-##' 	wl(faux_cell) <- list(wl = 1e7/(1e7/785 - wl(faux_cell)),
-##' 	                      label = expression(lambda / nm))
-##' 	plot (faux_cell [1])
-##'
+#' @rdname wl
+#' @export "wl<-"
+#' @aliases wl<-
+#' @usage
+#' wl (x, label=NULL, digits=6) <- value
+#'
+#' @param value either a numeric containing the new wavelength vector, or a
+#'   list with \code{value$wl} containing the new wavelength vector and
+#'   \code{value$label} holding the corresponding \code{label}.
+#' @param label The label for the new wavelength axis. See \link{initialize}
+#'   for details.
+#' @param digits handed to \code{\link[base]{signif}}. See details.
+#' @return \code{hyperSpec} object
+#' @examples
+#' 	# convert from wavelength to frequency
+#' 	plot (laser)
+#' 	wl (laser, "f / Hz") <- 2.998e8 * wl (laser) * 1e9
+#' 	plot (laser)
+#'
+#' 	# convert from Raman shift to wavelength
+#' 	# excitation was at 785 nm
+#' 	plot (faux_cell [1])
+#' 	wl(faux_cell) <- list(wl = 1e7/(1e7/785 - wl(faux_cell)),
+#' 	                      label = expression(lambda / nm))
+#' 	plot (faux_cell [1])
+#'
 "wl<-" <- function(x, label = NULL, digits = 6, value) {
   chk.hy(x)
   validObject(x)
@@ -98,21 +98,21 @@ wl <- function(x) {
 
 
 ### -----------------------------------------------------------------------------
-##' Convert different wavelength units
-##'
-##' The following units can be converted into each other:
-##' \emph{nm}, \emph{\eqn{cm^{-1}}{inverse cm}}, \emph{eV}, \emph{THz} and
-##' \emph{Raman shift}
-##'
-##' @param points data for conversion
-##' @param src source unit
-##' @param dst destination unit
-##' @param laser laser wavelength (required for work with Raman shift)
-##' @author R. Kiselev
-##' @export
-##' @examples
-##' wlconv (3200, "Raman shift", "nm", laser = 785.04)
-##' wlconv( 785, "nm", "invcm")
+#' Convert different wavelength units
+#'
+#' The following units can be converted into each other:
+#' \emph{nm}, \emph{\eqn{cm^{-1}}{inverse cm}}, \emph{eV}, \emph{THz} and
+#' \emph{Raman shift}
+#'
+#' @param points data for conversion
+#' @param src source unit
+#' @param dst destination unit
+#' @param laser laser wavelength (required for work with Raman shift)
+#' @author R. Kiselev
+#' @export
+#' @examples
+#' wlconv (3200, "Raman shift", "nm", laser = 785.04)
+#' wlconv( 785, "nm", "invcm")
 wlconv <- function(points, src, dst, laser = NULL) {
   SRC <- .fixunitname(src)
   DST <- .fixunitname(dst)
@@ -130,105 +130,105 @@ wlconv <- function(points, src, dst, laser = NULL) {
   return(f(points, laser))
 }
 
-##' @param x wavelength points for conversion
-##' @param ... ignored
-##' @describeIn wlconv conversion \strong{nanometers} -> \strong{Raman shift (relative wavenumber)}
-##' @export
+#' @param x wavelength points for conversion
+#' @param ... ignored
+#' @describeIn wlconv conversion \strong{nanometers} -> \strong{Raman shift (relative wavenumber)}
+#' @export
 nm2raman <- function(x, laser) 1e7 * (1 / laser - 1 / x)
 
 
-##' @describeIn wlconv conversion \strong{nanometers} -> \strong{inverse cm (absolute wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{nanometers} -> \strong{inverse cm (absolute wavenumber)}
+#' @export
 nm2invcm <- function(x, ...) 1e7 / x
 
 
-##' @describeIn wlconv conversion \strong{nanometers} -> \strong{electronvolt}
-##' @export
+#' @describeIn wlconv conversion \strong{nanometers} -> \strong{electronvolt}
+#' @export
 nm2ev <- function(x, ...) 1e9 * h * c / (q * x)
 
 
-##' @describeIn wlconv conversion \strong{nm} -> \strong{frequency in THz}
-##' @export
+#' @describeIn wlconv conversion \strong{nm} -> \strong{frequency in THz}
+#' @export
 nm2freq <- function(x, ...) 1e-3 * c / x
 
 
-##' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{Raman shift (relative wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{Raman shift (relative wavenumber)}
+#' @export
 invcm2raman <- function(x, laser) 1e7 / laser - x
 
 
-##' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{nanometers}
-##' @export
+#' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{nanometers}
+#' @export
 invcm2nm <- function(x, ...) 1e7 / x
 
 
-##' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{electronvolt}
-##' @export
+#' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{electronvolt}
+#' @export
 invcm2ev <- function(x, ...) 100 * x * c * h / q
 
 
-##' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{frequency in THz}
-##' @export
+#' @describeIn wlconv conversion \strong{inverse cm (absolute wavenumber)} -> \strong{frequency in THz}
+#' @export
 invcm2freq <- function(x, ...) nm2freq(invcm2nm(x))
 
 
-##' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{inverse cm (absolute wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{inverse cm (absolute wavenumber)}
+#' @export
 raman2invcm <- function(x, laser) 1e7 / laser - x
 
 
-##' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{nanometers}
-##' @export
+#' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{nanometers}
+#' @export
 raman2nm <- function(x, laser) 1e7 / (1e7 / laser - x)
 
 
-##' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{electronvolt}
-##' @export
+#' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{electronvolt}
+#' @export
 raman2ev <- function(x, laser) 100 * h * c * (1e7 / laser - x) / q
 
 
-##' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{frequency in THz}
-##' @export
+#' @describeIn wlconv conversion \strong{Raman shift (relative wavenumber)} -> \strong{frequency in THz}
+#' @export
 raman2freq <- function(x, laser) nm2freq(raman2nm(x, laser))
 
 
-##' @describeIn wlconv conversion \strong{electronvolt} -> \strong{Raman shift (relative wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{electronvolt} -> \strong{Raman shift (relative wavenumber)}
+#' @export
 ev2raman <- function(x, laser) 1e7 / laser - x * q / (100 * h * c)
 
 
-##' @describeIn wlconv conversion \strong{electronvolt} -> \strong{inverse cm (absolute wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{electronvolt} -> \strong{inverse cm (absolute wavenumber)}
+#' @export
 ev2invcm <- function(x, ...) q * x / (100 * h * c)
 
 
-##' @describeIn wlconv conversion \strong{electronvolt} -> \strong{nanometers}
-##' @export
+#' @describeIn wlconv conversion \strong{electronvolt} -> \strong{nanometers}
+#' @export
 ev2nm <- function(x, ...) 1e9 * h * c / (q * x)
 
 
-##' @describeIn wlconv conversion \strong{electronvolt} -> \strong{frequency in THz}
-##' @export
+#' @describeIn wlconv conversion \strong{electronvolt} -> \strong{frequency in THz}
+#' @export
 ev2freq <- function(x, ...) nm2freq(ev2nm(x))
 
 
-##' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{nanometers}
-##' @export
+#' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{nanometers}
+#' @export
 freq2nm <- function(x, ...) 1e-3 * c / x
 
 
-##' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{inverse cm (absolute wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{inverse cm (absolute wavenumber)}
+#' @export
 freq2invcm <- function(x, ...) nm2invcm(freq2nm(x))
 
 
-##' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{electronvolt}
-##' @export
+#' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{electronvolt}
+#' @export
 freq2ev <- function(x, ...) nm2ev(freq2nm(x))
 
 
-##' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{Raman shift (relative wavenumber)}
-##' @export
+#' @describeIn wlconv conversion \strong{frequency in THz} -> \strong{Raman shift (relative wavenumber)}
+#' @export
 freq2raman <- function(x, laser) nm2raman(freq2nm(x), laser)
 
 

--- a/hyperSpec/R/wl.R
+++ b/hyperSpec/R/wl.R
@@ -31,8 +31,7 @@
 #' spectral binning: \code{\link[hyperSpec]{spc.bin}}
 #' @examples
 #'
-#' 	wl (laser)
-#'
+#' wl(laser)
 wl <- function(x) {
   chk.hy(x)
   validObject(x)
@@ -66,18 +65,19 @@ wl <- function(x) {
 #' @param digits handed to \code{\link[base]{signif}}. See details.
 #' @return \code{hyperSpec} object
 #' @examples
-#' 	# convert from wavelength to frequency
-#' 	plot (laser)
-#' 	wl (laser, "f / Hz") <- 2.998e8 * wl (laser) * 1e9
-#' 	plot (laser)
+#' # convert from wavelength to frequency
+#' plot(laser)
+#' wl(laser, "f / Hz") <- 2.998e8 * wl(laser) * 1e9
+#' plot(laser)
 #'
-#' 	# convert from Raman shift to wavelength
-#' 	# excitation was at 785 nm
-#' 	plot (faux_cell [1])
-#' 	wl(faux_cell) <- list(wl = 1e7/(1e7/785 - wl(faux_cell)),
-#' 	                      label = expression(lambda / nm))
-#' 	plot (faux_cell [1])
-#'
+#' # convert from Raman shift to wavelength
+#' # excitation was at 785 nm
+#' plot(faux_cell [1])
+#' wl(faux_cell) <- list(
+#'   wl = 1e7 / (1e7 / 785 - wl(faux_cell)),
+#'   label = expression(lambda / nm)
+#' )
+#' plot(faux_cell [1])
 "wl<-" <- function(x, label = NULL, digits = 6, value) {
   chk.hy(x)
   validObject(x)
@@ -111,8 +111,8 @@ wl <- function(x) {
 #' @author R. Kiselev
 #' @export
 #' @examples
-#' wlconv (3200, "Raman shift", "nm", laser = 785.04)
-#' wlconv( 785, "nm", "invcm")
+#' wlconv(3200, "Raman shift", "nm", laser = 785.04)
+#' wlconv(785, "nm", "invcm")
 wlconv <- function(points, src, dst, laser = NULL) {
   SRC <- .fixunitname(src)
   DST <- .fixunitname(dst)

--- a/hyperSpec/R/wl2i.R
+++ b/hyperSpec/R/wl2i.R
@@ -24,65 +24,65 @@
   wavelength
 }
 
-##' Conversion between Wavelength and Spectra Matrix Column
-##' Index \code{wl2i} returns the column indices for the spectra matrix for the given wavelengths.
-##' \code{i2wl} converts column indices into wavelengths.
-##'
-##' If \code{wavelength} is numeric, each of its elements is converted to the respective index.
-##' Values outside the range of \code{x@@wavelength} become \code{NA}.
-##'
-##' If the range is given as a formula (i.e. \code{start ~ end}, a sequence
-##'
-##' index corresponding to start : index corresponding to end
-##'
-##' is returned. If the wavelengths are not ordered, that may lead to chaos. In this case, call
-##' \code{\link[hyperSpec]{orderwl}} first.
-##'
-##' Two special variables can be used: \code{min} and \code{max}, corresponding to the lowest and
-##' highest wavelength of \code{x}, respectively.
-##'
-##' start and end may be complex numbers. The resulting index for a complex x is then
-##'
-##' index (Re (x)) + Im (x)
-##'
-##' @aliases wl2i
-##' @param x a \code{hyperSpec} object
-##' @param wavelength the wavelengths to be converted into column indices,
-##'   either numeric or a formula, see details.
-##' @param i the column indices into the spectra matrix for which the
-##'   wavelength is to be computed
-##' @param unlist if multiple wavelength ranges are given, should the indices be unlisted or kept in a list?
-##' @return A numeric containing the resulting indices for \code{wl2i}
-##' @author C. Beleites
-##' @export
-##' @examples
-##'
-##' flu
-##' wl2i (flu, 405 : 407)
-##' wl2i (flu, 405 ~ 407)
-##'
-##' ## beginning of the spectrum to 407 nm
-##' wl2i (flu, min ~ 407)
-##'
-##' ## 2 data points from the beginning of the spectrum to 407 nm
-##' wl2i (flu, min + 2i ~ 407)
-##'
-##' ## the first 3 data points
-##' wl2i (flu, min ~ min + 2i)
-##'
-##' ## from 490 nm to end of the spectrum
-##' wl2i (flu, 490 ~ max)
-##'
-##' ## the last 8 data points
-##' wl2i (flu, max - 7i ~ max)
-##'
-##' ## get 450 nm +- 3 data points
-##' wl2i (flu, 450 - 3i ~ 450 + 3i)
-##'
-##' wl2i (flu, 300 : 400) ## all NA:
-##' wl2i (flu, 600 ~ 700) ## NULL: completely outside flu's wavelength range
-##'
-##' @importFrom lazyeval lazy lazy_eval is_formula f_eval_lhs f_eval_rhs
+#' Conversion between Wavelength and Spectra Matrix Column
+#' Index \code{wl2i} returns the column indices for the spectra matrix for the given wavelengths.
+#' \code{i2wl} converts column indices into wavelengths.
+#'
+#' If \code{wavelength} is numeric, each of its elements is converted to the respective index.
+#' Values outside the range of \code{x@@wavelength} become \code{NA}.
+#'
+#' If the range is given as a formula (i.e. \code{start ~ end}, a sequence
+#'
+#' index corresponding to start : index corresponding to end
+#'
+#' is returned. If the wavelengths are not ordered, that may lead to chaos. In this case, call
+#' \code{\link[hyperSpec]{orderwl}} first.
+#'
+#' Two special variables can be used: \code{min} and \code{max}, corresponding to the lowest and
+#' highest wavelength of \code{x}, respectively.
+#'
+#' start and end may be complex numbers. The resulting index for a complex x is then
+#'
+#' index (Re (x)) + Im (x)
+#'
+#' @aliases wl2i
+#' @param x a \code{hyperSpec} object
+#' @param wavelength the wavelengths to be converted into column indices,
+#'   either numeric or a formula, see details.
+#' @param i the column indices into the spectra matrix for which the
+#'   wavelength is to be computed
+#' @param unlist if multiple wavelength ranges are given, should the indices be unlisted or kept in a list?
+#' @return A numeric containing the resulting indices for \code{wl2i}
+#' @author C. Beleites
+#' @export
+#' @examples
+#'
+#' flu
+#' wl2i (flu, 405 : 407)
+#' wl2i (flu, 405 ~ 407)
+#'
+#' ## beginning of the spectrum to 407 nm
+#' wl2i (flu, min ~ 407)
+#'
+#' ## 2 data points from the beginning of the spectrum to 407 nm
+#' wl2i (flu, min + 2i ~ 407)
+#'
+#' ## the first 3 data points
+#' wl2i (flu, min ~ min + 2i)
+#'
+#' ## from 490 nm to end of the spectrum
+#' wl2i (flu, 490 ~ max)
+#'
+#' ## the last 8 data points
+#' wl2i (flu, max - 7i ~ max)
+#'
+#' ## get 450 nm +- 3 data points
+#' wl2i (flu, 450 - 3i ~ 450 + 3i)
+#'
+#' wl2i (flu, 300 : 400) ## all NA:
+#' wl2i (flu, 600 ~ 700) ## NULL: completely outside flu's wavelength range
+#'
+#' @importFrom lazyeval lazy lazy_eval is_formula f_eval_lhs f_eval_rhs
 wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRUE) {
   chk.hy(x)
   validObject(x)
@@ -227,14 +227,14 @@ wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRU
   test_that("inside extraction", {})
 }
 
-##' @rdname wl2i
-##' @aliases i2wl
-##' @return \code{i2wl} returns a numeric with the wavelengths
-##' @export
-##' @examples
-##'
-##' i2wl (faux_cell, 17:20)
-##'
+#' @rdname wl2i
+#' @aliases i2wl
+#' @return \code{i2wl} returns a numeric with the wavelengths
+#' @export
+#' @examples
+#'
+#' i2wl (faux_cell, 17:20)
+#'
 i2wl <- function(x, i) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/wl2i.R
+++ b/hyperSpec/R/wl2i.R
@@ -58,30 +58,29 @@
 #' @examples
 #'
 #' flu
-#' wl2i (flu, 405 : 407)
-#' wl2i (flu, 405 ~ 407)
+#' wl2i(flu, 405:407)
+#' wl2i(flu, 405 ~ 407)
 #'
 #' ## beginning of the spectrum to 407 nm
-#' wl2i (flu, min ~ 407)
+#' wl2i(flu, min ~ 407)
 #'
 #' ## 2 data points from the beginning of the spectrum to 407 nm
-#' wl2i (flu, min + 2i ~ 407)
+#' wl2i(flu, min + 2i ~ 407)
 #'
 #' ## the first 3 data points
-#' wl2i (flu, min ~ min + 2i)
+#' wl2i(flu, min ~ min + 2i)
 #'
 #' ## from 490 nm to end of the spectrum
-#' wl2i (flu, 490 ~ max)
+#' wl2i(flu, 490 ~ max)
 #'
 #' ## the last 8 data points
-#' wl2i (flu, max - 7i ~ max)
+#' wl2i(flu, max - 7i ~ max)
 #'
 #' ## get 450 nm +- 3 data points
-#' wl2i (flu, 450 - 3i ~ 450 + 3i)
+#' wl2i(flu, 450 - 3i ~ 450 + 3i)
 #'
-#' wl2i (flu, 300 : 400) ## all NA:
-#' wl2i (flu, 600 ~ 700) ## NULL: completely outside flu's wavelength range
-#'
+#' wl2i(flu, 300:400) ## all NA:
+#' wl2i(flu, 600 ~ 700) ## NULL: completely outside flu's wavelength range
 #' @importFrom lazyeval lazy lazy_eval is_formula f_eval_lhs f_eval_rhs
 wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRUE) {
   chk.hy(x)
@@ -233,8 +232,7 @@ wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRU
 #' @export
 #' @examples
 #'
-#' i2wl (faux_cell, 17:20)
-#'
+#' i2wl(faux_cell, 17:20)
 i2wl <- function(x, i) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/wl2i.R
+++ b/hyperSpec/R/wl2i.R
@@ -114,13 +114,13 @@ wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRU
   for (r in seq_along(wavelength)) {
 
     ## ~ sequence vs. scalars and : sequences
-    if (is_formula(wavelength [[r]])) {
-      from <- f_eval_lhs(wavelength [[r]])
-      to <- f_eval_rhs(wavelength [[r]])
+    if (is_formula(wavelength[[r]])) {
+      from <- f_eval_lhs(wavelength[[r]])
+      to <- f_eval_rhs(wavelength[[r]])
     } else {
       ## sequence with : or scalar
       from <- NULL
-      to <- wavelength [[r]]
+      to <- wavelength[[r]]
     }
 
     ## conversion to indices
@@ -131,7 +131,7 @@ wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRU
     }
 
     if (is.null(from)) {
-      results [[r]] <- to
+      results[[r]] <- to
       results [[r]][!is.finite(results [[r]])] <- NA
     } else {
       from <- .getindex(x, Re(from), extrapolate = FALSE) + Im(from)

--- a/hyperSpec/R/wl2i.R
+++ b/hyperSpec/R/wl2i.R
@@ -132,12 +132,12 @@ wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRU
 
     if (is.null(from)) {
       results[[r]] <- to
-      results [[r]][!is.finite(results [[r]])] <- NA
+      results[[r]][!is.finite(results[[r]])] <- NA
     } else {
       from <- .getindex(x, Re(from), extrapolate = FALSE) + Im(from)
 
       ## completely outside range
-      results [[r]] <- NULL
+      results[[r]] <- NULL
 
       ## start outside left
       if (from == -Inf) from <- 1
@@ -151,7 +151,7 @@ wl2i <- function(x, wavelength = stop("wavelengths are required."), unlist = TRU
         if (from < 1L) from <- 1L
         if (to > nwl(x)) to <- nwl(x)
 
-        results [[r]] <- seq(from, to)
+        results[[r]] <- seq(from, to)
       }
     }
   }

--- a/hyperSpec/R/wleval.R
+++ b/hyperSpec/R/wleval.R
@@ -1,19 +1,19 @@
-##' Evaluate function on wavelengths of hyperSpec object
-##'
-##' This is useful for generating certain types of baseline "reference spectra".
-##'
-##' @param x hyperSpec object
-##' @param ... hyperSpec method: expressions to be evaluated
-##' @param normalize.wl function to transorm the wavelengths before evaluating the polynomial (or
-##' other function). Use \code{\link[hyperSpec]{normalize01}} to map the wavelength range to the interval [0, 1].
-##' @return hyperSpec object containing one spectrum for each expression
-##' @export
-##' @seealso \code{\link[hyperSpec]{vanderMonde}} for  polynomials,
-##'
-##' \code{\link[hyperSpec]{normalize01}} to normalize the wavenumbers before evaluating the function
-##' @author C. Beleites
-##' @examples
-##' plot (wl.eval (laser, exp = function (x) exp (-x)))
+#' Evaluate function on wavelengths of hyperSpec object
+#'
+#' This is useful for generating certain types of baseline "reference spectra".
+#'
+#' @param x hyperSpec object
+#' @param ... hyperSpec method: expressions to be evaluated
+#' @param normalize.wl function to transorm the wavelengths before evaluating the polynomial (or
+#' other function). Use \code{\link[hyperSpec]{normalize01}} to map the wavelength range to the interval [0, 1].
+#' @return hyperSpec object containing one spectrum for each expression
+#' @export
+#' @seealso \code{\link[hyperSpec]{vanderMonde}} for  polynomials,
+#'
+#' \code{\link[hyperSpec]{normalize01}} to normalize the wavenumbers before evaluating the function
+#' @author C. Beleites
+#' @examples
+#' plot (wl.eval (laser, exp = function (x) exp (-x)))
 wl.eval <- function(x, ..., normalize.wl = I) {
   chk.hy(x)
   validObject(x)
@@ -31,7 +31,7 @@ wl.eval <- function(x, ..., normalize.wl = I) {
   x
 }
 
-##' @include unittest.R
+#' @include unittest.R
 .test(wl.eval) <- function() {
   context("wl.eval")
 

--- a/hyperSpec/R/wleval.R
+++ b/hyperSpec/R/wleval.R
@@ -41,7 +41,7 @@ wl.eval <- function(x, ..., normalize.wl = I) {
 
   test_that("wl.eval against manual evaluation", {
     expect_equivalent(
-      wl.eval(flu, function(x) rep(5, length(x)), normalize.wl = normalize01) [[]],
+      wl.eval(flu, function(x) rep(5, length(x)), normalize.wl = normalize01)[[]],
       matrix(rep(5, nwl(flu)), nrow = 1)
     )
 
@@ -51,24 +51,24 @@ wl.eval <- function(x, ..., normalize.wl = I) {
     )
 
     expect_equivalent(
-      wl.eval(flu, function(x) exp(-x)) [[]],
+      wl.eval(flu, function(x) exp(-x))[[]],
       matrix(exp(-flu@wavelength), nrow = 1)
     )
   })
 
   test_that("normalization", {
     expect_equivalent(
-      wl.eval(flu, function(x) rep(5, length(x)), normalize.wl = normalize01) [[]],
+      wl.eval(flu, function(x) rep(5, length(x)), normalize.wl = normalize01)[[]],
       matrix(rep(5, nwl(flu)), nrow = 1)
     )
 
     expect_equivalent(
-      wl.eval(flu, function(x) x, normalize.wl = normalize01) [[]],
+      wl.eval(flu, function(x) x, normalize.wl = normalize01)[[]],
       matrix(seq(0, 1, length.out = nwl(flu)), nrow = 1)
     )
 
     expect_equivalent(
-      wl.eval(flu, function(x) exp(x), normalize.wl = normalize01) [[]],
+      wl.eval(flu, function(x) exp(x), normalize.wl = normalize01)[[]],
       matrix(exp(seq(0, 1, length.out = nwl(flu))), nrow = 1)
     )
   })

--- a/hyperSpec/R/wleval.R
+++ b/hyperSpec/R/wleval.R
@@ -13,7 +13,7 @@
 #' \code{\link[hyperSpec]{normalize01}} to normalize the wavenumbers before evaluating the function
 #' @author C. Beleites
 #' @examples
-#' plot (wl.eval (laser, exp = function (x) exp (-x)))
+#' plot(wl.eval(laser, exp = function(x) exp(-x)))
 wl.eval <- function(x, ..., normalize.wl = I) {
   chk.hy(x)
   validObject(x)

--- a/hyperSpec/R/write.txt.long.R
+++ b/hyperSpec/R/write.txt.long.R
@@ -4,25 +4,25 @@
 ###
 ###
 
-##' @param object the \code{hyperSpec} object
-##' @param order which columns should be \code{\link[base]{order}}ed?
-##'   \code{order} is used as index vector into a \code{data.frame} with
-##'   columns given by \code{cols}.
-##' @param na.last handed to \code{\link[base]{order}} by
-##'   \code{write.txt.long}.
-##' @param quote,sep,col.names,row.names have their usual meaning (see
-##'   \code{\link[utils]{read.table}} and \code{\link[utils]{write.table}}),
-##'   but different default values.
-##'
-##'   For file import, \code{row.names} should usually be \code{NULL} so that the
-##' first column becomes a extra data column (as opposed to row names of the extra data).
-##' @param col.labels Should the column labels be used rather than the
-##'   colnames?
-##' @param append Should the output be appended to an existing file?
-##' @aliases write.txt.long
-##' @rdname textio
-##' @export
-##' @importFrom utils write.table
+#' @param object the \code{hyperSpec} object
+#' @param order which columns should be \code{\link[base]{order}}ed?
+#'   \code{order} is used as index vector into a \code{data.frame} with
+#'   columns given by \code{cols}.
+#' @param na.last handed to \code{\link[base]{order}} by
+#'   \code{write.txt.long}.
+#' @param quote,sep,col.names,row.names have their usual meaning (see
+#'   \code{\link[utils]{read.table}} and \code{\link[utils]{write.table}}),
+#'   but different default values.
+#'
+#'   For file import, \code{row.names} should usually be \code{NULL} so that the
+#' first column becomes a extra data column (as opposed to row names of the extra data).
+#' @param col.labels Should the column labels be used rather than the
+#'   colnames?
+#' @param append Should the output be appended to an existing file?
+#' @aliases write.txt.long
+#' @rdname textio
+#' @export
+#' @importFrom utils write.table
 write.txt.long <- function(object,
                            file = "",
                            order = c(".rownames", ".wavelength"),

--- a/hyperSpec/R/write.txt.long.R
+++ b/hyperSpec/R/write.txt.long.R
@@ -60,12 +60,12 @@ write.txt.long <- function(object,
     order.data <- as.list(X [, order, drop = FALSE])
 
     for (i in seq_along(order)) {
-      if (is.factor(order.data [[i]])) {
-        order.data [[i]] <- rank(order.data [[i]], na.last = na.last | is.na(na.last))
+      if (is.factor(order.data[[i]])) {
+        order.data[[i]] <- rank(order.data[[i]], na.last = na.last | is.na(na.last))
       }
 
       if (decreasing [i]) {
-        order.data [[i]] <- -order.data [[i]]
+        order.data[[i]] <- -order.data[[i]]
       }
     }
 

--- a/hyperSpec/R/write.txt.wide.R
+++ b/hyperSpec/R/write.txt.wide.R
@@ -3,13 +3,13 @@
 ### write.txt.wide
 ###
 ###
-##' @param header.lines Toggle one or two line header (wavelengths in the
-##'   second header line) for \code{write.txt.wide}
-##' @aliases write.txt.wide
-##' @rdname textio
-##' @export
-##' @importFrom utils write.table
-##'
+#' @param header.lines Toggle one or two line header (wavelengths in the
+#'   second header line) for \code{write.txt.wide}
+#' @aliases write.txt.wide
+#' @rdname textio
+#' @export
+#' @importFrom utils write.table
+#'
 
 write.txt.wide <- function(object,
                            file = "",

--- a/hyperSpec/R/write.txt.wide.R
+++ b/hyperSpec/R/write.txt.wide.R
@@ -92,7 +92,7 @@ write.txt.wide <- function(object,
 
   # no AsIs columns!
   for (c in which(sapply(object@data, class) == "AsIs")) {
-    class(object@data [[c]]) <- NULL
+    class(object@data[[c]]) <- NULL
   }
 
   write.table(object@data,

--- a/hyperSpec/R/zzz.R
+++ b/hyperSpec/R/zzz.R
@@ -5,19 +5,19 @@
   first_url <- sub(",.*$", "", desc$URL) # To use the first URL only
 
   packageStartupMessage(
-    '\n\n',
-    'Package ',  desc$Package, ' (version ', desc$Version, ')\n\n',
+    "\n\n",
+    "Package ", desc$Package, " (version ", desc$Version, ")\n\n",
 
-    'To get started, try: \n',
-    '   vignette("', desc$Package, '", package = "', desc$Package, '")', '\n',
-    '   package?', desc$Package,                      '\n',
+    "To get started, try: \n",
+    '   vignette("', desc$Package, '", package = "', desc$Package, '")', "\n",
+    "   package?", desc$Package, "\n",
     '   browseVignettes(package = "', desc$Package, '")\n',
-    '   vignette(package = "', desc$Package, '")',    '\n',
+    '   vignette(package = "', desc$Package, '")', "\n",
     # '   browseURL("', first_url, '") # Online documentation \n',
-    '\n',
+    "\n",
 
-    'If you use this package, please cite it appropriately.\n',
-    'The correct reference is given by:\n',
+    "If you use this package, please cite it appropriately.\n",
+    "The correct reference is given by:\n",
     '   citation("', desc$Package, '")\n\n',
 
     "The project's website:\n   ", first_url, "\n\n",

--- a/hyperSpec/data-raw/chondro.R
+++ b/hyperSpec/data-raw/chondro.R
@@ -45,19 +45,19 @@ spectra_to_save$clusters[-out] <- chondro_0$clusters
 pca <- prcomp(spectra_to_save)
 
 # Construct hyperSpe object --------------------------------------------------
-.chondro_0_scores   <- pca$x[,   seq_len(10)]
+.chondro_0_scores <- pca$x[, seq_len(10)]
 .chondro_0_loadings <- pca$rot[, seq_len(10)]
-.chondro_0_center   <- pca$center
-.chondro_0_wl       <- wl(chondro_0)
-.chondro_0_labels   <- lapply(labels(chondro_0), as.expression)
-.chondro_0_extra    <- spectra_to_save$..
+.chondro_0_center <- pca$center
+.chondro_0_wl <- wl(chondro_0)
+.chondro_0_labels <- lapply(labels(chondro_0), as.expression)
+.chondro_0_extra <- spectra_to_save$..
 
 chondro <-
   new(
     "hyperSpec",
     spc =
       tcrossprod(.chondro_0_scores, .chondro_0_loadings) +
-      rep(.chondro_0_center, each = nrow(.chondro_0_scores)),
+        rep(.chondro_0_center, each = nrow(.chondro_0_scores)),
     wavelength = .chondro_0_wl,
     data = .chondro_0_extra,
     labels = .chondro_0_labels
@@ -65,4 +65,3 @@ chondro <-
 
 # Save the prepared dataset as package data ----------------------------------
 usethis::use_data(chondro, overwrite = TRUE)
-

--- a/hyperSpec/data-raw/flu.R
+++ b/hyperSpec/data-raw/flu.R
@@ -10,11 +10,11 @@ library(usethis)
 source("vignettes/read.txt.PerkinElmer.R")
 
 folder <- system.file("extdata/flu", package = "hyperSpec")
-files  <- Sys.glob(paste0(folder, "/flu?.txt"))
-flu0   <- read.txt.PerkinElmer(files, skip = 54)
+files <- Sys.glob(paste0(folder, "/flu?.txt"))
+flu0 <- read.txt.PerkinElmer(files, skip = 54)
 
 # Pre-process ----------------------------------------------------------------
-flu0$c        <- seq(from = 0.05, to = 0.30, by = 0.05)
+flu0$c <- seq(from = 0.05, to = 0.30, by = 0.05)
 flu0$filename <- basename(flu0$filename)
 labels(flu0, "c") <- "c, mg/l"
 

--- a/hyperSpec/data-raw/laser.R
+++ b/hyperSpec/data-raw/laser.R
@@ -7,7 +7,7 @@ library(hyperSpec)
 library(usethis)
 
 # Read the raw data ----------------------------------------------------------
-file   <- system.file("extdata/laser.txt.gz", package = "hyperSpec")
+file <- system.file("extdata/laser.txt.gz", package = "hyperSpec")
 laser0 <- read.txt.Renishaw(file, data = "ts") # Renishaw file
 
 # Pre-process ----------------------------------------------------------------

--- a/hyperSpec/tests/testthat/test-attached.R
+++ b/hyperSpec/tests/testthat/test-attached.R
@@ -1,8 +1,8 @@
 # C. Beleites
-# get all tests attached to objects 
-tests <- eapply(env=getNamespace ("hyperSpec"), FUN=get.test, all.names=TRUE) 
-tests <- tests [! sapply (tests, is.null)] 
+# get all tests attached to objects
+tests <- eapply(env = getNamespace("hyperSpec"), FUN = get.test, all.names = TRUE)
+tests <- tests [!sapply(tests, is.null)]
 
-for (t in seq_along (tests))   
-  tests [[t]] ()
-
+for (t in seq_along(tests)) {
+  tests [[t]]()
+}

--- a/hyperSpec/tests/testthat/test-attached.R
+++ b/hyperSpec/tests/testthat/test-attached.R
@@ -4,5 +4,5 @@ tests <- eapply(env = getNamespace("hyperSpec"), FUN = get.test, all.names = TRU
 tests <- tests [!sapply(tests, is.null)]
 
 for (t in seq_along(tests)) {
-  tests [[t]]()
+  tests[[t]]()
 }

--- a/hyperSpec/tests/testthat/test-plotspc.r
+++ b/hyperSpec/tests/testthat/test-plotspc.r
@@ -1,10 +1,7 @@
-context ("plotspc")
+context("plotspc")
 
 test_that("BARBITURATES", {
-  spc <- do.call (collapse, barbiturates [1:3])
+  spc <- do.call(collapse, barbiturates [1:3])
 
-  plotspc (spc, col = matlab.dark.palette (3), stacked = TRUE, lines.args = list (type = "h"))
-
-}) 
-
-
+  plotspc(spc, col = matlab.dark.palette(3), stacked = TRUE, lines.args = list(type = "h"))
+})

--- a/hyperSpec/tests/unittests.R
+++ b/hyperSpec/tests/unittests.R
@@ -1,3 +1,2 @@
-library (testthat)
+library(testthat)
 test_check("hyperSpec")
-

--- a/hyperSpec/vignettes/plotting.Rmd
+++ b/hyperSpec/vignettes/plotting.Rmd
@@ -124,7 +124,7 @@ dummies <- check.req.pkg("latticeExtra",
   hynsgrid   = "plotvoronoi"
 )
 for (i in seq_along(dummies)) {
-  eval(dummies [[i]])
+  eval(dummies[[i]])
 }
 
 check.req.pkg("deldir", hynsgrid = "plotvoronoi")


### PR DESCRIPTION
- [x] Replace ##' → #' in .R files These changes enable some functionality in RStudio. Closes #184. 
- [x] Apply *styler* on the package. It fixes most of the style issues in R code of examples as elsewhere the code was styled in #117. Some changes may occur outside the documentation.
