### PR TITLE
Feature/288 initialize with wl only

### DIFF
--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -21,6 +21,7 @@
 * Column names in spectra matrix (`$spc` column of `hyperSpec` object) are now returned correctly by functions `spc.bin()` (#237), and `spc.loess()` (#245).
 * New function `hy_list_available_hySpc_packages()` lists packages, that are available in GitHub organization `r-hyperSpec`.
 * New function `hy_browse_homepage()` opens the homepage of *R hyperSpec* in a web browser.
+* Possibility to initialize `hyperSpec` object by providing wavelengths only (#288).
 
 
 ## Non-User-Facing Changes from 0.99 Series

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -321,5 +321,22 @@ hySpc.testthat::test(.initialize) <- function() {
     spc <- new("hyperSpec", spc = flu[[]])
     expect_equal(spc[[]], flu[[]])
   })
+
+
+  test_that("hyperSpec initializes with wavelength only", {
+    # One wavelength
+    expect_silent(hy_obj_1 <- new("hyperSpec", wavelength = 1))
+    expect_equal(nwl(hy_obj_1), 1)
+    expect_equal(nrow(hy_obj_1), 0)
+    expect_equal(ncol(hy_obj_1), 1)
+    expect_equal(colnames(hy_obj_1), "spc")
+
+    # 100 wavelengths
+    expect_silent(hy_obj_2 <- new("hyperSpec", wavelength = 1:100))
+    expect_equal(nwl(hy_obj_2), 100)
+    expect_equal(nrow(hy_obj_2), 0)
+    expect_equal(ncol(hy_obj_2), 1)
+    expect_equal(colnames(hy_obj_2), "spc")
+  })
 }
 

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -31,6 +31,11 @@
     nwl <- 0
   }
 
+  if (is.null(spc) && is.null(data) && !is.null(wavelength) &&
+      is.numeric(wavelength) && is.vector(wavelength)) {
+
+    spc <- matrix(NA_real_, ncol = length(wavelength), nrow = 0)
+  }
 
   if (is.null(wavelength)) {
     ## guess from spc's colnames


### PR DESCRIPTION
This PR enables the possibility to initialize `hyperSpec` object by providing only wavelengths. So the following syntax does not fail anymore:

```r
new("hyperSpec", wavelength = 300:400)
```
![image](https://user-images.githubusercontent.com/12725868/102792731-93085000-43b1-11eb-9631-25ad50a39d7e.png)


Includes fix #291, closes #288.