### PR TITLE
Feature/Get list of available hySpc packages

### DIFF
--- a/hyperSpec/DESCRIPTION
+++ b/hyperSpec/DESCRIPTION
@@ -131,6 +131,8 @@ Collate:
     'flu.R'
     'generate-test-data.R'
     'getbynames.R'
+    'hy_browse_homepage.R'
+    'hy_list_available_hySpc_packages.R'
     'paracetamol.R'
     'laser.R'
     'hyperspec-package.R'

--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -19,6 +19,8 @@
 * Dataset `faux_cell` and function `generate_faux_cell` replace `chondro` dataset (#125, #156, #180, #229).
 * Function `spc.NA.linapprox()`, which was deprecated for long time, is now completely removed (#239).
 * Column names in spectra matrix (`$spc` column of `hyperSpec` object) are now returned correctly by functions `spc.bin()` (#237), and `spc.loess()` (#245).
+* New function `hy_list_available_hySpc_packages()` lists packages, that are available in GitHub organization `r-hyperSpec`.
+* New function `hy_browse_homepage()` opens the homepage of *R hyperSpec* in a web browser.
 
 
 ## Non-User-Facing Changes from 0.99 Series

--- a/hyperSpec/R/hy_browse_homepage.R
+++ b/hyperSpec/R/hy_browse_homepage.R
@@ -1,0 +1,18 @@
+
+#' Browse homepage of *R hyperSpec*
+#'
+#' Browse homepage of [**R hyperSpec**](https://r-hyperspec.github.io/)
+#' family packages.
+#'
+#' @export
+#'
+#' @concept utils
+#'
+#' @examples
+#' \dontrun{
+#' hy_browse_homepage()
+#' }
+
+hy_browse_homepage <- function() {
+  browseURL("https://r-hyperspec.github.io/")
+}

--- a/hyperSpec/R/hy_list_available_hySpc_packages.R
+++ b/hyperSpec/R/hy_list_available_hySpc_packages.R
@@ -1,0 +1,53 @@
+
+#' List available *R hyperSpec* family packages
+#'
+#' @description
+#' Get the names of *R hyperSpec* family packages that are available on GitHub
+#' organization [**`r-hyperspec`**](https://r-hyperspec.github.io/)
+#' (the official homepage of these packages).
+#'
+#' This function requires Internet connection.
+#'
+#' @details
+#' If your machine is connected to the Internet and you receive issues due to
+#' overused limit of anonymous connections to GitHub, you may run alternative
+#' code that employs GitHub PAT (personal access token) for authentication.
+#' On how to set your GitHub PAT, see sections "Create a PAT" and
+#' "Add your PAT to `.Renviron`" in this book:
+#' [happygitwithr.com/github-pat.html](https://happygitwithr.com/github-pat.html#step-by-step).
+#'
+#' ```r
+#' # install.pacakges("gh")
+#' gh_api_response <- gh::gh("GET /users/r-hyperspec/repos?per_page=100")
+#' repo_names <- vapply(gh_api_response, "[[", "", "name")
+#' package_names <- grep("^hyperSpec|^hySpc[.]", repo_names, value = TRUE)
+#' package_names
+#' ```
+#'
+#' @return Character vector with the names of the pacakges.
+#' @export
+#'
+#' @concept utils
+#'
+#' @author V. Gegzna
+#'
+#' @examples
+#' \dontrun{
+#' hy_list_available_hySpc_packages()
+#' }
+
+hy_list_available_hySpc_packages <- function() {
+
+  # TODO: Check if there is an access to the Internet. In case of no access,
+  #       a more user-friendly error message should be given.
+
+  gh_api_response <- readLines(
+    "https://api.github.com/orgs/r-hyperspec/repos?per_page=100",
+    warn = FALSE
+  )
+  one_line_per_repo <- strsplit(gh_api_response, "}}")[[1]]
+  pattern <- '(?<="name":")(hyperSpec|hySpc[.].*?)(?=",)'
+  matches <- regexpr(pattern = pattern, text = one_line_per_repo, perl = TRUE)
+  package_names <- regmatches(one_line_per_repo, m = matches)
+  package_names
+}

--- a/hyperSpec/R/hy_list_available_hySpc_packages.R
+++ b/hyperSpec/R/hy_list_available_hySpc_packages.R
@@ -51,3 +51,19 @@ hy_list_available_hySpc_packages <- function() {
   package_names <- regmatches(one_line_per_repo, m = matches)
   package_names
 }
+
+# Unit tests -----------------------------------------------------------------
+
+hySpc.testthat::test(hy_list_available_hySpc_packages) <- function() {
+  context("hy_list_available_hySpc_packages")
+
+  test_that("hy_list_available_hySpc_packages() works", {
+
+    # TODO: skip if not online
+
+    expect_silent(pkgs <- hy_list_available_hySpc_packages())
+    expect_is(pkgs, "character")
+    expect_true(length(pkgs) > 5)
+    expect_true(all(grepl("^hySpc[.]|^hyperSpec$", pkgs)))
+  })
+}


### PR DESCRIPTION
These functions require an Internet connection. The functions include funktionality like:

- to open *R hyperSpec* homepage in a browser;
- to list all *R hyperSpec* in GitHub's `r-hyperspec` organization.

In the future, this functionality may be used to check which packages should be installed.