### PR TITLE
Fearure/287 create method wl.eval(<numeric>)

### DIFF
--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -21,6 +21,7 @@
 * Column names in spectra matrix (`$spc` column of `hyperSpec` object) are now returned correctly by functions `spc.bin()` (#237), and `spc.loess()` (#245).
 * New function `hy_list_available_hySpc_packages()` lists packages, that are available in GitHub organization `r-hyperSpec`.
 * New function `hy_browse_homepage()` opens the homepage of *R hyperSpec* in a web browser.
+* Possibility to initialize `hyperSpec` object by providing wavelengths only (#288).
 
 
 ## Non-User-Facing Changes from 0.99 Series

--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -22,6 +22,7 @@
 * New function `hy_list_available_hySpc_packages()` lists packages, that are available in GitHub organization `r-hyperSpec`.
 * New function `hy_browse_homepage()` opens the homepage of *R hyperSpec* in a web browser.
 * Possibility to initialize `hyperSpec` object by providing wavelengths only (#288).
+* Function `wl.eval()` is converted into S3 generic. Methods `wl.eval(<hyperSpec>)` and `wl.eval(<numeric>)` for numeric vectors were added (#287).
 
 
 ## Non-User-Facing Changes from 0.99 Series

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -99,7 +99,6 @@
     }
   }
 
-
   if (!is.null(spc) && !is.numeric(spc) && !all(is.na(spc))) {
     dim <- dim(spc)
     spc <- suppressWarnings(as.numeric(spc))

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -321,5 +321,22 @@ hySpc.testthat::test(.initialize) <- function() {
     spc <- new("hyperSpec", spc = flu[[]])
     expect_equal(spc[[]], flu[[]])
   })
+
+
+  test_that("hyperSpec initializes with wavelength only", {
+    # One wavelength
+    expect_silent(hy_obj_1 <- new("hyperSpec", wavelength = 1))
+    expect_equal(nwl(hy_obj_1), 1)
+    expect_equal(nrow(hy_obj_1), 0)
+    expect_equal(ncol(hy_obj_1), 1)
+    expect_equal(colnames(hy_obj_1), "spc")
+
+    # 100 wavelengths
+    expect_silent(hy_obj_2 <- new("hyperSpec", wavelength = 1:100))
+    expect_equal(nwl(hy_obj_2), 100)
+    expect_equal(nrow(hy_obj_2), 0)
+    expect_equal(ncol(hy_obj_2), 1)
+    expect_equal(colnames(hy_obj_2), "spc")
+  })
 }
 

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -99,6 +99,7 @@
     }
   }
 
+
   if (!is.null(spc) && !is.numeric(spc) && !all(is.na(spc))) {
     dim <- dim(spc)
     spc <- suppressWarnings(as.numeric(spc))

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -31,6 +31,11 @@
     nwl <- 0
   }
 
+  if (is.null(spc) && is.null(data) && !is.null(wavelength) &&
+      is.numeric(wavelength) && is.vector(wavelength)) {
+
+    spc <- matrix(NA_real_, ncol = length(wavelength), nrow = 0)
+  }
 
   if (is.null(wavelength)) {
     ## guess from spc's colnames

--- a/hyperSpec/R/wl_eval.R
+++ b/hyperSpec/R/wl_eval.R
@@ -144,4 +144,9 @@ hySpc.testthat::test(wl.eval.hyperSpec) <- function() {
     )
     expect_equal(tmp$.f, c("f", "g"))
   })
+
+  test_that("wl.eval fails with matrix input", {
+    expect_error(wl.eval(matrix(1:10), f = function(x) x))
+    expect_error(wl.eval(matrix(), f = function(x) x))
+  })
 }

--- a/hyperSpec/R/wl_eval.R
+++ b/hyperSpec/R/wl_eval.R
@@ -15,10 +15,16 @@
 #' @seealso [hyperSpec::vanderMonde()] for  polynomials,
 #'
 #' [hyperSpec::normalize01()] to normalize the wavenumbers before evaluating the function
-#' @author C. Beleites
+#' @author C. Beleites, V. Gegzna
 #' @examples
 #' plot(wl.eval(laser, exp = function(x) exp(-x)))
 wl.eval <- function(x, ..., normalize.wl = I) {
+  UseMethod("wl.eval")
+}
+
+#' @rdname wl.eval
+#' @export
+wl.eval.hyperSpec <- function(x, ..., normalize.wl = I) {
   chk.hy(x)
   validObject(x)
 

--- a/hyperSpec/R/wl_eval.R
+++ b/hyperSpec/R/wl_eval.R
@@ -1,23 +1,33 @@
-#' Evaluate function on wavelengths of `hyperSpec` object.
+#' Evaluate function on wavelengths of `hyperSpec` object
 #'
 #' This is useful for generating certain types of baseline "reference spectra".
 #'
-#' @param x `hyperSpec` object
-#' @param ... hyperSpec method: expressions to be evaluated
-#' @param normalize.wl function to transorm the wavelengths before evaluating the polynomial (or
-#' other function). Use [hyperSpec::normalize01()] to map the wavelength range to the interval \[0, 1\].
-#' @return `hyperSpec` object containing one spectrum for each expression
+#' @param x either `hyperSpec` object or numeric vector.
+#' @param ... expressions to be evaluated.
+#' @param normalize.wl function to transorm the wavelengths before evaluating
+#' the polynomial (or  other function). Use [hyperSpec::normalize01()] to map
+#' the wavelength range to the interval \[0, 1\].
+#' @return `hyperSpec` object containing one spectrum for each expression.
 #'
 #' @export
 #'
 #' @concept wavelengths
 #'
-#' @seealso [hyperSpec::vanderMonde()] for  polynomials,
+#' @seealso
 #'
-#' [hyperSpec::normalize01()] to normalize the wavenumbers before evaluating the function
+#' - [hyperSpec::vanderMonde()] for  polynomials,
+#' - [hyperSpec::normalize01()] to normalize the wavenumbers before evaluating
+#' the function.
+#'
 #' @author C. Beleites, V. Gegzna
+#'
 #' @examples
 #' plot(wl.eval(laser, exp = function(x) exp(-x)))
+#'
+#' plot(wl.eval(1000:4000, y = function(x) 1/log(x)))
+#'
+#' plot(wl.eval(300:550, y2 = function(x) x*2, y3 = function(x) x*3))
+#'
 wl.eval <- function(x, ..., normalize.wl = I) {
   UseMethod("wl.eval")
 }
@@ -134,6 +144,4 @@ hySpc.testthat::test(wl.eval.hyperSpec) <- function() {
     )
     expect_equal(tmp$.f, c("f", "g"))
   })
-
-
 }

--- a/hyperSpec/R/wl_eval.R
+++ b/hyperSpec/R/wl_eval.R
@@ -15,16 +15,10 @@
 #' @seealso [hyperSpec::vanderMonde()] for  polynomials,
 #'
 #' [hyperSpec::normalize01()] to normalize the wavenumbers before evaluating the function
-#' @author C. Beleites, V. Gegzna
+#' @author C. Beleites
 #' @examples
 #' plot(wl.eval(laser, exp = function(x) exp(-x)))
 wl.eval <- function(x, ..., normalize.wl = I) {
-  UseMethod("wl.eval")
-}
-
-#' @rdname wl.eval
-#' @export
-wl.eval.hyperSpec <- function(x, ..., normalize.wl = I) {
   chk.hy(x)
   validObject(x)
 

--- a/hyperSpec/R/wl_eval.R
+++ b/hyperSpec/R/wl_eval.R
@@ -54,14 +54,17 @@ wl.eval.numeric <- function(x, ..., normalize.wl = I) {
 }
 
 
-hySpc.testthat::test(wl.eval) <- function() {
+# Unit tests -----------------------------------------------------------------
+
+
+hySpc.testthat::test(wl.eval.hyperSpec) <- function() {
   context("wl.eval")
 
   test_that("error on function not returning same length as input", {
     expect_error(wl.eval(flu, function(x) 1))
   })
 
-  test_that("wl.eval against manual evaluation", {
+  test_that("wl.eval(<hyperSpec>) against manual evaluation", {
     expect_equivalent(
       wl.eval(flu, function(x) rep(5, length(x)), normalize.wl = normalize01)[[]],
       matrix(rep(5, nwl(flu)), nrow = 1)
@@ -108,4 +111,29 @@ hySpc.testthat::test(wl.eval) <- function() {
 
     expect_equal(tmp$.f, c("f", "g"))
   })
+
+  test_that("wl.eval(<numeric>) works", {
+
+    expect_equal(
+      as.vector(wl.eval(1:10, f = function(x) x)$spc),
+      1:10
+    )
+
+    expect_equal(
+      as.vector(wl.eval(1:10, f = function(x) x**2)$spc),
+      (1:10)**2
+    )
+
+    expect_equal(
+      wl.eval(wl(flu), f = function(x) x)$.f,
+      wl.eval(   flu,  f = function(x) x)$.f
+    )
+
+    expect_silent(
+      tmp <- wl.eval(300:500, f = function(x) x, g = function(x) exp(-x))
+    )
+    expect_equal(tmp$.f, c("f", "g"))
+  })
+
+
 }

--- a/hyperSpec/R/wl_eval.R
+++ b/hyperSpec/R/wl_eval.R
@@ -42,6 +42,18 @@ wl.eval.hyperSpec <- function(x, ..., normalize.wl = I) {
 }
 
 
+#' @rdname wl.eval
+#' @export
+wl.eval.numeric <- function(x, ..., normalize.wl = I) {
+  if (!is.vector(x)) {
+    class_txt <- paste(class(x), collapse = ", ")
+    stop("`x` must be a vector. Now it is ", class_txt, ".")
+  }
+  x <- new("hyperSpec", spc = seq_along(x), wavelength = x)
+  wl.eval(x, ..., normalize.wl = normalize.wl)
+}
+
+
 hySpc.testthat::test(wl.eval) <- function() {
   context("wl.eval")
 


### PR DESCRIPTION
Implementation details: `wl.eval()` is converted into S3 generic and methods `wl.eval(<hyperSpec>)` that contains current functionality and `wl.eval(<numeric>)` that contais new functionality were implemented.

Closes #287.
Includes #292 so #292 should be accepted first.