### PR TITLE
Use of tibble::glimpse to show contents of the extra data (#210).

### DIFF
--- a/hyperSpec/DESCRIPTION
+++ b/hyperSpec/DESCRIPTION
@@ -76,6 +76,7 @@ Imports:
     latticeExtra,
     lazyeval,
     dplyr,
+    tibble,
     rlang
 URL: 
     https://cbeleites.github.io/hyperSpec,

--- a/hyperSpec/R/show.R
+++ b/hyperSpec/R/show.R
@@ -14,6 +14,7 @@
 #'
 #' @seealso [base::as.character()]
 #' @include paste.row.R
+#' @importFrom tibble glimpse
 #' @export
 
 setMethod("as.character",
@@ -58,15 +59,9 @@ setMethod("as.character",
     ))
 
     if (n.cols > 0) {
-      for (n in names(x@data)) {
-        chr <- c(chr, .paste.row(x@data[[n]], x@label[[n]], n,
-          ins = 3,
-          i = match(n, names(x@data)),
-          val = TRUE, range = range,
-          shorten.to = shorten.to, max.print = max.print
-        ))
+      # glimpse at the contents of the extra data
+      chr <- c(chr, paste0(strsplit(capture.output(glimpse(x$.)), split="\n")[-(1:2)]))
       }
-    }
 
     chr
   }


### PR DESCRIPTION
Output of the show()/print() is formed with `glimpse`, as suggested in #210 

It is more compact, uses abbreviations for the data types, always occupies the full console width, and uses colors in RStudio. The result looks like this:
![image](https://user-images.githubusercontent.com/8937566/87382040-a76f3380-c55b-11ea-837d-a26ebd2fcd41.png)





