### PR TITLE
Feature/282 Create method as.hyperSpec(<hyperSpec>)

### DIFF
--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -21,6 +21,7 @@
 * Column names in spectra matrix (`$spc` column of `hyperSpec` object) are now returned correctly by functions `spc.bin()` (#237), and `spc.loess()` (#245).
 * New function `hy_list_available_hySpc_packages()` lists packages, that are available in GitHub organization `r-hyperSpec`.
 * New function `hy_browse_homepage()` opens the homepage of *R hyperSpec* in a web browser.
+* New method `as.hyperSpec(<hyperSpec>)` (#282).
 
 
 ## Non-User-Facing Changes from 0.99 Series

--- a/hyperSpec/R/as_hyperSpec.R
+++ b/hyperSpec/R/as_hyperSpec.R
@@ -69,6 +69,14 @@ setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
 setMethod("as.hyperSpec", "data.frame", .as.hyperSpec.data.frame)
 
 
+.as.hyperSpec.hyperSpec <- function(X) {
+  X
+}
+
+#' @rdname as.hyperSpec
+setMethod("as.hyperSpec", "hyperSpec", .as.hyperSpec.hyperSpec)
+
+
 # Unit tests -----------------------------------------------------------------
 
 

--- a/hyperSpec/R/as_hyperSpec.R
+++ b/hyperSpec/R/as_hyperSpec.R
@@ -149,4 +149,8 @@ hySpc.testthat::test(as.hyperSpec) <- function() {
     tmp <- new("hyperSpec", spc = spc, wavelength = wl)
     expect_equal(colnames(tmp$spc), as.character(signif(wl, 6)))
   })
+
+  test_that("as.hyperSpec(<hyperSpec>) works", {
+    expect_equal(as.hyperSpec(flu), flu)
+  })
 }


### PR DESCRIPTION
Closes #282