### PR TITLE
Treat warnings as errors on R-devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -108,7 +108,7 @@ jobs:
           rcmdcheck::rcmdcheck(
             "./hyperSpec",
             args = c("--no-manual", "--as-cran"),
-            error_on = "error",
+            error_on = "warning",
             check_dir = "check"
           )
         shell: Rscript {0}


### PR DESCRIPTION
The setup of R CMD check on GH Actions was updated. Should be updated accordingli in **hySpc.skeleton** and all ater packages.

Closes #200 