### PR TITLE
Document & export .fileio.optional

### DIFF
--- a/hyperSpec/R/fileio.optional.R
+++ b/hyperSpec/R/fileio.optional.R
@@ -1,13 +1,31 @@
-## TODO: blog post after feature is finished
-
-## consistent optional treatment during file import
-
-.fileio.optional <- function (spc, filename, ...,
-                              file.remove.emptyspc = hy.getOption ("file.remove.emptyspc"),
-                              file.keep.name = hy.getOption ("file.keep.name"),
-															tolerance = hy.getOption ("tolerance")){
-
-	tolerance <- .checkpos (tolerance, "tolerance")
+#' Helper function to harmonize treatment of file import results
+#'
+#' This function provides two ways of post-processing imported spectra:
+#'
+#' - optionally remove empty spectra (some spectrograph software will produce
+#'   empty spectra when measurements are cancelled)
+#' - optionally keep the filenames in column `spc$filename`
+#'
+#' The desired overall behavior can be set by options via [hy.setOptions()]. All
+#' file import filters should call `.fileio.optional()` to ensure the same
+#' behavior.
+#'
+#' @param spc hyperSpec object for file import post-processing
+#' @param filename filename(s) to become extra data column of `spc`
+#' @param ... (ignored)
+#' @param file.remove.emptyspc should empty (all `NA` or all `0`) spectra be
+#'   removed?
+#' @param file.keep.name should file names be kept and put into `spc$filename`?
+#' @param tolerance intensities in +/- `tolerance` are considered `0` for
+#'   `file.remove.emptyspc = TRUE`
+#' @keywords internal
+#' @return hyperSpec object
+#' @export
+.fileio.optional <- function(spc, filename, ...,
+                             file.remove.emptyspc = hy.getOption("file.remove.emptyspc"),
+                             file.keep.name = hy.getOption("file.keep.name"),
+                             tolerance = hy.getOption("tolerance")) {
+  tolerance <- .checkpos(tolerance, "tolerance")
 
   if (file.remove.emptyspc) {
     ## number of NAs in each spectrum
@@ -16,7 +34,7 @@
     ## number of zero-values in each spectrum
     zeros <- rowSums (abs (spc) < tolerance, na.rm = TRUE)
 
-    spc <- spc [nas + zeros < nwl (spc)]
+    spc <- spc[nas + zeros < nwl(spc)]
   }
 
   if (file.keep.name & nrow (spc) > 0L){


### PR DESCRIPTION
Exporting is required so that the new hySpc.read.* packages can use it.