### PR TITLE
Export function that generates faux_cell data

### DIFF
--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -8,6 +8,7 @@
 * Documentation now available in `pkgdown` sites.
 * Introductory vignette reorganized and enhanced, thanks to Bryan Hanson.
 * Portions of `hyperSpec` were spun out into their own packages for ease of maintenance.  ELABORATE
+* Dataset `faux_cell` and function `generate_faux_cell` replace `chondro` dataset #125, #156, #180, #229).
 
 ## Non-User-Facing Changes from 0.99 Series
 * Note: this listing is for the benefit of developers, and should summarize significant infrastructure changes.

--- a/hyperSpec/R/faux_cell.R
+++ b/hyperSpec/R/faux_cell.R
@@ -165,3 +165,20 @@ generate_faux_cell <- function() {
 delayedAssign("faux_cell", generate_faux_cell())
 
 
+# Unit tests -----------------------------------------------------------------
+.test(generate_faux_cell) <- function() {
+
+  context("generate_faux_cell")
+
+  # Perform tests
+  test_that("generate_faux_cell() works", {
+    set.seed(1)
+    expect_silent(faux_cell_data <- generate_faux_cell())
+    expect_is(faux_cell_data, "hyperSpec")
+
+    set.seed(1)
+    expect_silent(faux_cell_data_2 <- generate_faux_cell())
+    expect_identical(faux_cell_data, faux_cell_data_2)
+  })
+}
+

--- a/hyperSpec/R/faux_cell.R
+++ b/hyperSpec/R/faux_cell.R
@@ -1,5 +1,55 @@
-generate_faux_cell <- function() {
 
+# Faux cell data generation function -----------------------------------------
+
+#' Faux Cell Data Set for Testing & Demonstration.
+#'
+#' This is a synthetic data set intended for testing and demonstration.
+#'
+#' The data set resembles the `chondro` data set but is entirely synthetic.
+#'
+#' @format The object contains 875 Raman-like spectra, allocated to three
+#'   groups/regions in column region: the matrix/background, the cell and the
+#'   cell nucleus. Each spectrum is composed of 300 data points.  The spectrum
+#'   of each region is unique and simple, with a single peak at a particular
+#'   frequency and line width.  Poisson noise has been added.  The data is
+#'   indexed along the x and y dimensions, simulating data collected on a grid.
+#'
+#' @rdname faux_cell
+#' @docType data
+#' @include initialize.R
+#' @keywords datasets
+#' @concept datasets
+#' @export
+#' @author Claudia Beleites, Bryan A. Hanson
+#' @examples
+#'
+#' faux_cell
+#'
+#' plot(sample(faux_cell, 10), stacked = TRUE)
+#'
+#' # Plot mean spectra
+#' FCgrps <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
+#' plotspc(FCgrps,
+#'   stacked = ".aggregate",
+#'   col = c("red", "green", "blue"), fill = ".aggregate"
+#' )
+#'
+#' mapcols <- c(cell = "aquamarine", matrix = "aliceblue", nucleus = "dodgerblue")
+#' plotmap(faux_cell, region ~ x * y, col.regions = mapcols)
+#'
+#' # PCA
+#' pca <- prcomp(faux_cell)
+#' plot(pca)
+#'
+#' loadings <- decomposition(faux_cell, t(pca$rotation), scores = FALSE)
+#' plot(loadings[1:5], stacked = TRUE)
+#'
+#' plot(pca$x[, 2], pca$x[, 3],
+#'   xlab = "PC 1", ylab = "PC 2",
+#'   bg = mapcols[faux_cell$region], col = "black", pch = 21
+#' )
+
+generate_faux_cell <- function() {
 
   # Check for points inside ellipse
   #
@@ -11,6 +61,7 @@ generate_faux_cell <- function() {
   # @param scale length of the main axes
   # @param rot rotation angle
   # @return logical indicating points inside the ellipse
+
   in_ellipse <- function(xy, center = c(0, 0), scale = c(1, 1), a = 0,
                          debuglevel = 0L) {
     xy <- as.matrix(xy)
@@ -98,51 +149,11 @@ generate_faux_cell <- function() {
   spc
 }
 
-#' Faux Cell Data Set for Testing & Demonstration.
-#'
-#' This is a synthetic data set intended for testing and demonstration.
-#'
-#' The data set resembles the `chondro` data set but is entirely synthetic.
-#'
-#' @format The object contains 875 Raman-like spectra, allocated to three
-#'   groups/regions in column region: the matrix/background, the cell and the
-#'   cell nucleus. Each spectrum is composed of 300 data points.  The spectrum
-#'   of each region is unique and simple, with a single peak at a particular
-#'   frequency and line width.  Poisson noise has been added.  The data is
-#'   indexed along the x and y dimensions, simulating data collected on a grid.
-#'
+
+# Generate an instance of faux cell data -------------------------------------
 #' @rdname faux_cell
-#' @docType data
-#' @include initialize.R
-#' @keywords datasets
-#' @concept datasets
 #' @export
-#' @author Claudia Beleites, Bryan A. Hanson
-#' @examples
-#'
-#' faux_cell
-#'
-#' plot(sample(faux_cell, 10), stacked = TRUE)
-#'
-#' # Plot mean spectra
-#' FCgrps <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
-#' plotspc(FCgrps,
-#'   stacked = ".aggregate",
-#'   col = c("red", "green", "blue"), fill = ".aggregate"
-#' )
-#'
-#' mapcols <- c(cell = "aquamarine", matrix = "aliceblue", nucleus = "dodgerblue")
-#' plotmap(faux_cell, region ~ x * y, col.regions = mapcols)
-#'
-#' # PCA
-#' pca <- prcomp(faux_cell)
-#' plot(pca)
-#'
-#' loadings <- decomposition(faux_cell, t(pca$rotation), scores = FALSE)
-#' plot(loadings[1:5], stacked = TRUE)
-#'
-#' plot(pca$x[, 2], pca$x[, 3],
-#'   xlab = "PC 1", ylab = "PC 2",
-#'   bg = mapcols[faux_cell$region], col = "black", pch = 21
-#' )
+
 delayedAssign("faux_cell", generate_faux_cell())
+
+

--- a/hyperSpec/R/faux_cell.R
+++ b/hyperSpec/R/faux_cell.R
@@ -4,32 +4,40 @@
 #' Faux Cell Data Set for Testing & Demonstration.
 #'
 #' This is a synthetic data set intended for testing and demonstration.
+#' Function `generate_faux_cell()` simulates the faux cell data (*note:* in
+#' the future, it is planned to parameterize thefuncion) and object `faux_cell`
+#' is an instance of this dataset generated first time it is used.
 #'
 #' The data set resembles the `chondro` data set but is entirely synthetic.
 #'
-#' @format The object contains 875 Raman-like spectra, allocated to three
-#'   groups/regions in column region: the matrix/background, the cell and the
-#'   cell nucleus. Each spectrum is composed of 300 data points.  The spectrum
-#'   of each region is unique and simple, with a single peak at a particular
-#'   frequency and line width.  Poisson noise has been added.  The data is
-#'   indexed along the x and y dimensions, simulating data collected on a grid.
+#' @format The object `faux_cell` is a `hyperSpec` object that contains 875
+#'  Raman-like spectra, allocated to three groups/regions in column region:
+#'  the matrix/background, the cell and the cell nucleus. Each spectrum is
+#'  composed of 300 data points. The spectrum of each region is unique and
+#'  simple, with a single peak at a particular frequency and line width.
+#'  Poisson noise has been added. The data is indexed along the x and y
+#'  dimensions, simulating data collected on a grid.
 #'
 #' @rdname faux_cell
+#' @aliases faux_cell generate_faux_cell
 #' @docType data
 #' @include initialize.R
 #' @keywords datasets
 #' @concept datasets
+#' @concept data generation
 #' @export
 #' @author Claudia Beleites, Bryan A. Hanson
 #' @examples
+#' set.seed(1)
+#' faux_cell <- generate_faux_cell()
 #'
 #' faux_cell
 #'
 #' plot(sample(faux_cell, 10), stacked = TRUE)
 #'
 #' # Plot mean spectra
-#' FCgrps <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
-#' plotspc(FCgrps,
+#' fc_groups <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
+#' plotspc(fc_groups,
 #'   stacked = ".aggregate",
 #'   col = c("red", "green", "blue"), fill = ".aggregate"
 #' )

--- a/hyperSpec/R/faux_cell.R
+++ b/hyperSpec/R/faux_cell.R
@@ -1,4 +1,4 @@
-.faux_cell <- function() {
+generate_faux_cell <- function() {
 
 
   # Check for points inside ellipse
@@ -145,4 +145,4 @@
 #'   xlab = "PC 1", ylab = "PC 2",
 #'   bg = mapcols[faux_cell$region], col = "black", pch = 21
 #' )
-delayedAssign("faux_cell", .faux_cell())
+delayedAssign("faux_cell", generate_faux_cell())


### PR DESCRIPTION
This is the step towards solving #154. This PR:

- renames `.faux_cell()` into `generate_faux_cell()` and exports it.
- makes related changes in documentation.
- adds unit tests.
- adds a bullet to `NEWS.md`  (the bullet should be updated later as the work progresses).