### PR TITLE
 Updated setup to build pkgdown website

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -65,3 +65,4 @@ jobs:
         run: |
           pkgdown::deploy_to_branch("./hyperSpec", new_process = FALSE)
         shell: Rscript {0}
+

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,9 +1,11 @@
 on:
   push:
     branches:
+      - release
       - master
       - develop
-      - fix/190-pkgdown-setup
+      - feature/polish-vignettes
+      - feature/update-pkgdown-settings
 
 name: Update pkgdown website
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,7 +3,7 @@ on:
     branches:
       - master
       - develop
-      - feature/vignettes-in-rmd
+      - fix/190-pkgdown-setup
 
 name: Update pkgdown website
 
@@ -13,10 +13,13 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: 'release'
 
       - uses: r-lib/actions/setup-pandoc@master
 


### PR DESCRIPTION
The main update in the setup is the setting to explicitly use "release" version of R.

Works on my fork:

![image](https://user-images.githubusercontent.com/12725868/85336432-4073d700-b4e7-11ea-9715-4bb68f0d4ed0.png)


Fixes #190.
