### PR TITLE
Fix unit test and CI workflow due to changes in deldir & rgl

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,9 +70,14 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps("./hyperSpec", dependencies = TRUE)
-          remotes::install_cran("rgl")
           remotes::install_cran("rcmdcheck")
           remotes::install_cran("devtools")
+        shell: Rscript {0}
+
+      - name: Install dependencies (for R-oldrel)
+        if: matrix.config.r == 'oldrel'
+        run: |
+          remotes::install_version("rgl", "0.100.50")
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,6 +70,7 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps("./hyperSpec", dependencies = TRUE)
+          remotes::install_cran("rgl")
           remotes::install_cran("rcmdcheck")
           remotes::install_cran("devtools")
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,7 +17,7 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (R-${{ matrix.config.r }})
 
     strategy:
       fail-fast: false

--- a/hyperSpec/R/plot.R
+++ b/hyperSpec/R/plot.R
@@ -229,7 +229,7 @@ hySpc.testthat::test(.plot) <- function() {
     expect_silent(plot_depth)
 
     expect_silent(plot_map)
-    expect_message(print(plot_voronoi))
+    expect_silent(plot_voronoi)
 
     # Visual tests
     vdiffr::expect_doppelganger("plot-c",       plot_c)


### PR DESCRIPTION
This issue is related to the updated version of **deldir** package.

You may reproduce the previous behavior by installing the previous version of *deldir*:
```r
remotes::install_version("deldir", "0.1-29")
```
And running the code:
```r
library(hyperSpec)
hy_map <- generate_hy_map()
plot_voronoi <- plot(hy_map, "voronoi")
plot_voronoi
```



Closes #290