### PR TITLE
Calculate default values inside methods of as.hyperSpec()

### DIFF
--- a/hyperSpec/NEWS.md
+++ b/hyperSpec/NEWS.md
@@ -21,7 +21,10 @@
 * Column names in spectra matrix (`$spc` column of `hyperSpec` object) are now returned correctly by functions `spc.bin()` (#237), and `spc.loess()` (#245).
 * New function `hy_list_available_hySpc_packages()` lists packages, that are available in GitHub organization `r-hyperSpec`.
 * New function `hy_browse_homepage()` opens the homepage of *R hyperSpec* in a web browser.
-* New method `as.hyperSpec(<hyperSpec>)` (#282).
+* Changes related to function `as.hyperSpec()`:
+    - New method `as.hyperSpec(<hyperSpec>)` was created (#282).
+    - The default value of argument `wl` is now set to `wl = NULL` (#297).
+    - `wl = NULL` now means that the default values of wavelengths should be calculated inside the methods of `as.hyperSpec()` (#297).
 * Possibility to initialize `hyperSpec` object by providing wavelengths only (#288).
 * Function `wl.eval()` is converted into S3 generic. Methods `wl.eval(<hyperSpec>)` and `wl.eval(<numeric>)` for numeric vectors were added (#287).
 * New function `new_hyperSpec()` that initializes `hyperSpec` object in a similar way as `new("hyperSpec")` does but has autocompletion possibilities in RStudio (#283).

--- a/hyperSpec/R/as_hyperSpec.R
+++ b/hyperSpec/R/as_hyperSpec.R
@@ -23,7 +23,8 @@ setGeneric(
 )
 
 #' @include guess_wavelength.R
-.as.hyperSpec.matrix <- function(X, wl = guess.wavelength(colnames(X)), ...) {
+.as.hyperSpec.matrix <- function(X, wl = NULL, ...) {
+  if (is.null(wl)) wl <- guess.wavelength(colnames(X))
   new("hyperSpec", spc = X, wavelength = wl, ...)
 }
 
@@ -41,8 +42,10 @@ setGeneric(
 #' guess.wavelength(wl)
 setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
 
-.as.hyperSpec.data.frame <- function(X, spc = NULL, wl = guess.wavelength(spc),
+.as.hyperSpec.data.frame <- function(X, spc = NULL, wl = NULL,
   labels = attr(X, "labels"), ...) {
+
+  if (is.null(wl)) wl <- guess.wavelength(X)
   # TODO: remove after 31.12.2020
   if (!all(!is.na(guess.wavelength(colnames(X))))) {
     warning(

--- a/hyperSpec/R/as_hyperSpec.R
+++ b/hyperSpec/R/as_hyperSpec.R
@@ -1,13 +1,16 @@
 
 #' `as.hyperSpec`: Convenience Conversion Functions
 #'
-#' These functions are shortcuts to convert other objects into hypeSpec objects.
+#' These functions are shortcuts to convert other objects into `hypeSpec`
+#' objects.
 #'
-#' @param X the object to convert.
-#' A matrix is assumed to contain the spectra matrix,
-#' a data.frame is assumed to contain extra data.
+#' @param X the object to convert. If `X` is:
+#'
+#' - a `matrix`, it is assumed to contain the spectra matrix,
+#' - a `data.frame`, it is assumed to contain extra data.
+#'
 #' @param ... additional parameters that should be handed over to
-#'       `new("hyperSpec")` (initialize)
+#'       `new("hyperSpec")` (initialize).
 #'
 #' @return hyperSpec object
 #' @seealso [hyperSpec::initialize()]
@@ -29,9 +32,9 @@ setGeneric(
 }
 
 #' @rdname as.hyperSpec
-#' @param wl wavelength vector. Defaults to guessing from the column names in `X`
-#' @param spc spectra matrix
-#' @param labels list with labels
+#' @param wl wavelength vector. Defaults to guessing from the column names in `X`.
+#' @param spc spectra matrix.
+#' @param labels list with labels.
 #' @export
 #'
 #' @concept hyperSpec conversion
@@ -49,7 +52,7 @@ setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
   # TODO: remove after 31.12.2020
   if (!all(!is.na(guess.wavelength(colnames(X))))) {
     warning(
-      "as.hyperSpec.data.frame has changed its behaviour. ",
+      "Method as.hyperSpec(<data.frame>) has changed its behaviour. ",
       "Use as.hyperSpec(as.matrix(X)) instead."
     )
   }
@@ -63,11 +66,10 @@ setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
 }
 
 #' @rdname as.hyperSpec
-#' @note *Note that the behaviour of `as.hyperSpec(X)` was changed: it now
-#' assumes `X` to be extra data, and returns a hyperSpec object with 0
-#' wavelengths. To get the old behaviour*
-
-# FIXME: it seems that the documentation sentence in incomplete.
+#' @note Note that the behaviour of `as.hyperSpec(X)` was changed when `X` is a
+#' `data.frame`: it now assumes `X` to be extra data, and returns a `hyperSpec`
+#' object with 0 wavelengths. To get the old behaviour, use
+#' `as.hyperSpec(as.matrix(X))`.
 
 setMethod("as.hyperSpec", "data.frame", .as.hyperSpec.data.frame)
 


### PR DESCRIPTION
Partially addresses #297.

Some improvements in documentation were also made.