### PR TITLE
Convert anonymous functions into hidden functions

### DIFF
--- a/hyperSpec/R/Arith.R
+++ b/hyperSpec/R/Arith.R
@@ -5,6 +5,9 @@
 # m ... matrix
 # _ ... missing
 
+
+# Function -------------------------------------------------------------------
+
 #' @include expand.R
 ## arithmetic function called with both parameters hyperSpec
 .arith_hh <- function(e1, e2) {
@@ -23,33 +26,6 @@
   e1 <- merge_data(e1, e2)
 
   e1
-}
-
-hySpc.testthat::test(.arith_hh) <- function() {
-  context("Arithmetic operators, 2 hyperSpec objects")
-
-  tmp <- as.hyperSpec(matrix(1:length(flu[[]]), nrow = nrow(flu)))
-  tmp[[]] <- 1:length(tmp[[]])
-  tmp$testcolumn <- 1:nrow(tmp)
-
-  test_that("correct results for 2 equal-sized objects", {
-    for (operator in c(`+`, `-`, `*`, `/`, `^`, `%%`, `%/%`)) {
-      res <- operator(flu, tmp)
-      expect_equal(res[[]], operator(flu[[]], tmp[[]]))
-      expect_equal(res$.., cbind(flu$.., tmp$..))
-      expect_equal(dim(res), dim(flu) + c(0, 1, 0))
-      expect_equal(wl(res), wl(flu))
-    }
-  })
-
-  test_that("correct results with row-sized object", {
-  })
-
-  test_that("correct results with column-sized object", {
-  })
-
-  test_that("correct results with 1x1 object", {
-  })
 }
 
 #' @title Arithmetical operators: `+`, `-`, `*`, `/`, `^`, `%%`, `%/%`, `%*%`
@@ -80,38 +56,42 @@ hySpc.testthat::test(.arith_hh) <- function() {
 #'
 #' If you want to calculate on the extra data as well, use the data.frame
 #' `hyperSpec@data` directly or [`as.data.frame(x)`][as.data.frame()].
+#'
 #' @author C. Beleites
 #'
 #' @rdname Arith
 #' @docType methods
+#'
 #' @param e1,e2 or
 #' @param x,y either two `hyperSpec` objects or
 #'
 #'   one `hyperSpec` object and  matrix of same size as `x[[]]` or
 #'
-#'   a vector which length equalling either the number of rows or the number of
+#'   a vector which length equaling either the number of rows or the number of
 #'   wavelengths of the `hyperSpec` object, or
 #'
 #'   a scalar (numeric of length 1).
+#'
 #' @return `hyperSpec` object with the new spectra matrix.
 #'
-#' If
-#' If the `e2` is a `hyperSpec` objects, its extra data columns will silently be
-#' dropped silently.
+#' If the `e2` is a `hyperSpec` object, its extra data columns will be dropped
+#' silently.
 #'
-#' @export
 #'
 #' @keywords methods arith
 #' @concept manipulation
-#'
-#' @include paste_row.R
-#'
-#' @include hyperspec-class.R
 #' @concept hyperSpec arithmetic
 #' @concept hyperSpec arithmetical operators
 #' @concept hyperSpec plus
 #' @concept hyperSpec division
 #' @concept hyperSpec spectra conversion
+#'
+#'
+#' @include paste_row.R
+#' @include hyperspec-class.R
+#'
+#' @export
+#'
 #' @seealso [sweep()] for calculations with a vector and the spectra matrix.
 #'
 #' [methods::S4groupGeneric] for group generic methods.
@@ -121,6 +101,7 @@ hySpc.testthat::test(.arith_hh) <- function() {
 #' [hyperSpec::Comparison] for comparison operators,
 #' [hyperSpec::Math] for mathematical group generic functions (Math
 #' and Math2 groups) working on hyperSpec objects.
+#'
 #' @examples
 #' flu + flu
 #' 1 / flu
@@ -129,6 +110,41 @@ hySpc.testthat::test(.arith_hh) <- function() {
 #' flu / flu$c
 setMethod("Arith", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .arith_hh)
 
+
+# Unit tests -----------------------------------------------------------------
+
+hySpc.testthat::test(.arith_hh) <- function() {
+  context("Arithmetic operators, 2 hyperSpec objects")
+
+  tmp <- as.hyperSpec(matrix(1:length(flu[[]]), nrow = nrow(flu)))
+  tmp[[]] <- 1:length(tmp[[]])
+  tmp$testcolumn <- 1:nrow(tmp)
+
+  test_that("correct results for 2 equal-sized objects", {
+    for (operator in c(`+`, `-`, `*`, `/`, `^`, `%%`, `%/%`)) {
+      res <- operator(flu, tmp)
+      expect_equal(res[[]], operator(flu[[]], tmp[[]]))
+      expect_equal(res$.., cbind(flu$.., tmp$..))
+      expect_equal(dim(res), dim(flu) + c(0, 1, 0))
+      expect_equal(wl(res), wl(flu))
+    }
+  })
+
+  test_that("correct results with row-sized object", {
+    # TODO: add unit tests
+  })
+
+  test_that("correct results with column-sized object", {
+    # TODO: add unit tests
+  })
+
+  test_that("correct results with 1x1 object", {
+    # TODO: add unit tests
+  })
+}
+
+
+# Function -------------------------------------------------------------------
 ## unary operators
 
 .arith_h_ <- function(e1, e2) {
@@ -141,6 +157,13 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .arith_hh)
   e1[[]] <- callGeneric(e1[[]])
   e1
 }
+
+#' @rdname Arith
+setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
+
+
+# Unit tests -----------------------------------------------------------------
+
 hySpc.testthat::test(.arith_h_) <- function() {
   context("Unary arithmetic operators")
 
@@ -167,9 +190,8 @@ hySpc.testthat::test(.arith_h_) <- function() {
   })
 }
 
-#' @rdname Arith
-setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
 
+# Function -------------------------------------------------------------------
 
 ## arithmetic function called with first parameter hyperSpec
 .arith_hn <- function(e1, e2) {
@@ -186,6 +208,14 @@ setMethod("Arith", signature(e1 = "hyperSpec", e2 = "missing"), .arith_h_)
 
   e1
 }
+
+#' @rdname Arith
+setMethod("Arith", signature(e1 = "hyperSpec", e2 = "numeric"), .arith_hn)
+#' @rdname Arith
+setMethod("Arith", signature(e1 = "hyperSpec", e2 = "matrix"), .arith_hn)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.arith_hn) <- function() {
   context("Arithmetic operators, hyperSpec object x")
@@ -268,12 +298,10 @@ hySpc.testthat::test(.arith_hn) <- function() {
 }
 
 
-#' @rdname Arith
-setMethod("Arith", signature(e1 = "hyperSpec", e2 = "numeric"), .arith_hn)
-#' @rdname Arith
-setMethod("Arith", signature(e1 = "hyperSpec", e2 = "matrix"), .arith_hn)
+# Function -------------------------------------------------------------------
 
 ## arithmetic function called with second parameter hyperSpec
+
 .arith_nh <- function(e1, e2) {
   # e1 <- as.matrix(e1)
   validObject(e2)
@@ -297,6 +325,8 @@ setMethod("Arith", signature(e1 = "numeric", e2 = "hyperSpec"), .arith_nh)
 setMethod("Arith", signature(e1 = "matrix", e2 = "hyperSpec"), .arith_nh)
 
 
+# Function -------------------------------------------------------------------
+
 ## matrix multiplication two hyperSpec objects
 .matmul_hh <- function(x, y) {
   validObject(x)
@@ -308,6 +338,18 @@ setMethod("Arith", signature(e1 = "matrix", e2 = "hyperSpec"), .arith_nh)
 
   x
 }
+
+#' @rdname Arith
+#' @export
+#'
+#' @concept hyperSpec matrix multiplication
+#' @concept manipulation
+#'
+#' @seealso  [base::matmult] for matrix multiplications with `%*%`.
+setMethod("%*%", signature(x = "hyperSpec", y = "hyperSpec"), .matmul_hh)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.matmul_hh) <- function() {
   context("matrix multiplication: 2 hyperSpec objects")
@@ -330,14 +372,7 @@ hySpc.testthat::test(.matmul_hh) <- function() {
 }
 
 
-#' @rdname Arith
-#' @export
-#'
-#' @concept hyperSpec matrix multiplication
-#' @concept manipulation
-#'
-#' @seealso  [base::matmult] for matrix multiplications with `%*%`.
-setMethod("%*%", signature(x = "hyperSpec", y = "hyperSpec"), .matmul_hh)
+# Function -------------------------------------------------------------------
 
 ## matrix multiplication hyperSpec object %*% matrix
 .matmul_hm <- function(x, y) {
@@ -350,6 +385,12 @@ setMethod("%*%", signature(x = "hyperSpec", y = "hyperSpec"), .matmul_hh)
 
   x
 }
+
+#' @rdname Arith
+setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.matmul_hm) <- function() {
   context("matrix multiplication hyperSpec x matrix")
@@ -369,8 +410,8 @@ hySpc.testthat::test(.matmul_hm) <- function() {
   })
 }
 
-#' @rdname Arith
-setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
+
+# Function -------------------------------------------------------------------
 
 ## matrix multiplication matrix %*% hyperSpec object
 .matmul_mh <- function(x, y) {
@@ -378,6 +419,12 @@ setMethod("%*%", signature(x = "hyperSpec", y = "matrix"), .matmul_hm)
 
   new("hyperSpec", wavelength = y@wavelength, spc = x %*% y@data$spc)
 }
+
+#' @rdname Arith
+setMethod("%*%", signature(x = "matrix", y = "hyperSpec"), .matmul_mh)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.matmul_mh) <- function() {
   context("matrix multiplication: matrix x hyperSpec")
@@ -392,7 +439,3 @@ hySpc.testthat::test(.matmul_mh) <- function() {
     expect_equal(wl(res), wl(flu))
   })
 }
-
-
-#' @rdname Arith
-setMethod("%*%", signature(x = "matrix", y = "hyperSpec"), .matmul_mh)

--- a/hyperSpec/R/Compare.R
+++ b/hyperSpec/R/Compare.R
@@ -1,7 +1,18 @@
+# Function -------------------------------------------------------------------
+
+.Compare_hh <-  function(e1, e2) {
+    validObject(e1)
+    validObject(e2)
+
+    callGeneric(e1[[]], e2[[]])
+  }
+
+
 #' @title Comparison of `hyperSpec` objects
 #'
 #' @description
-#' The comparison operators `>`, `<`, `>=`, `<=`, `==`, and `!=` for `hyperSpec` objects.
+#' The comparison operators `>`, `<`, `>=`, `<=`, `==`, and `!=` for `hyperSpec`
+#' objects.
 #'
 #' `all.equal` checks the equality of two `hyperSpec` objects.
 #'
@@ -15,18 +26,31 @@
 #' With numeric vectors [hyperSpec::sweep()] might be more
 #' appropriate.
 #'
-#' If you want to calculate on the `data.frame` `hyperSpec@@data`,
-#' you have to do this directly on `hyperSpec@@data`.
+#' If you want to calculate on the `data.frame` `hyperSpec@data`,
+#' you have to do this directly on `hyperSpec@data`.
 #'
-#' @author C. Beleites
 #' @name Comparison
 #' @rdname Comparison
+#' @aliases Comparison Operators
+#' Comparison,hyperSpec
+#' comparison,hyperSpec
+#' Operators,hyperSpec
+#' operators,hyperSpec
+#' compare,hyperSpec
+#' Compare,hyperSpec-method
+#' Compare,hyperSpec,hyperSpec-method
+#' Compare,hyperSpec,matrix-method
+#' Compare,hyperSpec,numeric-method
+#' Compare,matrix,hyperSpec-method
+#' Compare,numeric,hyperSpec-method
+#' <,hyperSpec,hyperSpec-method
+#' >,hyperSpec,hyperSpec-method
+#' <=,hyperSpec,hyperSpec-method
+#' >=,hyperSpec,hyperSpec-method
+#' ==,hyperSpec,hyperSpec-method
+#' !=,hyperSpec,hyperSpec-method
 #' @docType methods
-#' @aliases Comparison Operators Compare,hyperSpec-method
-#' Compare,hyperSpec,hyperSpec-method <,hyperSpec,hyperSpec-method >,hyperSpec,hyperSpec-method
-#' <=,hyperSpec,hyperSpec-method >=,hyperSpec,hyperSpec-method ==,hyperSpec,hyperSpec-method
-#' !=,hyperSpec,hyperSpec-method Compare,hyperSpec,matrix-method Compare,hyperSpec,numeric-method
-#' Compare,matrix,hyperSpec-method Compare,numeric,hyperSpec-method
+#'
 #' @param e1,e2 Either two `hyperSpec` objects or one `hyperSpec`
 #'   object and matrix of same size as `hyperSpec[[]]` or a scalar
 #'   (numeric of length 1).
@@ -45,36 +69,27 @@
 #'   [hyperSpec::Math()] for mathematical group generic functions
 #'   (groups Math and Math2) working on `hyperSpec` objects.
 #'
-#' @export
+#' @author C. Beleites
 #'
 #' @keywords methods arith
 #' @concept manipulation
+#'
+#' @export
 #'
 #' @examples
 #'
 #' flu[, , 445 ~ 450] > 300
 #'
 #' all(flu == flu[[]])
-setMethod(
-  "Compare", signature(e1 = "hyperSpec", e2 = "hyperSpec"),
-  function(e1, e2) {
-    validObject(e1)
-    validObject(e2)
+setMethod("Compare", signature(e1 = "hyperSpec", e2 = "hyperSpec"), .Compare_hh)
 
-    callGeneric(e1[[]], e2[[]])
-  }
-)
+
+# Function -------------------------------------------------------------------
 
 .compx <- function(e1, e2) {
   validObject(e1)
   callGeneric(e1[[]], e2)
 }
-
-.compy <- function(e1, e2) {
-  validObject(e2)
-  callGeneric(e1, e2[[]])
-}
-
 
 #' @rdname Comparison
 setMethod("Compare", signature(e1 = "hyperSpec", e2 = "numeric"), .compx)
@@ -83,8 +98,21 @@ setMethod("Compare", signature(e1 = "hyperSpec", e2 = "numeric"), .compx)
 setMethod("Compare", signature(e1 = "hyperSpec", e2 = "matrix"), .compx)
 
 
+# Function -------------------------------------------------------------------
+
+.compy <- function(e1, e2) {
+  validObject(e2)
+  callGeneric(e1, e2[[]])
+}
+
 #' @rdname Comparison
 setMethod("Compare", signature(e1 = "numeric", e2 = "hyperSpec"), .compy)
 
 #' @rdname Comparison
 setMethod("Compare", signature(e1 = "matrix", e2 = "hyperSpec"), .compy)
+
+
+# Unit tests -----------------------------------------------------------------
+
+# TODO: add unit tests
+

--- a/hyperSpec/R/Math.R
+++ b/hyperSpec/R/Math.R
@@ -1,4 +1,5 @@
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Function -------------------------------------------------------------------
+
 .math2 <- function(x, digits) {
   validObject(x)
 
@@ -16,6 +17,7 @@
 #' `trigamma()`, `cumsum()`, `cumprod()`, `cummax()`, `cummin()` for `hyperSpec`
 #'  objects.
 #'
+#' @rdname math
 #' @aliases  Math Math2 Math,hyperSpec-method Math2,hyperSpec-method abs,hyperSpec-method
 #' sign,hyperSpec-method sqrt,hyperSpec-method floor,hyperSpec-method ceiling,hyperSpec-method
 #' trunc,hyperSpec-method round,hyperSpec-method signif,hyperSpec-method exp,hyperSpec-method
@@ -26,10 +28,12 @@
 #' gamma,hyperSpec-method digamma,hyperSpec-method trigamma,hyperSpec-method cumsum,hyperSpec-method
 #' cumprod,hyperSpec-method cummax,hyperSpec-method cummin,hyperSpec-method round,hyperSpec-method
 #' signif,hyperSpec-method
+#'
 #' @param x the `hyperSpec` object
 #' @param digits integer stating the rounding precision
+#'
 #' @return a `hyperSpec` object
-#' @rdname math
+#'
 #' @author C. Beleites
 #' @seealso [methods::S4groupGeneric()] for group generic methods.
 #'
@@ -41,9 +45,9 @@
 #' objects.
 #'
 #' @keywords methods math
-#' @export
-#'
 #' @concept manipulation
+#'
+#' @export
 #'
 #' @examples
 #'
@@ -51,7 +55,8 @@
 setMethod("Math2", signature(x = "hyperSpec"), .math2)
 
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Function -------------------------------------------------------------------
+
 .log <- function(x, base = exp(1), ...) {
   validObject(x)
 
@@ -60,17 +65,20 @@ setMethod("Math2", signature(x = "hyperSpec"), .math2)
 }
 
 #' @rdname math
+#' @aliases log log,hyperSpec-method
+#'
 #' @param ... ignored
 #' @param base base of logarithm
+#'
 #' @export
 #'
 #' @concept manipulation
 #'
-#' @aliases log log,hyperSpec-method
 setMethod("log", signature(x = "hyperSpec"), .log)
 
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Function -------------------------------------------------------------------
+
 .math <- function(x) {
   validObject(x)
 
@@ -84,14 +92,15 @@ setMethod("log", signature(x = "hyperSpec"), .log)
 
 
 #' @rdname math
-#' @export
 #'
 #' @concept manipulation
+#' @export
 #'
 setMethod("Math", signature(x = "hyperSpec"), .math)
 
 
 # Unit tests -----------------------------------------------------------------
+
 hySpc.testthat::test(.math) <- function() {
   context("math")
 

--- a/hyperSpec/R/Math.R
+++ b/hyperSpec/R/Math.R
@@ -48,9 +48,7 @@
 #' @examples
 #'
 #' log(flu)
-setMethod(
-  "Math2", signature(x = "hyperSpec"), .math2
-)
+setMethod("Math2", signature(x = "hyperSpec"), .math2)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hyperSpec/R/Summary.R
+++ b/hyperSpec/R/Summary.R
@@ -1,87 +1,98 @@
-#' @title Statistical summary and other functions for `hyperSpec`
+# Function -------------------------------------------------------------------
+.Summary <- function(x, ..., na.rm = FALSE) {
+  validObject(x)
+
+  if ((.Generic == "prod") || (.Generic == "sum")) {
+    warning(paste(
+      "Do you really want to use", .Generic, "on a 'hyperSpec' object?"
+    ))
+  }
+
+  ## dispatch also on the objects in ...
+  x <- sapply(list(x[[]], ...), .Generic, na.rm = na.rm)
+
+  callGeneric(x, na.rm = na.rm)
+}
+
+#' Statistical summary and other functions for `hyperSpec`
+#'
 #' @description
-#' The functions
+#' The following functions for `hyperSpec` objects:
 #'
-#' `all`, `any`,
-#'
-#' `sum`, `prod`,
-#'
-#' `min`, `max`,
-#'
-#' `range`, and
-#'
-#' `is.na`
-#'
-#' for `hyperSpec` objects.
+#' - `all()`, `any()`,
+#' - `sum()`, `prod()`,
+#' - `min()`, `max()`,
+#' - `range()`, and
+#' - `is.na()`
 #'
 #' All these functions work on the spectra matrix.
+#'
 #' @name Summary
-#' @docType methods
 #' @rdname summary
+#'
+#' @concept stats
+#' @docType methods
 #' @aliases Summary,hyperSpec-method Summary all,hyperSpec-method
 #'   any,hyperSpec-method sum,hyperSpec-method prod,hyperSpec-method
 #'   min,hyperSpec-method max,hyperSpec-method range,hyperSpec-method
+#'
 #' @param x hyperSpec object
 #' @param ... further objects
 #' @param na.rm logical indicating whether missing values should be removed
 #' @return `sum`, `prod`, `min`, `max`, and `range` return  a numeric,
 #' `all`, `any`, and `is.na` a logical.
+#'
 #' @seealso [base::Summary()] for the base summary functions.
-#'
-#' @export
-#'
-#' @concept stats
 #'
 #' @examples
 #'
 #' range(flu)
-setMethod(
-  "Summary", signature(x = "hyperSpec"),
-  function(x, ..., na.rm = FALSE) {
-    validObject(x)
+#' @export
+setMethod("Summary", signature(x = "hyperSpec"), .Summary)
 
-    if ((.Generic == "prod") || (.Generic == "sum")) {
-      warning(paste("Do you really want to use", .Generic, "on a hyperSpec object?"))
-    }
 
-    ## dispatch also on the objects in ...
-    x <- sapply(list(x[[]], ...), .Generic, na.rm = na.rm)
+# TODO: add unit tests for '.Summary'
 
-    callGeneric(x, na.rm = na.rm)
+
+# Function -------------------------------------------------------------------
+.is.na <- function(x) {
+    is.na(x@data$spc)
   }
-)
 
 #' @rdname summary
 #' @aliases is.na,hyperSpec-method
 #' @seealso [base::all.equal()] and [base::isTRUE()]
-#' @export
 #' @examples
 #'
 #' is.na(flu[, , 405 ~ 410])
-setMethod(
-  "is.na", signature(x = "hyperSpec"),
-  function(x) {
-    is.na(x@data$spc)
-  }
-)
-
-#' @details
-#' `all_wl` and `any_wl` are shortcut function to check whether
-#' any or all intensities fulfill the condition per spectrum.
-#' `na.rm` behaviour is like [base::all()] and [base::any()].
-#'
-#' @param expression expression that evaluates to a logical matrix of the same size as the spectra matrix
-#'
-#' @rdname summary
 #' @export
+setMethod("is.na", signature(x = "hyperSpec"), .is.na)
+
+
+# TODO: add unit tests for '.is.na'
+
+
+# Function -------------------------------------------------------------------
+
+#' @rdname summary
+#' @details
+#' `all_wl()` and `any_wl()` are shortcut function to check whether
+#' any or all intensities fulfill the condition per spectrum.
+#' `na.rm` behavior is like [base::all()] and [base::any()].
+#'
+#' @param expression expression that evaluates to a logical matrix of the same
+#'        size as the spectra matrix
+#'
 #' @examples
 #'
 #' all_wl(flu > 100)
+#' @export
 all_wl <- function(expression, na.rm = FALSE) {
   res <- rowSums(!expression, na.rm = TRUE) == 0
 
   if (!na.rm) {
-    res[res] <- rowSums(expression[res, , drop = FALSE], na.rm = FALSE) == ncol(expression)
+    res[res] <-
+      rowSums(expression[res, , drop = FALSE], na.rm = FALSE) == ncol(expression)
   }
 
   res
@@ -127,14 +138,14 @@ hySpc.testthat::test(all_wl) <- function() {
   })
 }
 
-# ... ------------------------------------------------------------------------
+# Function -------------------------------------------------------------------
 
 #' @rdname summary
-#' @export
 #' @examples
 #'
 #' any_wl(flu > 300)
 #' !any_wl(is.na(flu))
+#' @export
 any_wl <- function(expression, na.rm = FALSE) {
   res <- rowSums(expression, na.rm = TRUE) > 0
 
@@ -187,12 +198,12 @@ hySpc.testthat::test(any_wl) <- function() {
   test_that("Summary warnings", {
     expect_warning(
       prod(flu),
-      "Do you really want to use prod on a hyperSpec object?"
+      "Do you really want to use prod on a 'hyperSpec' object?"
     )
 
     expect_warning(
       sum(flu),
-      "Do you really want to use sum on a hyperSpec object?"
+      "Do you really want to use sum on a 'hyperSpec' object?"
     )
   })
 }

--- a/hyperSpec/R/Summary.R
+++ b/hyperSpec/R/Summary.R
@@ -1,4 +1,5 @@
 # Function -------------------------------------------------------------------
+#
 .Summary <- function(x, ..., na.rm = FALSE) {
   validObject(x)
 
@@ -55,6 +56,7 @@ setMethod("Summary", signature(x = "hyperSpec"), .Summary)
 
 
 # Function -------------------------------------------------------------------
+
 .is.na <- function(x) {
     is.na(x@data$spc)
   }
@@ -137,6 +139,7 @@ hySpc.testthat::test(all_wl) <- function() {
     )
   })
 }
+
 
 # Function -------------------------------------------------------------------
 

--- a/hyperSpec/R/aggregate.R
+++ b/hyperSpec/R/aggregate.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 .aggregate <- function(x, by = stop("by is needed"), FUN = stop("FUN is needed."),
                        ..., out.rows = NULL, append.rows = NULL,
                        by.isindex = FALSE) {
@@ -71,7 +73,7 @@
 #' It combines the functionality of [stats::aggregate()], [base::tapply()],
 #' and [stats::ave()] for `hyperSpec` objects.
 #'
-#' `aggregate` avoids splitting `x@@data`.
+#' `aggregate` avoids splitting `x@data`.
 #'
 #' `FUN` does not need to return exactly one value.  The number of
 #' returned values needs to be the same for all wavelengths (otherwise the
@@ -80,40 +82,43 @@
 #' If the initially preallocated `data.frame` turns out to be too small,
 #' more rows are appended and a warning is issued.
 #'
-#' @include hyperspec-class.R
-#' @aliases aggregate,hyperSpec-method ave,hyperSpec-method
 #' @name aggregate
-#' @docType methods
-#' @param x a `hyperSpec` object
-#' @param by grouping for the rows of `x@@data`.
+#' @rdname aggregate
+#' @aliases aggregate,hyperSpec-method ave,hyperSpec-method
 #'
-#' Either a list containing an index vector for each of the subgroups or a
-#'   vector that can be `split` in such a list.
+#' @docType methods
+#'
+#' @param x a `hyperSpec` object
+#' @param by grouping for the rows of `x@@data`. \cr
+#'        Either a list containing an index vector for each of the subgroups
+#'        or a vector that can be `split` in such a list.
 #' @param FUN function to compute the summary statistics
 #' @param out.rows number of rows in the resulting `hyperSpec` object,
-#'   for memory preallocation.
-#' @param append.rows If more rows are needed, how many should be appended?
-#'
-#' Defaults to 100 or an estimate based on the percentage of groups that are
-#'   still to be done, whatever is larger.
+#'        for memory preallocation.
+#' @param append.rows If more rows are needed, how many should be appended? \cr
+#'        Defaults to 100 or an estimate based on the percentage of groups that
+#'        are still to be done, whatever is larger.
 #' @param by.isindex If a list is given in `by`: does the list already
-#'   contain the row indices of the groups? If `FALSE`, the list in
-#'   `by` is computed first (as in [stats::aggregate()]).
+#'        contain the row indices of the groups? If `FALSE`, the list in
+#'        `by` is computed first (as in [stats::aggregate()]).
 #' @param ... further arguments passed to `FUN`
-#' @return A `hyperSpec` object with an additional column
-#'   `@@data$.aggregate` tracing which group the rows belong to.
+#'
+#' @return A `hyperSpec` object with an additional column `@data$.aggregate`
+#'         tracing which group the rows belong to.
+#'
 #' @author C. Beleites
 #' @seealso [base::tapply()], [stats::aggregate()],
+#'
 #'   [stats::ave()]
-#' @rdname aggregate
-#' @export
 #'
 #' @keywords methods category array
 #' @concept manipulation
 #' @concept stats
 #'
-#' @import stats
 #' @include hyperspec-class.R
+#' @import stats
+#' @export
+#'
 #' @examples
 #' region.means <- aggregate(faux_cell, faux_cell$region, mean_pm_sd)
 #' plot(region.means,

--- a/hyperSpec/R/all.equal.R
+++ b/hyperSpec/R/all.equal.R
@@ -1,6 +1,10 @@
-.all.equal <- function(target, current, ..., check.attributes = FALSE, check.names = FALSE,
-                       check.column.order = FALSE, check.label = FALSE,
-                       tolerance = hy.getOption("tolerance"), wl.tolerance = hy.getOption("wl.tolerance")) {
+# Function -------------------------------------------------------------------
+
+.all.equal <- function(target, current, ..., check.attributes = FALSE,
+                       check.names = FALSE, check.column.order = FALSE,
+                       check.label = FALSE,
+                       tolerance = hy.getOption("tolerance"),
+                       wl.tolerance = hy.getOption("wl.tolerance")) {
   validObject(target)
   validObject(current)
   tolerance <- .checkpos(tolerance, "tolerance")
@@ -50,6 +54,8 @@
 }
 
 
+# Unit tests -----------------------------------------------------------------
+
 hySpc.testthat::test(.all.equal) <- function() {
   context(".all.equal")
 
@@ -82,27 +88,32 @@ hySpc.testthat::test(.all.equal) <- function() {
   })
 }
 
+# Function -------------------------------------------------------------------
 
-#' @aliases all.equal  all.equal,hyperSpec,hyperSpec-method
 #' @rdname Comparison
+#' @aliases all.equal  all.equal,hyperSpec,hyperSpec-method
+#'
 #' @param target,current two `hyperSpec` objects that are tested for
-#'   equality
+#'        equality
 #' @param ... handed to [base::all.equal()] when testing the slots of the
-#'   `hyperSpec` objects
+#'        `hyperSpec` objects
 #' @param check.column.order If two objects have the same data, but the order
-#'   of the columns (determined by the names) differs, should they be regarded
-#'   as different?
-#' @param check.label Should the slot `label` be checked? \cr If the
-#'   labels differ only in the order of their entries, they are conidered
-#'   equal.
+#'        of the columns (determined by the names) differs, should they be
+#'        regarded as different?
+#' @param check.label Should the slot `label` be checked? \cr
+#'        If the labels differ only in the order of their entries, they are
+#'        considered equal.
 #' @param check.attributes,check.names see [base::all.equal()]
-#' @param tolerance,wl.tolerance tolerances for checking wavelengths and data, respectively
-#' @return `all.equal` returns either `TRUE`, or a character vector describing the
-#' differences. In conditions, the result must therefore be tested with
-#' [base::isTRUE()].
+#' @param tolerance,wl.tolerance tolerances for checking wavelengths and data,
+#'        respectively
+#'
+#' @return `all.equal` returns either `TRUE`, or a character vector describing
+#'          the differences. In conditions, the result must therefore be tested
+#'          with  [base::isTRUE()].
+#'
 #' @seealso [base::all.equal()] and [base::isTRUE()]
-#' @export
 #'
 #' @concept manipulation
 #'
+#' @export
 setMethod("all.equal", signature(target = "hyperSpec", current = "hyperSpec"), .all.equal)

--- a/hyperSpec/R/apply.R
+++ b/hyperSpec/R/apply.R
@@ -1,3 +1,5 @@
+# Functions ------------------------------------------------------------------
+
 .na.if.different <- function(x) {
   if (length(unique(x)) > 1) NA else x[1]
 }
@@ -49,6 +51,7 @@
   data$spc <- unclass(data$spc)
   data
 }
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .apply <- function(X, MARGIN, FUN, ..., label.wl = NULL,
                    label.spc = NULL, new.wavelength = NULL, simplify) {
@@ -76,8 +79,8 @@
 
     if (all(MARGIN == 1)) {
 
-      ## if the number of data points per spectrum is changed, the wavelength vector needs to be
-      ## adapted, too
+      ## if the number of data points per spectrum is changed, the wavelength
+      ## vector needs to be adapted, too
 
       if (ncol(X@data$spc) != length(X@wavelength)) {
 
@@ -121,7 +124,7 @@
 
 #' Compute summary statistics for the spectra of a `hyperSpec` object
 #'
-#' `apply` gives the functionality of [base::apply()] for `hyperSpec` objects.
+#' `apply()` gives the functionality of [base::apply()] for `hyperSpec` objects.
 #'
 #' The generic functions of group [methods::Math()] are not defined
 #' for `hyperSpec` objects. Instead, `apply` can be used. For
@@ -138,6 +141,7 @@
 #' @rdname apply
 #' @aliases apply apply,hyperSpec-method
 #' @docType methods
+#'
 #' @param X,spc a `hyperSpec` object
 #' @param MARGIN The subscript which the function will be applied over.
 #'
@@ -191,7 +195,6 @@ setMethod("apply", signature = signature(X = "hyperSpec"), .apply)
 
 
 # Unit tests -----------------------------------------------------------------
-
 
 hySpc.testthat::test(.apply) <- function() {
   context("apply")

--- a/hyperSpec/R/as_hyperSpec.R
+++ b/hyperSpec/R/as_hyperSpec.R
@@ -1,3 +1,4 @@
+# Set generic ----------------------------------------------------------------
 
 #' `as.hyperSpec`: convenience conversion functions
 #'
@@ -22,6 +23,9 @@ setGeneric("as.hyperSpec", function(X, ...) {
   stop("as.hyperSpec is not available for objects of class ", class(X))
 })
 
+
+# Function -------------------------------------------------------------------
+
 #' @include extract_numbers.R
 .as.hyperSpec.matrix <- function(X, wl = NULL, ...) {
   if (is.null(wl)) wl <- extract_numbers(colnames(X))
@@ -41,6 +45,9 @@ setGeneric("as.hyperSpec", function(X, ...) {
 #' (wl <- colnames(tmp))
 #' extract_numbers(wl)
 setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
+
+
+# Function -------------------------------------------------------------------
 
 .as.hyperSpec.data.frame <- function(X, spc = NULL, wl = NULL,
                                      labels = attr(X, "labels"), ...) {
@@ -69,6 +76,8 @@ setMethod("as.hyperSpec", "matrix", .as.hyperSpec.matrix)
 
 setMethod("as.hyperSpec", "data.frame", .as.hyperSpec.data.frame)
 
+
+# Function -------------------------------------------------------------------
 
 .as.hyperSpec.hyperSpec <- function(X) {
   X

--- a/hyperSpec/R/bind.R
+++ b/hyperSpec/R/bind.R
@@ -389,7 +389,7 @@ setMethod("rbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .rb
 
 # Function -------------------------------------------------------------------
 
-.rbind2_h_  <- function(x, y, wl.tolerance) {
+.rbind2_h_ <- function(x, y, wl.tolerance) {
   x
 }
 

--- a/hyperSpec/R/bind.R
+++ b/hyperSpec/R/bind.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 #' Binding `hyperSpec` objects
 #'
 #' Functions to bind `hyperSpec` objects.
@@ -7,43 +9,48 @@
 #' 3.2.0 and `cbind()` and `rbind()` now work as intended and expected for
 #' `hyperSpec` objects.
 #'
-#' Therefore, calling `rbind.hyperSpec` and `cbind.hyperSpec` is now depecated:
+#' Therefore, calling `rbind.hyperSpec` and `cbind.hyperSpec` is now deprecated:
 #' `cbind` and `rbind` should now be called directly.
 #'
-#' However, in consequence it is no longer possible to call `cbind()` or `rbind()`
-#' with a list of `hyperSpec` objects. In that case, use `bind()` or
+#' However, in consequence it is no longer possible to call `cbind()` or
+#' `rbind()` with a list of `hyperSpec` objects. In that case, use `bind()` or
 #' [base::do.call()] (see example).
 #'
 #' `bind()` does the common work for both column- and row-wise binding.
 #'
-#' @aliases bind
-#' @param ... The `hyperSpec` objects to be combined.
 #'
-#' Alternatively, *one* list of `hyperSpec` objects can be given to `bind()`.
+#' @aliases bind bind,hyperSpec
 #'
-#' @param wl.tolerance `rbind` and `rbind2` check for equal wavelengths
-#' with this tolerance.
-#' @include paste_row.R
-#' @param direction "r" or "c" to bind rows or columns
+#' @param ... The `hyperSpec` objects to be combined. \cr
+#'        Alternatively, *one* list of `hyperSpec` objects can be given to
+#'        `bind()`.
+#' @param wl.tolerance `rbind` and `rbind2` check for equal wavelengths with
+#'        this tolerance.
+#' @param direction "r" or "c" to bind rows or columns.
 #'
-#' @return a `hyperSpec` object, possibly with different row order (for
-#'   \code{bind ("c", \dots{})} and `cbind2`).
+#' @return A `hyperSpec` object, possibly with different row order
+#'        (for `bind("c", ...)` and `cbind2()`).
 #'
 #' @note You might have to make sure that the objects either all have or all
-#'   do not have rownames and/or colnames.
+#'       do not have rownames and/or colnames.
 #'
 #' @author C. Beleites
-#' @export
 #'
 #' @keywords methods manip
 #' @concept manipulation
 #'
 #' @seealso
-#' [methods::rbind2()], [methods::cbind2()]
-#' [base::rbind()], [base::cbind()]
+#' [methods::rbind2()], [methods::cbind2()],
+#' [base::rbind()], [base::cbind()],
 #'
 #' [merge()] and [collapse()] for combining objects that do not share spectra
 #' or wavelengths, respectively.
+#'
+#'
+#' @include paste_row.R
+#' @export
+#'
+#'
 #' @examples
 #'
 #' faux_cell
@@ -103,8 +110,8 @@ bind <- function(direction = stop("direction('c' or 'r') required"), ...,
   }
 }
 
-# Unit tests -----------------------------------------------------------------
 
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(bind) <- function() {
   context("bind")
@@ -144,37 +151,41 @@ hySpc.testthat::test(bind) <- function() {
   })
 }
 
-# ... ------------------------------------------------------------------------
 
-#' @description `cbind2` binds the spectral matrices of two `hyperSpec` objects
-#' by column. All columns besides `spc` with the same name in `x@@data` and
-#' `y@@data` must have the same elements.  Rows are ordered before checking.
+# Function -------------------------------------------------------------------
+
+#' @description `cbind2()` binds the spectral matrices of two `hyperSpec`
+#' objects by column. All columns besides `spc` with the same name in `x@data`
+#' and `y@data` must have the same elements.  Rows are ordered before checking.
 #'
+#' @rdname bind
 #' @aliases bind cbind.hyperSpec rbind.hyperSpec
 #'   cbind2,hyperSpec,hyperSpec-method rbind2,hyperSpec,hyperSpec-method
 #'   cbind2,hyperSpec,missing-method rbind2,hyperSpec,missing-method
+#' @aliases cbind.hyperSpec
+#'
 #' @param x,y `hyperSpec` objects
-#' @rdname bind
-#' @export
 #'
 #' @concept manipulation
 #'
-#' @aliases cbind.hyperSpec
+#' @export
+cbind.hyperSpec <- function(...) {
+  bind("c", ...)
+}
 
-cbind.hyperSpec <- function(...) bind("c", ...)
 
-
-#' `rbind2` binds two `hyperSpec` objects by row. They need to have the same
+#' `rbind2()` binds two `hyperSpec` objects by row. They need to have the same
 #' columns.
 #'
-#' @aliases  rbind.hyperSpec
 #' @rdname bind
-#' @export
+#' @aliases rbind.hyperSpec
 #'
 #' @concept manipulation
 #'
-#' @aliases rbind.hyperSpec
-rbind.hyperSpec <- function(...) bind("r", ...)
+#' @export
+rbind.hyperSpec <- function(...) {
+  bind("r", ...)
+}
 
 
 # Unit tests -----------------------------------------------------------------
@@ -260,7 +271,7 @@ hySpc.testthat::test(cbind.hyperSpec) <- function() {
   })
 }
 
-# ... ------------------------------------------------------------------------
+# Function -------------------------------------------------------------------
 
 .cbind2 <- function(x, y) {
   validObject(x)
@@ -300,6 +311,29 @@ hySpc.testthat::test(cbind.hyperSpec) <- function() {
   x
 }
 
+#' @rdname bind
+#' @export
+#'
+#' @concept manipulation
+#'
+#' @aliases cbind2,hyperSpec,hyperSpec-method
+setMethod("cbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .cbind2)
+
+
+# Function -------------------------------------------------------------------
+
+.cbind2_h_ <- function(x, y) {
+  x
+}
+
+#' @rdname bind
+#' @export
+#'
+#' @concept manipulation
+#'
+#' @aliases cbind2,hyperSpec,missing-method
+setMethod("cbind2", signature = signature(x = "hyperSpec", y = "missing"), .cbind2_h_)
+
 
 # Unit tests -----------------------------------------------------------------
 
@@ -325,23 +359,7 @@ hySpc.testthat::test(.cbind2) <- function() {
 }
 
 
-# ... ------------------------------------------------------------------------
-
-#' @rdname bind
-#' @export
-#'
-#' @concept manipulation
-#'
-#' @aliases cbind2,hyperSpec,hyperSpec-method
-setMethod("cbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .cbind2)
-
-#' @rdname bind
-#' @export
-#'
-#' @concept manipulation
-#'
-#' @aliases cbind2,hyperSpec,missing-method
-setMethod("cbind2", signature = signature(x = "hyperSpec", y = "missing"), function(x, y) x)
+# Function -------------------------------------------------------------------
 
 .rbind2 <- function(x, y, wl.tolerance = hy.getOption("wl.tolerance")) {
   validObject(x)
@@ -359,6 +377,29 @@ setMethod("cbind2", signature = signature(x = "hyperSpec", y = "missing"), funct
 
   x
 }
+
+#' @rdname bind
+#' @export
+#'
+#' @concept manipulation
+#'
+#' @aliases rbind2,hyperSpec,hyperSpec-method
+setMethod("rbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .rbind2)
+
+
+# Function -------------------------------------------------------------------
+
+.rbind2_h_  <- function(x, y, wl.tolerance) {
+  x
+}
+
+#' @rdname bind
+#' @export
+#'
+#' @concept manipulation
+#'
+#' @aliases rbind2,hyperSpec,missing-method
+setMethod("rbind2", signature = signature(x = "hyperSpec", y = "missing"), .rbind2_h_)
 
 # Unit tests -----------------------------------------------------------------
 
@@ -389,21 +430,3 @@ hySpc.testthat::test(.rbind2) <- function() {
     expect_equal(rbind2(flu, flu), rbind(flu, flu))
   })
 }
-
-# ... ------------------------------------------------------------------------
-
-#' @rdname bind
-#' @export
-#'
-#' @concept manipulation
-#'
-#' @aliases rbind2,hyperSpec,hyperSpec-method
-setMethod("rbind2", signature = signature(x = "hyperSpec", y = "hyperSpec"), .rbind2)
-
-#' @rdname bind
-#' @export
-#'
-#' @concept manipulation
-#'
-#' @aliases rbind2,hyperSpec,missing-method
-setMethod("rbind2", signature = signature(x = "hyperSpec", y = "missing"), function(x, y, wl.tolerance) x)

--- a/hyperSpec/R/colMeans.R
+++ b/hyperSpec/R/colMeans.R
@@ -1,24 +1,35 @@
-#' Functions `colSums()`, `colMeans()`, `rowSums()`, and `rowMeans()` for `hyperSpec` objects
+# Set generic ----------------------------------------------------------------
+
+#' Functions `colSums()`, `colMeans()`, `rowSums()`, and `rowMeans()` for
+#' `hyperSpec` objects
 #'
 #' `hyperSpec` objects can use the base functions [base::colMeans()],
 #' [base::colSums()], [base::rowMeans()] and [base::rowSums()].
 #'
+#' @name colSums
+#' @rdname colSums
+#'
+#'
 #' @param x `hyperSpec` object
-#' @param label.spc labels for the intensity axis for loadings-like (col) statistics
-#' @param label.wavelength labels for the wavelength axis for scores-like (row) statistics
+#' @param label.spc labels for the intensity axis for loadings-like (col)
+#'        statistics
+#' @param label.wavelength labels for the wavelength axis for scores-like (row)
+#'        statistics
 #' @param na.rm,... further parameters to the base functions
 #'
 #' `na.rm` defaults to `TRUE` for `hyperSpec` objects.
+#'
 #' @seealso [colSums][base::colSums]
 #'
 #' @concept stats
 #'
-#' @rdname colSums
-#' @name colSums
 NULL
 
 #' @noRd
 setGeneric("colMeans") # , package = 'matrixStats')
+
+
+# Function -------------------------------------------------------------------
 
 .colMeans <- function(x, na.rm = TRUE, ..., label.spc) {
   result <- colMeans(x@data$spc, na.rm = na.rm, ...)
@@ -39,8 +50,13 @@ setGeneric("colMeans") # , package = 'matrixStats')
 setMethod("colMeans", signature = signature(x = "hyperSpec"), .colMeans)
 
 
+# Set generic ----------------------------------------------------------------
+
 #' @noRd
 setGeneric("colSums") # , package = 'matrixStats')
+
+
+# Function -------------------------------------------------------------------
 
 .colSums <- function(x, na.rm = TRUE, ..., label.spc) {
   result <- colSums(x@data$spc, na.rm = na.rm, ...)
@@ -61,8 +77,12 @@ setGeneric("colSums") # , package = 'matrixStats')
 setMethod("colSums", signature = signature(x = "hyperSpec"), .colSums)
 
 
+# Set generic ----------------------------------------------------------------
+
 #' @noRd
 setGeneric("rowMeans") # , package = 'matrixStats')
+
+# Function -------------------------------------------------------------------
 
 .rowMeans <- function(x, na.rm = TRUE, ..., label.wavelength) {
   result <- rowMeans(x@data$spc, na.rm = na.rm, ...)
@@ -83,9 +103,13 @@ setGeneric("rowMeans") # , package = 'matrixStats')
 setMethod("rowMeans", signature = signature(x = "hyperSpec"), .rowMeans)
 
 
+# Set generic ----------------------------------------------------------------
+
 #' @noRd
 setGeneric("rowSums") # , package = 'matrixStats')
 
+
+# Function -------------------------------------------------------------------
 
 .rowSums <- function(x, na.rm = TRUE, ..., label.wavelength) {
   result <- rowSums(x@data$spc, na.rm = na.rm, ...)

--- a/hyperSpec/R/cov.R
+++ b/hyperSpec/R/cov.R
@@ -1,36 +1,44 @@
-#' Covariance matrices for `hyperSpec` objects
-#'
-#'
-#' @param x `hyperSpec` object
-#' @param y not supported
-#' @param use,method handed to  [stats::cov()]
-#' @return covariance matrix of size `nwl(x)` x `nwl(x)`
-#' @seealso [stats::cov()]
-#' @author C. Beleites
-#' @rdname cov
-#'
-#' @export
-#'
-#' @concept stats
-#'
-#' @examples
-#' image(cov(faux_cell))
-setMethod("cov",
-  signature = signature(x = "hyperSpec", y = "missing"),
-  function(x, y, use, method) {
+# Function -------------------------------------------------------------------
+
+.cov_h_ <-  function(x, y, use, method) {
     validObject(x)
 
     cov(x@data$spc, use = use, method = method)
   }
-)
+
+#' Covariance matrices for `hyperSpec` objects
+#'
+#' @rdname cov
+#'
+#' @param x `hyperSpec` object
+#' @param y not supported
+#' @param use,method handed to [stats::cov()]
+#'
+#' @return covariance matrix of size `nwl(x)` x `nwl(x)`
+#'
+#' @concept stats
+#'
+#' @author C. Beleites
+#'
+#' @export
+#'
+#' @seealso [stats::cov()]
+#'
+#' @examples
+#' image(cov(faux_cell))
+setMethod("cov", signature = signature(x = "hyperSpec", y = "missing"), .cov_h_)
 
 
+# Function -------------------------------------------------------------------
+
+#' @rdname cov
+#'
 #' @param ... ignored
 #' @param regularize regularization of the covariance matrix. Set `0` to switch off
 #'
 #' `pooled.cov` calculates pooled covariance like e.g. in LDA.
 #' @param groups factor indicating the groups
-#' @rdname cov
+#'
 #' @export
 #' @examples
 #' pcov <- pooled.cov(faux_cell, faux_cell$region)

--- a/hyperSpec/R/dim.R
+++ b/hyperSpec/R/dim.R
@@ -1,3 +1,9 @@
+# Function -------------------------------------------------------------------
+.ncol <- function(x) {
+  validObject(x)
+  ncol(x@data)
+}
+
 #' Number of rows (spectra), columns, and data points per spectrum of a
 #' `hyperSpec` object
 #'
@@ -12,46 +18,54 @@
 #'
 #' @rdname dim
 #' @docType methods
-#' @param x a `hyperSpec` object
-#' @author C. Beleites
-#' @seealso [base::ncol()]
 #'
-#' @return `nrow()`, `ncol()`, `nwl()`, and `length()`, return an `integer`.
+#' @param x a `hyperSpec` object
+#'
+#' @return `nrow()`, `ncol()`, `nwl()`, and `length()` return an `integer`.
+#'
+#' @author C. Beleites
+#'
+#' @concept summary
+#' @seealso [base::ncol()]
 #'
 #' @export
 #'
-#' @concept summary
-#'
 #' @examples
 #' ncol(faux_cell)
-setMethod("ncol", signature = signature("hyperSpec"), function(x) {
+setMethod("ncol", signature = signature("hyperSpec"), .ncol)
+
+
+# Function -------------------------------------------------------------------
+
+.nrow <- function(x) {
   validObject(x)
 
-  ncol(x@data)
-})
+  nrow(x@data)
+}
 
+#' @rdname dim
+#'
 #' @details
 #' - `nrow()` yields the number of rows in `x@@data`, i.e. the number of
 #'   spectra in the `hyperSpec` object.
 #'
-#' @rdname dim
 #' @seealso [base::nrow()]
 #' @export
 #' @examples
 #'
 #' nrow(faux_cell)
-setMethod("nrow", signature = signature("hyperSpec"), function(x) {
-  validObject(x)
+setMethod("nrow", signature = signature("hyperSpec"), .nrow)
 
-  nrow(x@data)
-})
 
+# Function -------------------------------------------------------------------
+
+#' @rdname dim
+#' @aliases nwl
+#'
 #' @details
 #' - `nwl()` returns the number of columns in `x@@data$spc`, i.e. thelength of
 #'   each spectrum.
 #'
-#' @rdname dim
-#' @aliases nwl
 #' @export
 #' @examples
 #'
@@ -64,35 +78,49 @@ nwl <- function(x) {
 }
 
 
+# Function -------------------------------------------------------------------
 
+.dim <- function(x) {
+  validObject(x)
+  c(nrow = nrow(x@data), ncol = ncol(x@data), nwl = ncol(x@data$spc))
+}
+
+#' @rdname dim
 #' @details
 #' - `dim()` returns all three values in a vector.
 #'
-#' @rdname dim
 #' @return
 #'
 #' `dim()` returns a vector of length 3.
+#'
 #' @seealso [base::dim()]
 #' @keywords methods
+#'
 #' @export
+#'
 #' @examples
 #'
 #' dim(faux_cell)
-setMethod("dim", signature = signature("hyperSpec"), function(x) {
-  validObject(x)
-  c(nrow = nrow(x@data), ncol = ncol(x@data), nwl = ncol(x@data$spc))
-})
+setMethod("dim", signature = signature("hyperSpec"), .dim)
 
+
+# Function -------------------------------------------------------------------
+
+.length <- function(x) {
+  validObject(x)
+  nrow(x@data)
+}
+
+#' @rdname dim
+#'
 #' @details
 #' - `length()` is a synonym for `nrow()`. It is supplied so that `seq_along(x)`
 #' returns a sequence to index each spectrum.
-#' @rdname dim
 #' @seealso [base::length()]
+#'
 #' @export
+#'
 #' @examples
 #'
 #' length(faux_cell)
-setMethod("length", signature = signature("hyperSpec"), function(x) {
-  validObject(x)
-  nrow(x@data)
-})
+setMethod("length", signature = signature("hyperSpec"), .length)

--- a/hyperSpec/R/dim.R
+++ b/hyperSpec/R/dim.R
@@ -124,3 +124,8 @@ setMethod("dim", signature = signature("hyperSpec"), .dim)
 #'
 #' length(faux_cell)
 setMethod("length", signature = signature("hyperSpec"), .length)
+
+
+# Unit tests -----------------------------------------------------------------
+
+# TODO: add unit tests

--- a/hyperSpec/R/dimnames.R
+++ b/hyperSpec/R/dimnames.R
@@ -1,32 +1,38 @@
-#' Dimnames for `hyperSpec` objects
-#'
-#' `hyperSpec` objects can have row- and column names like data.frames.
-#' The "names" of the wavelengths are treated separately: see [wl()].
-#'
-#' @param x the `hyperSpec` object
-#' @aliases dimnames
-#' @rdname dimnames
-#' @docType methods
-#' @author C. Beleites
-#' @seealso [wl()] for the wavelength dimension
-#'
-#' [base::dimnames()]
-#'
-#' @export
-#'
-#' @keywords methods
-#' @concept manipulation
-#'
-#' @examples
-#' dimnames(flu)
-setMethod("dimnames", signature = signature(x = "hyperSpec"), function(x) {
+# Function -------------------------------------------------------------------
+
+.dimnames <- function(x) {
   validObject(x)
 
   list(
     row = rownames(x@data), data = colnames(x@data),
     wl = colnames(x@data$spc)
   )
-})
+}
+
+#' Dimnames for `hyperSpec` objects
+#'
+#' `hyperSpec` objects can have row- and column names like data.frames.
+#' The "names" of the wavelengths are treated separately: see [wl()].
+#'
+#' @param x the `hyperSpec` object
+#'
+#' @rdname dimnames
+#' @aliases dimnames
+#' @docType methods
+#'
+#' @author C. Beleites
+#'
+#' @keywords methods
+#' @concept manipulation
+#' @seealso [wl()] for the wavelength dimension
+#'
+#' [base::dimnames()]
+#'
+#' @export
+#'
+#' @examples
+#' dimnames(flu)
+setMethod("dimnames", signature = signature(x = "hyperSpec"), .dimnames)
 
 #' @rdname dimnames
 #' @aliases rownames
@@ -46,58 +52,83 @@ setMethod("rownames", signature = signature(x = "hyperSpec"), function(x, do.NUL
   rownames(x@data, do.NULL = do.NULL, prefix = prefix)
 })
 
-#' @param value the new names
-#' @usage
-#' \S4method{rownames}{hyperSpec} (x) <- value
-#' @aliases rownames<-,hyperSpec-method
-#' @rdname dimnames
-#' @name rownames<-
-#' @export "rownames<-"
-#'
-#' @concept manipulation
-#'
-setReplaceMethod("rownames", signature = signature(x = "hyperSpec"), function(x, value) {
+
+# Function -------------------------------------------------------------------
+
+.rownames_replace <- function(x, value) {
   validObject(x)
 
   rownames(x@data) <- value
   x
-})
+}
+
+#' @name rownames<-
+#' @rdname dimnames
+#' @aliases rownames<-,hyperSpec-method
+#'
+#' @param value the new names
+#' @usage
+#' \S4method{rownames}{hyperSpec} (x) <- value
+#'
+#' @export "rownames<-"
+#'
+#' @concept manipulation
+#'
+setReplaceMethod("rownames",
+  signature = signature(x = "hyperSpec"),
+  .rownames_replace
+)
+
+
+# Function -------------------------------------------------------------------
+
+.colnames <- function(x, do.NULL = TRUE, prefix = "col") {
+  validObject(x)
+  colnames(x@data, do.NULL = do.NULL, prefix = prefix)
+}
 
 #' @rdname dimnames
 #' @aliases colnames
 #' @seealso [base::colnames()]
-#' @export
 #'
 #' @concept manipulation
 #'
+#' @export
+#'
 #' @examples
 #' colnames(faux_cell)
-setMethod("colnames",
-  signature = signature(x = "hyperSpec"),
-  function(x, do.NULL = TRUE, prefix = "col") {
-    validObject(x)
-    colnames(x@data, do.NULL = do.NULL, prefix = prefix)
-  }
-)
+setMethod("colnames", signature = signature(x = "hyperSpec"), .colnames)
 
+
+# Function -------------------------------------------------------------------
+
+.colnames_replace <- function(x, value) {
+  validObject(x)
+
+  names(x@label[colnames(x@data)]) <- value
+  colnames(x@data) <- value
+
+  validObject(x) # necessary: $spc could be renamed!
+  x
+}
+
+#' @name colnames<-
 #' @rdname dimnames
+#' @aliases colnames<-,hyperSpec-method
+#'
 #' @usage
 #' \S4method{colnames}{hyperSpec} (x) <- value
-#' @aliases colnames<-,hyperSpec-method
-#' @name colnames<-
+#'
 #' @export "colnames<-"
 #'
 #' @concept manipulation
 #'
 setReplaceMethod("colnames",
   signature = signature(x = "hyperSpec"),
-  function(x, value) {
-    validObject(x)
-
-    names(x@label[colnames(x@data)]) <- value
-    colnames(x@data) <- value
-
-    validObject(x) # necessary: $spc could be renamed!
-    x
-  }
+  .colnames_replace
 )
+
+
+# Unit tests -----------------------------------------------------------------
+
+# TODO: add unit tests

--- a/hyperSpec/R/dimnames.R
+++ b/hyperSpec/R/dimnames.R
@@ -4,8 +4,9 @@
   validObject(x)
 
   list(
-    row = rownames(x@data), data = colnames(x@data),
-    wl = colnames(x@data$spc)
+    row  = rownames(x@data),
+    data = colnames(x@data),
+    wl   = colnames(x@data$spc)
   )
 }
 
@@ -34,23 +35,31 @@
 #' dimnames(flu)
 setMethod("dimnames", signature = signature(x = "hyperSpec"), .dimnames)
 
-#' @rdname dimnames
-#' @aliases rownames
-#' @param do.NULL handed to [base::rownames()] or [base::colnames()]: logical.
-#' Should this create names if they are `NULL`?
-#' @param prefix handed to [base::rownames()] or [base::colnames()]
-#' @seealso [base::rownames()]
-#' @export
-#'
-#' @concept manipulation
-#'
-#' @examples
-#' rownames(flu)
-setMethod("rownames", signature = signature(x = "hyperSpec"), function(x, do.NULL = TRUE, prefix = "row") {
+
+# Function -------------------------------------------------------------------
+
+.rownames <- function(x, do.NULL = TRUE, prefix = "row") {
   validObject(x)
 
   rownames(x@data, do.NULL = do.NULL, prefix = prefix)
-})
+}
+
+#' @rdname dimnames
+#' @aliases rownames
+#'
+#' @param do.NULL handed to [base::rownames()] or [base::colnames()]: logical.
+#'        Should this create names if they are `NULL`?
+#' @param prefix handed to [base::rownames()] or [base::colnames()]
+#'
+#' @seealso [base::rownames()]
+#'
+#' @concept manipulation
+#'
+#' @export
+#'
+#' @examples
+#' rownames(flu)
+setMethod("rownames", signature = signature(x = "hyperSpec"), .rownames)
 
 
 # Function -------------------------------------------------------------------
@@ -68,7 +77,7 @@ setMethod("rownames", signature = signature(x = "hyperSpec"), function(x, do.NUL
 #'
 #' @param value the new names
 #' @usage
-#' \S4method{rownames}{hyperSpec} (x) <- value
+#' \S4method{rownames}{hyperSpec}(x) <- value
 #'
 #' @export "rownames<-"
 #'
@@ -117,7 +126,7 @@ setMethod("colnames", signature = signature(x = "hyperSpec"), .colnames)
 #' @aliases colnames<-,hyperSpec-method
 #'
 #' @usage
-#' \S4method{colnames}{hyperSpec} (x) <- value
+#' \S4method{colnames}{hyperSpec}(x) <- value
 #'
 #' @export "colnames<-"
 #'

--- a/hyperSpec/R/droplevels.R
+++ b/hyperSpec/R/droplevels.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 .droplevels <- function(x, ...) {
   x@data <- droplevels(x@data, ...)
 
@@ -22,6 +24,9 @@
 #' faux_cell[1:3]$region
 #' droplevels(faux_cell[1:3])$region
 setMethod("droplevels", signature = "hyperSpec", definition = .droplevels)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.droplevels) <- function() {
   context("droplevels")

--- a/hyperSpec/R/extract.R
+++ b/hyperSpec/R/extract.R
@@ -251,7 +251,7 @@ setMethod("[", signature = signature(x = "hyperSpec"), .extract_h)
 
 # Function -------------------------------------------------------------------
 
-.extract2_hy <- function(x, i, j, l, ..., wl.index = FALSE, drop = FALSE) {
+.extract2_h <- function(x, i, j, l, ..., wl.index = FALSE, drop = FALSE) {
   validObject(x)
 
   dots <- list(...)
@@ -291,7 +291,7 @@ setMethod("[", signature = signature(x = "hyperSpec"), .extract_h)
 #'
 #' @aliases [[ [[,hyperSpec-method
 ## ' @name [[
-setMethod("[[", signature = signature(x = "hyperSpec"), .extract2_hy)
+setMethod("[[", signature = signature(x = "hyperSpec"), .extract2_h)
 
 
 # Function -------------------------------------------------------------------

--- a/hyperSpec/R/extract.R
+++ b/hyperSpec/R/extract.R
@@ -1,7 +1,10 @@
-### -----------------------------------------------------------------------------
+### --------------------------------------------------------------------------~
 ###
 ### .extract - internal function doing the work for extracting with [] and [[]]
 ###
+### --------------------------------------------------------------------------~
+
+# Function -------------------------------------------------------------------
 
 #' @include wl2i.R
 #' @noRd
@@ -32,6 +35,32 @@
 
   x
 }
+
+.extract_hy <- function(x, i, j, l, ...,
+                        wl.index = FALSE,
+                        drop = FALSE # drop has to be at end
+) {
+  validObject(x)
+
+  if (drop) {
+    warning("Ignoring drop = TRUE.")
+  }
+
+  dots <- list(...)
+  if (length(dots) > 0L) {
+    warning("Ignoring additional parameters: ", .pastenames(dots))
+  }
+
+  x <- .extract(x, i, j, l, wl.index = wl.index)
+
+  if (is.null(x@data$spc)) {
+    x@data$spc <- matrix(NA, nrow(x@data), 0)
+    x@wavelength <- numeric(0)
+  }
+
+  x
+}
+
 
 #' These methods allow one to extract and replace parts of the `hyperSpec` object.
 #' They can be used for selecting/deleting spectra, cutting the spectral range, and extracting
@@ -111,6 +140,7 @@
 #' @rdname extractreplace
 #' @docType methods
 #' @aliases [ [,hyperSpec-method
+#'
 #' @param x A `hyperSpec` Object.
 #' @param i Index of rows in `x@@data`. Integer, logical, or in the case of
 #'          `[[` and `[[<-`, a `nrow` by 2 logical matrix or
@@ -129,6 +159,7 @@
 #'          `[`, as otherwise invalid `hyperSpec` objects might result.
 #' @param ... Ignored.
 #' @param name Name of the data column to extract. `$spc` yields the spectra matrix.
+#'
 #' @return
 #'  * For `[`, `[<-`, `[[<-`, and `$<-` a `hyperSpec` object.
 #'  * For `[[` a matrix or `data.frame`.
@@ -214,33 +245,43 @@
 #'
 #' @concept manipulation
 #'
-setMethod("[",
-  signature = signature(x = "hyperSpec"),
-  function(x, i, j, l, ...,
-           wl.index = FALSE,
-           drop = FALSE # drop has to be at end
-  ) {
-    validObject(x)
+setMethod("[", signature = signature(x = "hyperSpec"), .extract_hy)
 
-    if (drop) {
-      warning("Ignoring drop = TRUE.")
-    }
 
-    dots <- list(...)
-    if (length(dots) > 0L) {
-      warning("Ignoring additional parameters: ", .pastenames(dots))
-    }
+# Function -------------------------------------------------------------------
 
-    x <- .extract(x, i, j, l, wl.index = wl.index)
+.extract2_hy <- function(x, i, j, l, ..., wl.index = FALSE, drop = FALSE) {
+  validObject(x)
 
-    if (is.null(x@data$spc)) {
-      x@data$spc <- matrix(NA, nrow(x@data), 0)
-      x@wavelength <- numeric(0)
-    }
-
-    x
+  dots <- list(...)
+  if (length(dots) > 0L) {
+    warning("Ignoring additional parameters: ", .pastenames(dots))
   }
-)
+
+  ## check wheter a index matrix is used
+  if (!missing(i) && is.matrix(i)) {
+    if (!is.logical(i) && !(is.numeric(i) && ncol(i) == 2)) {
+      stop(
+        "Index matrix i  must either be logical of the size of x$spc,",
+        "or a n by 2 matrix."
+      )
+    }
+
+    if (is.numeric(i) && !wl.index) {
+      i[, 2] <- .getindex(x, i[, 2], extrapolate = FALSE)
+    }
+
+    x@data$spc[i] # return value
+  } else { # index by row and columns
+    x <- .extract(x, i, j, l, wl.index = wl.index)
+    if (missing(j)) {
+      unclass(x@data$spc[, , drop = drop])
+    } # retrun value; removes the "AsIs"
+    else {
+      x@data[, , drop = drop] # return value: data.frame
+    }
+  }
+}
 
 #' @rdname extractreplace
 #' @export
@@ -249,43 +290,23 @@ setMethod("[",
 #'
 #' @aliases [[ [[,hyperSpec-method
 ## ' @name [[
-setMethod("[[",
-  signature = signature(x = "hyperSpec"),
-  function(x, i, j, l, ...,
-           wl.index = FALSE,
-           drop = FALSE) {
-    validObject(x)
+setMethod("[[", signature = signature(x = "hyperSpec"), .extract2_hy)
 
-    dots <- list(...)
-    if (length(dots) > 0L) {
-      warning("Ignoring additional parameters: ", .pastenames(dots))
-    }
 
-    ## check wheter a index matrix is used
-    if (!missing(i) && is.matrix(i)) {
-      if (!is.logical(i) && !(is.numeric(i) && ncol(i) == 2)) {
-        stop(
-          "Index matrix i  must either be logical of the size of x$spc,",
-          "or a n by 2 matrix."
-        )
-      }
+# Function -------------------------------------------------------------------
 
-      if (is.numeric(i) && !wl.index) {
-        i[, 2] <- .getindex(x, i[, 2], extrapolate = FALSE)
-      }
+.dollar_shortcuts <- function(x, name) {
+  validObject(x)
 
-      x@data$spc[i] # return value
-    } else { # index by row and columns
-      x <- .extract(x, i, j, l, wl.index = wl.index)
-      if (missing(j)) {
-        unclass(x@data$spc[, , drop = drop])
-      } # retrun value; removes the "AsIs"
-      else {
-        x@data[, , drop = drop] # return value: data.frame
-      }
-    }
+  if (name == ".") { ## shortcut
+    x@data[, , drop = FALSE]
+  } else if (name == "..") {
+    x@data[, -match("spc", colnames(x@data)), drop = FALSE]
+  } else {
+    x@data[[name]]
   }
-)
+}
+
 
 #' @rdname extractreplace
 #' @aliases $ $,hyperSpec-method
@@ -293,17 +314,4 @@ setMethod("[[",
 #'
 #' @concept manipulation
 #'
-setMethod("$",
-  signature = signature(x = "hyperSpec"),
-  function(x, name) {
-    validObject(x)
-
-    if (name == ".") { ## shortcut
-      x@data[, , drop = FALSE]
-    } else if (name == "..") {
-      x@data[, -match("spc", colnames(x@data)), drop = FALSE]
-    } else {
-      x@data[[name]]
-    }
-  }
-)
+setMethod("$", signature = signature(x = "hyperSpec"), .dollar_shortcuts)

--- a/hyperSpec/R/extract.R
+++ b/hyperSpec/R/extract.R
@@ -36,7 +36,8 @@
   x
 }
 
-.extract_hy <- function(x, i, j, l, ...,
+
+.extract_h <- function(x, i, j, l, ...,
                         wl.index = FALSE,
                         drop = FALSE # drop has to be at end
 ) {
@@ -245,7 +246,7 @@
 #'
 #' @concept manipulation
 #'
-setMethod("[", signature = signature(x = "hyperSpec"), .extract_hy)
+setMethod("[", signature = signature(x = "hyperSpec"), .extract_h)
 
 
 # Function -------------------------------------------------------------------

--- a/hyperSpec/R/initialize.R
+++ b/hyperSpec/R/initialize.R
@@ -1,13 +1,17 @@
-### -----------------------------------------------------------------------------
+### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ###
 ###  initialize -- initialization, called by new("hyperSpec", ...)
 ###
 ###  C. Beleites
 ###
+### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Function -------------------------------------------------------------------
 
 #' @include paste_row.R
 #' @noRd
-.initialize <- function(.Object, spc = NULL, data = NULL, wavelength = NULL, labels = NULL) {
+.initialize <- function(.Object, spc = NULL, data = NULL, wavelength = NULL,
+                        labels = NULL) {
 
   # Do the small stuff first, so we need not be too careful about copies
 
@@ -159,8 +163,14 @@
 #' @name initialize
 #' @rdname initialize
 #'
-#' @aliases initialize,hyperSpec-method initialize create new_hyperSpec
-#'   create,hyperSpec-method new,hyperSpec-method new
+#' @aliases
+#'  initialize
+#'  initialize,hyperSpec-method
+#'  create
+#'  create,hyperSpec-method
+#'  new
+#'  new,hyperSpec-method
+#'  new_hyperSpec
 #'
 #' @docType methods
 #'
@@ -233,7 +243,7 @@
 #' plotc(h, spc ~ pos)
 setMethod("initialize", "hyperSpec", .initialize)
 
-
+# Function -------------------------------------------------------------------
 #' @rdname initialize
 #' @export
 new_hyperSpec <- function(spc = NULL, data = NULL, wavelength = NULL, labels = NULL) {
@@ -242,7 +252,6 @@ new_hyperSpec <- function(spc = NULL, data = NULL, wavelength = NULL, labels = N
 
 
 # Unit tests -----------------------------------------------------------------
-
 
 hySpc.testthat::test(.initialize) <- function() {
   context(".initialize / new (\"hyperSpec\")")

--- a/hyperSpec/R/labels.R
+++ b/hyperSpec/R/labels.R
@@ -1,3 +1,6 @@
+
+# Function -------------------------------------------------------------------
+
 #' @importFrom utils modifyList
 .labels <- function(object, which = bquote(), drop = TRUE, ..., use.colnames = TRUE) {
   validObject(object)
@@ -28,6 +31,53 @@
   label
 }
 
+
+#' Get and set labels of a `hyperSpec` object
+#'
+#' Get and set labels of a `hyperSpec` object.
+#'
+#'
+#' `value` may be a list or vector of labels giving the new label for
+#' each of the entries specified by `which`.
+#'
+#' The names of the labels are the same as the colnames of the
+#' `data.frame`.  The label for the wavelength axis has the name
+#' `.wavelength`.
+#'
+#' The labels should be given in a form ready for the text-drawing functions
+#' (see [grDevices::plotmath()]), e.g. as `expression` or a
+#' `character`.
+#'
+#' @rdname labels
+#' @docType methods
+#'
+#' @param object a `hyperSpec` object
+#' @param which numeric or character to specify the label(s)
+#' @param ... ignored
+#' @param drop if the result would be a list with only one element, should the
+#'        element be returned instead?
+#' @param use.colnames should missing labels be replaced by column names of
+#'        the extra data?
+#'
+#' @return `labels` returns a list of labels.  If `drop` is
+#'         `TRUE` and the list contains only one element, the element is
+#'         returned instead.
+#'
+#'
+#' @author C. Beleites
+#' @seealso [base::labels()]
+#'
+#' @export
+#'
+#' @concept labels
+#'
+#' @examples
+#'
+#' labels(faux_cell)
+setMethod("labels", signature = signature(object = "hyperSpec"), .labels)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.labels) <- function() {
   context(".labels")
@@ -70,17 +120,23 @@ hySpc.testthat::test(.labels) <- function() {
   })
 }
 
+
+# Function -------------------------------------------------------------------
+
 #' @rdname labels
+#' @aliases labels<-,hyperSpec-method
+#'
 #' @usage
 #' labels(object, which = NULL, ...) <- value
 #'
-#' @aliases labels<-,hyperSpec-method
+#' @param value the new label(s)
+#'
+#' @return  `labels<-` returns a `hyperSpec` object.
+#'
 #' @export "labels<-"
 #'
 #' @concept labels
 #'
-#' @param value the new label(s)
-#' @return  `labels<-` returns a `hyperSpec` object.
 #' @examples
 #'
 #' labels(flu, "c") <- expression("/"("c", "mg / l"))
@@ -108,38 +164,6 @@ hySpc.testthat::test(.labels) <- function() {
 }
 
 
-#' Get and set labels of a `hyperSpec` object
-#'
-#' `value` may be a list or vector of labels giving the new label for
-#' each of the entries specified by `which`.
-#'
-#' The names of the labels are the same as the colnames of the
-#' `data.frame`.  The label for the wavelength axis has the name
-#' `.wavelength`.
-#'
-#' The labels should be given in a form ready for the text-drawing functions
-#' (see [grDevices::plotmath()]), e.g. as `expression` or a
-#' `character`.
-#'
-#' @param object a `hyperSpec` object
-#' @param which numeric or character to specify the label(s)
-#' @param ... ignored
-#' @param drop if the result would be a list with only one element, should the
-#'   element be returned instead?
-#' @param use.colnames should missing labels be replaced by column names of
-#'   the extra data?
-#' @return `labels` returns a list of labels.  If `drop` is
-#'   `TRUE` and the list contains only one element, the element is
-#'   returned instead.
-#' @docType methods
-#' @rdname labels
-#' @author C. Beleites
-#' @seealso [base::labels()]
-#' @export
-#'
-#' @concept labels
-#'
-#' @examples
-#'
-#' labels(faux_cell)
-setMethod("labels", signature = signature(object = "hyperSpec"), .labels)
+# Unit tests -----------------------------------------------------------------
+
+# TODO: Add unit test for "set labels"

--- a/hyperSpec/R/levelplot.R
+++ b/hyperSpec/R/levelplot.R
@@ -79,27 +79,17 @@ setGeneric("levelplot", package = "lattice")
   do.call(levelplot, c(list(x, data), dots))
 }
 
+#' @rdname levelplot
+#' @export
+setMethod("levelplot",
+  signature = signature(x = "formula", data = "hyperSpec"),
+  definition = .levelplot
+)
 
-# Unit tests -----------------------------------------------------------------
-
-hySpc.testthat::test(.levelplot) <- function() {
-  context(".levelplot")
-
-  test_that("no errors", {
-    ## just check that no errors occur
-    expect_silent(levelplot(laser, contour = TRUE, col = "#00000080"))
-
-    ## applying a function before plotting
-    expect_silent(plotmap(faux_cell, func = max, col.regions = gray(seq(0, 1, 0.05))))
-
-    expect_silent(plotmap(faux_cell, region ~ x * y, transform.factor = FALSE))
-    expect_silent(plotmap(faux_cell, region ~ x * y, col.regions = gray(seq(0, 1, 0.05))))
-  })
-}
 
 # Function -------------------------------------------------------------------
 
-.levelplot_hy_miss <- function(x, data, ...) {
+.levelplot_h_ <- function(x, data, ...) {
   .levelplot(x = formula(spc ~ .wavelength * .row), data = x, ...)
 }
 
@@ -122,15 +112,24 @@ hySpc.testthat::test(.levelplot) <- function() {
 #'  [trellis.factor.key()] for improved color coding of factors
 setMethod("levelplot",
   signature = signature(x = "hyperSpec", data = "missing"),
-  .levelplot_hy_miss
+  .levelplot_h_
 )
 
 
-# Function -------------------------------------------------------------------
+# Unit tests -----------------------------------------------------------------
 
-#' @rdname levelplot
-#' @export
-setMethod("levelplot",
-  signature = signature(x = "formula", data = "hyperSpec"),
-  definition = .levelplot
-)
+hySpc.testthat::test(.levelplot) <- function() {
+  context(".levelplot")
+
+  test_that("no errors", {
+    ## just check that no errors occur
+    expect_silent(levelplot(laser, contour = TRUE, col = "#00000080"))
+
+    ## applying a function before plotting
+    expect_silent(plotmap(faux_cell, func = max, col.regions = gray(seq(0, 1, 0.05))))
+
+    expect_silent(plotmap(faux_cell, region ~ x * y, transform.factor = FALSE))
+    expect_silent(plotmap(faux_cell, region ~ x * y, col.regions = gray(seq(0, 1, 0.05))))
+  })
+}
+

--- a/hyperSpec/R/levelplot.R
+++ b/hyperSpec/R/levelplot.R
@@ -1,14 +1,17 @@
+# Set generic ----------------------------------------------------------------
+
 #' @importFrom lattice latticeParseFormula
 setGeneric("levelplot", package = "lattice")
 
-#################################################################################
-###
+###--------------------------------------------------------------------------~
 ###  levelplot.R - everything that has to do with levelplot-like plotting:
 ###
 ###  levelplot is used by plotmap, plotvoronoi
 ###
+###--------------------------------------------------------------------------~
 
-### the workhorse function
+# Function -------------------------------------------------------------------
+# the workhorse function
 
 #' @importFrom utils modifyList
 .levelplot <- function(x, data, transform.factor = TRUE, ...,
@@ -77,6 +80,8 @@ setGeneric("levelplot", package = "lattice")
 }
 
 
+# Unit tests -----------------------------------------------------------------
+
 hySpc.testthat::test(.levelplot) <- function() {
   context(".levelplot")
 
@@ -92,12 +97,21 @@ hySpc.testthat::test(.levelplot) <- function() {
   })
 }
 
-#' @include plotmap.R
+# Function -------------------------------------------------------------------
+
+.levelplot_hy_miss <- function(x, data, ...) {
+  .levelplot(x = formula(spc ~ .wavelength * .row), data = x, ...)
+}
+
 #' @rdname levelplot
+#'
 #' @param transform.factor If the color-coded variable is a factor, should
 #'   [trellis.factor.key()] be used to compute the color coding and
 #'   legend?
 #' @param contour,useRaster see  [lattice::levelplot()]
+#'
+#' @include plotmap.R
+#' @importFrom lattice levelplot
 #' @export
 #'
 #' @concept plotting
@@ -106,17 +120,17 @@ hySpc.testthat::test(.levelplot) <- function() {
 #' @seealso  [lattice::levelplot()]
 #'
 #'  [trellis.factor.key()] for improved color coding of factors
-#' @importFrom lattice levelplot
-setMethod(
-  f = "levelplot", signature = signature(x = "hyperSpec", data = "missing"),
-  definition = function(x, data, ...) {
-    .levelplot(x = formula(spc ~ .wavelength * .row), data = x, ...)
-  }
+setMethod("levelplot",
+  signature = signature(x = "hyperSpec", data = "missing"),
+  .levelplot_hy_miss
 )
+
+
+# Function -------------------------------------------------------------------
 
 #' @rdname levelplot
 #' @export
-setMethod(
-  f = "levelplot", signature = signature(x = "formula", data = "hyperSpec"),
+setMethod("levelplot",
+  signature = signature(x = "formula", data = "hyperSpec"),
   definition = .levelplot
 )

--- a/hyperSpec/R/merge.R
+++ b/hyperSpec/R/merge.R
@@ -1,83 +1,4 @@
-#' Merge `hyperSpec` objects
-#'
-#' Merges two `hyperSpec` objects and [base::cbind()]s their spectra
-#' matrices, or merges additional extra data into a `hyperSpec` object.
-#'
-#' After merging, the spectra matrix can contain duplicates, and is not
-#' ordered according to the wavelength.
-#'
-#' If the wavelength axis should be ordered, use [wl_sort()].
-#'
-#' If a `hyperSpec` object and  a `data.frame` are merged, the result is of the
-#' class of the first (`x`) object.
-#'
-#' @aliases merge,hyperSpec,hyperSpec-method merge
-#' @param x a `hyperSpec` object or data.frame
-#' @param y a `hyperSpec` object or data.frame (including derived classes like tibble)
-#' @param ... handed to [base::merge.data.frame()]
-#' @author C. Beleites
-#'
-#' @export
-#'
-#' @concept manipulation
-#'
-#' @rdname merge
-#' @docType methods
-#' @aliases merge
-#' @seealso [base::merge()].
-#'
-#' [collapse()] combines `hyperSpec` objects that do not share the wavelength axis.
-#' [rbind()], and [cbind()] for combining `hyperSpec` objects that.
-#' @keywords manip
-#' @examples
-#'
-#' merge(faux_cell[1:10, , 600], faux_cell[5:15, , 600], by = c("x", "y"))$.
-#' tmp <- merge(faux_cell[1:10, , 610], faux_cell[5:15, , 610],
-#'   by = c("x", "y"), all = TRUE
-#' )
-#' tmp$.
-#' wl(tmp)
-#'
-#' ## remove duplicated wavelengths:
-#' approxfun <- function(y, wl, new.wl) {
-#'   approx(wl, y, new.wl,
-#'     method = "constant",
-#'     ties = function(x) mean(x, na.rm = TRUE)
-#'   )$y
-#' }
-#'
-#' merged <- merge(faux_cell[1:7, , 610 ~ 620], faux_cell[5:10, , 615 ~ 625], all = TRUE)
-#' merged$.
-#' merged <- apply(merged, 1, approxfun,
-#'   wl = wl(merged), new.wl = unique(wl(merged)),
-#'   new.wavelength = "new.wl"
-#' )
-#' merged$.
-#'
-#' ## merging data.frame into hyperSpec object => hyperSpec object
-#' y <- data.frame(filename = sample(flu$filename, 4, replace = TRUE), cpred = 1:4)
-#' y
-#' tmp <- merge(flu, y)
-#' tmp$..
-#'
-#' ## merging hyperSpec object into data.frame => data.frame
-#' merge(y, flu)
-setMethod("merge",
-  signature = signature(x = "hyperSpec", y = "hyperSpec"),
-  function(x, y, ...) {
-    validObject(x)
-    validObject(y)
-
-    tmp <- .merge(x, y, ...)
-
-    if (nrow(tmp) == 0 && nrow(x) > 0 && nrow(y) > 0) {
-      warning("Merge results in 0 spectra.")
-    }
-
-    tmp
-  }
-)
-
+# Functions ------------------------------------------------------------------
 
 .merge <- function(x, y,
                    by = setdiff(intersect(colnames(x), colnames(y)), "spc"),
@@ -119,37 +40,143 @@ setMethod("merge",
   x
 }
 
+.merge_hy_hy <- function(x, y, ...) {
+  validObject(x)
+  validObject(y)
+
+  tmp <- .merge(x, y, ...)
+
+  if (nrow(tmp) == 0 && nrow(x) > 0 && nrow(y) > 0) {
+    warning("Merge results in 0 spectra.")
+  }
+
+  tmp
+}
+
+#' Merge `hyperSpec` objects
+#'
+#' Merges two `hyperSpec` objects and [base::cbind()]s their spectra
+#' matrices, or merges additional extra data into a `hyperSpec` object.
+#'
+#' After merging, the spectra matrix can contain duplicates, and is not
+#' ordered according to the wavelength.
+#'
+#' If the wavelength axis should be ordered, use [wl_sort()].
+#'
+#' If a `hyperSpec` object and  a `data.frame` are merged, the result is
+#' of the class of the first (`x`) object.
+#'
+#'
+#' @param x a `hyperSpec` object or `data.frame`
+#' @param y a `hyperSpec` object or `data.frame`
+#'       (including derived classes like `tibble`)
+#' @param ... handed to [base::merge.data.frame()]
+#'
+#' @author C. Beleites
+#'
 #' @rdname merge
+#' @aliases merge
+#' @aliases merge,hyperSpec,hyperSpec-method merge
+#' @docType methods
+#'
+#' @concept manipulation
+#' @seealso [base::merge()]
+#'
+#' [collapse()] combines `hyperSpec` objects that do not share the wavelength axis.
+#'
+#' [rbind()], and [cbind()] for combining `hyperSpec` objects that.
+#'
+#' [merge_data()]
+#' @keywords manip
+#'
+#' @export
+#'
+#' @examples
+#'
+#' merge(faux_cell[1:10, , 600], faux_cell[5:15, , 600], by = c("x", "y"))$.
+#'
+#' tmp <- merge(faux_cell[1:10, , 610], faux_cell[5:15, , 610],
+#'   by = c("x", "y"), all = TRUE
+#' )
+#' tmp$.
+#'
+#' wl(tmp)
+#'
+#' ## remove duplicated wavelengths:
+#' approxfun <- function(y, wl, new.wl) {
+#'   approx(wl, y, new.wl,
+#'     method = "constant",
+#'     ties = function(x) mean(x, na.rm = TRUE)
+#'   )$y
+#' }
+#'
+#' merged <- merge(faux_cell[1:7, , 610 ~ 620], faux_cell[5:10, , 615 ~ 625], all = TRUE)
+#' merged$.
+#'
+#' merged <- apply(merged, 1, approxfun,
+#'   wl = wl(merged), new.wl = unique(wl(merged)),
+#'   new.wavelength = "new.wl"
+#' )
+#' merged$.
+#'
+#' ## merging data.frame into hyperSpec object => hyperSpec object
+#' y <- data.frame(filename = sample(flu$filename, 4, replace = TRUE), cpred = 1:4)
+#' y
+#'
+#' tmp <- merge(flu, y)
+#' tmp$..
+#'
+#' ## merging hyperSpec object into data.frame => data.frame
+#' merge(y, flu)
+setMethod("merge",
+  signature = signature(x = "hyperSpec", y = "hyperSpec"),
+  .merge_hy_hy
+)
+
+
+# Function -------------------------------------------------------------------
+
+.merge_hy_df <- function(x, y, ...) {
+  validObject(x)
+
+  tmp <- merge(x@data, y, ...)
+  tmp
+  if (nrow(tmp) == 0 && nrow(x) > 0 && nrow(y) > 0) {
+    warning("Merge results in 0 spectra.")
+  }
+
+  x@data <- tmp
+
+  x
+}
+
+#' @rdname merge
+#' @export
+#'
 setMethod("merge",
   signature = signature(x = "hyperSpec", y = "data.frame"),
-  function(x, y, ...) {
-    validObject(x)
-
-    tmp <- merge(x@data, y, ...)
-    tmp
-    if (nrow(tmp) == 0 && nrow(x) > 0 && nrow(y) > 0) {
-      warning("Merge results in 0 spectra.")
-    }
-
-    x@data <- tmp
-
-    x
-  }
+  .merge_hy_df
 )
+
+
+# Function -------------------------------------------------------------------
+
+.merge_df_hy <- function(x, y, ...) {
+  validObject(y)
+  merge(x, y@data, ...)
+}
 
 #' @rdname merge
+#' @export
+#'
 setMethod("merge",
   signature = signature(x = "data.frame", y = "hyperSpec"),
-  function(x, y, ...) {
-    validObject(y)
-
-    merge(x, y@data, ...)
-  }
+  .merge_df_hy
 )
 
 
 
-
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.merge) <- function() {
   context("merge")

--- a/hyperSpec/R/mvtnorm.R
+++ b/hyperSpec/R/mvtnorm.R
@@ -1,3 +1,5 @@
+# Set generic ----------------------------------------------------------------
+
 .rmmvnorm <- function(n, mean, sigma) {
   if (!requireNamespace("mvtnorm")) {
     stop("package 'mvtnorm' needed to generate multivariate normal random data.")
@@ -27,6 +29,7 @@
 #' @name rmmvnorm
 setGeneric("rmmvnorm", .rmmvnorm)
 
+# Function -------------------------------------------------------------------
 
 #' Multivariate normal random numbers
 #'
@@ -37,22 +40,24 @@ setGeneric("rmmvnorm", .rmmvnorm)
 #' normal data for groups with different mean but common covariance matrix,
 #' see the examples.
 #'
-#' @param n vector giving the numer of cases to generate for each group
+#' @rdname rmmvnorm
+#' @aliases rmmvnorm rmmvnorm,hyperSpec-method
+#' @docType methods
+#'
+#' @param n vector giving the number of cases to generate for each group
 #' @param mean matrix with mean cases in rows
 #' @param sigma common covariance matrix or array
 #' (`ncol(mean)` x `ncol(mean)` x `nrow(mean)`) with individual covariance
 #' matrices for the groups.
-#' @export
 #'
 #' @concept data generation
-#'
 #' @seealso [mvtnorm::rmvnorm()]
 #'
 #' [hyperSpec::cov()] and [hyperSpec::pooled.cov()] about calculating covariance
 #' of `hyperSpec` objects.
-#' @rdname rmmvnorm
-#' @aliases rmmvnorm rmmvnorm,hyperSpec-method
-#' @docType methods
+#'
+#' @export
+#'
 #' @examples
 #' ## multiple groups, common covariance matrix
 #'
@@ -76,22 +81,29 @@ setMethod(
   }
 )
 
+# Function -------------------------------------------------------------------
+
+.rmmvnorm_num_hy_arr <- function(n, mean, sigma) {
+  tmp <- .rmmvnorm(n, mean@data$spc, sigma)
+
+  data <- mean[attr(tmp, "group"), , drop = FALSE]
+  if (hy.getOption("gc")) gc()
+  data@data$spc <- tmp
+  if (hy.getOption("gc")) gc()
+  data$.group <- attr(tmp, "group")
+  if (hy.getOption("gc")) gc()
+  data
+}
+
 #' @rdname rmmvnorm
 #' @export
 setMethod(
   "rmmvnorm", signature(n = "numeric", mean = "hyperSpec", sigma = "array"),
-  function(n, mean, sigma) {
-    tmp <- .rmmvnorm(n, mean@data$spc, sigma)
-
-    data <- mean[attr(tmp, "group"), , drop = FALSE]
-    if (hy.getOption("gc")) gc()
-    data@data$spc <- tmp
-    if (hy.getOption("gc")) gc()
-    data$.group <- attr(tmp, "group")
-    if (hy.getOption("gc")) gc()
-    data
-  }
+  .rmmvnorm_num_hy_arr
 )
+
+
+# Function -------------------------------------------------------------------
 
 #' @rdname rmmvnorm
 #' @export
@@ -100,6 +112,9 @@ setMethod(
   .rmmvnorm
 )
 
+
+# Function -------------------------------------------------------------------
+
 #' @rdname rmmvnorm
 #' @export
 setMethod(
@@ -107,5 +122,11 @@ setMethod(
   .rmmvnorm
 )
 
-## produces matrices instead of hyperSpec objects.
-## mapply (rmvnorm, n = 1:3, mean = pcov$mean, MoreArgs= list (sigma = pcov$COV), SIMPLIFY = FALSE))
+# FIXME:
+# produces matrices instead of hyperSpec objects.
+# mapply(rmvnorm, n = 1:3, mean = pcov$mean, MoreArgs= list(sigma = pcov$COV), SIMPLIFY = FALSE)
+
+
+# Unit testes ----------------------------------------------------------------
+
+# TODO: add unit tests

--- a/hyperSpec/R/mvtnorm.R
+++ b/hyperSpec/R/mvtnorm.R
@@ -29,7 +29,20 @@
 #' @name rmmvnorm
 setGeneric("rmmvnorm", .rmmvnorm)
 
+
 # Function -------------------------------------------------------------------
+
+.rmmvnorm_nhm <- function(n, mean, sigma) {
+    tmp <- .rmmvnorm(n, mean@data$spc, sigma)
+
+    data <- mean[attr(tmp, "group"), , drop = FALSE]
+    if (hy.getOption("gc")) gc()
+    data@data$spc <- tmp
+    if (hy.getOption("gc")) gc()
+    data$.group <- attr(tmp, "group")
+    if (hy.getOption("gc")) gc()
+    data
+  }
 
 #' Multivariate normal random numbers
 #'
@@ -66,24 +79,15 @@ setGeneric("rmmvnorm", .rmmvnorm)
 #'   rnd <- rmmvnorm(rep(10, 3), mean = pcov$mean, sigma = pcov$COV)
 #'   plot(rnd, col = rnd$.group)
 #' }
-setMethod(
-  "rmmvnorm", signature(n = "numeric", mean = "hyperSpec", sigma = "matrix"),
-  function(n, mean, sigma) {
-    tmp <- .rmmvnorm(n, mean@data$spc, sigma)
-
-    data <- mean[attr(tmp, "group"), , drop = FALSE]
-    if (hy.getOption("gc")) gc()
-    data@data$spc <- tmp
-    if (hy.getOption("gc")) gc()
-    data$.group <- attr(tmp, "group")
-    if (hy.getOption("gc")) gc()
-    data
-  }
+setMethod("rmmvnorm",
+  signature(n = "numeric", mean = "hyperSpec", sigma = "matrix"),
+  .rmmvnorm_nhm
 )
+
 
 # Function -------------------------------------------------------------------
 
-.rmmvnorm_num_hy_arr <- function(n, mean, sigma) {
+.rmmvnorm_nha <- function(n, mean, sigma) {
   tmp <- .rmmvnorm(n, mean@data$spc, sigma)
 
   data <- mean[attr(tmp, "group"), , drop = FALSE]
@@ -97,9 +101,9 @@ setMethod(
 
 #' @rdname rmmvnorm
 #' @export
-setMethod(
-  "rmmvnorm", signature(n = "numeric", mean = "hyperSpec", sigma = "array"),
-  .rmmvnorm_num_hy_arr
+setMethod("rmmvnorm",
+  signature(n = "numeric", mean = "hyperSpec", sigma = "array"),
+  .rmmvnorm_nha
 )
 
 
@@ -107,8 +111,8 @@ setMethod(
 
 #' @rdname rmmvnorm
 #' @export
-setMethod(
-  "rmmvnorm", signature(n = "numeric", mean = "matrix", sigma = "matrix"),
+setMethod("rmmvnorm",
+  signature(n = "numeric", mean = "matrix", sigma = "matrix"),
   .rmmvnorm
 )
 
@@ -117,8 +121,8 @@ setMethod(
 
 #' @rdname rmmvnorm
 #' @export
-setMethod(
-  "rmmvnorm", signature(n = "numeric", mean = "matrix", sigma = "array"),
+setMethod("rmmvnorm",
+  signature(n = "numeric", mean = "matrix", sigma = "array"),
   .rmmvnorm
 )
 

--- a/hyperSpec/R/normalize01.R
+++ b/hyperSpec/R/normalize01.R
@@ -1,5 +1,7 @@
 # @title normalization for mixed colors
 
+# Set generic ----------------------------------------------------------------
+
 #' Normalize numbers to interval \[0, 1\]
 #'
 #' The input `x` is mapped to \[0, 1\] by subtracting the minimum and
@@ -7,23 +9,27 @@
 #'  1 is returned.
 #'
 #' @name normalize01
+#'
 #' @param x  vector with values to transform
 #' @param tolerance tolerance level for determining what is 0 and 1
 #' @param ... additional parameters such as `tolerance` handed down.
+#'
 #' @return vector with `x` values mapped to the interval \[0, 1\]
+#'
 #' @author C. Beleites
-#' @seealso [hyperSpec::wl_eval()], [hyperSpec::vanderMonde()]
-#' @export
 #'
 #' @concept manipulation
+#' @seealso [hyperSpec::wl_eval()], [hyperSpec::vanderMonde()]
+#'
+#' @export
 #'
 setGeneric("normalize01", function(x, ...) standardGeneric("normalize01"))
 
+# Functions ------------------------------------------------------------------
+
+#' @rdname normalize01
 #' @export
 #'
-#' @concept manipulation
-#'
-#' @rdname normalize01
 setMethod(
   normalize01, signature(x = "matrix"),
   function(x, tolerance = hy.getOption("tolerance")) {
@@ -36,11 +42,9 @@ setMethod(
   }
 )
 
+#' @rdname normalize01
 #' @export
 #'
-#' @concept manipulation
-#'
-#' @rdname normalize01
 setMethod("normalize01", signature(x = "numeric"), function(x, tolerance = hy.getOption("tolerance")) {
   x <- x - min(x)
 
@@ -52,20 +56,18 @@ setMethod("normalize01", signature(x = "numeric"), function(x, tolerance = hy.ge
   }
 })
 
+
+#' @rdname normalize01
 #' @export
 #'
-#' @concept manipulation
-#'
-#' @rdname normalize01
 setMethod(normalize01, signature(x = "hyperSpec"), function(x, ...) {
   validObject(x)
-
   x@data$spc <- normalize01(unclass(x@data$spc), ...)
-
-  ## logbook
   x
 })
 
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(normalize01) <- function() {
   context("normalize01")

--- a/hyperSpec/R/normalize01.R
+++ b/hyperSpec/R/normalize01.R
@@ -10,11 +10,11 @@
 #'
 #' @name normalize01
 #'
-#' @param x  vector with values to transform
-#' @param tolerance tolerance level for determining what is 0 and 1
+#' @param x  Object (e.g., vector) with values to transform.
+#' @param tolerance Tolerance level for determining what is 0 and 1.
 #' @param ... additional parameters such as `tolerance` handed down.
 #'
-#' @return vector with `x` values mapped to the interval \[0, 1\]
+#' @return object (e.g., vector) with `x` values mapped to the interval \[0, 1\].
 #'
 #' @author C. Beleites
 #'
@@ -25,27 +25,27 @@
 #'
 setGeneric("normalize01", function(x, ...) standardGeneric("normalize01"))
 
-# Functions ------------------------------------------------------------------
+
+# Function -------------------------------------------------------------------
+
+.normalize01_mat <- function(x, tolerance = hy.getOption("tolerance")) {
+  m <- apply(x, 1, min)
+  x <- sweep(x, 1, m, `-`)
+  m <- apply(x, 1, max)
+  x <- sweep(x, 1, m, `/`)
+  x[m < tolerance, ] <- 1
+  x
+}
 
 #' @rdname normalize01
 #' @export
 #'
-setMethod(
-  normalize01, signature(x = "matrix"),
-  function(x, tolerance = hy.getOption("tolerance")) {
-    m <- apply(x, 1, min)
-    x <- sweep(x, 1, m, `-`)
-    m <- apply(x, 1, max)
-    x <- sweep(x, 1, m, `/`)
-    x[m < tolerance, ] <- 1
-    x
-  }
-)
+setMethod(normalize01, signature(x = "matrix"), .normalize01_mat)
 
-#' @rdname normalize01
-#' @export
-#'
-setMethod("normalize01", signature(x = "numeric"), function(x, tolerance = hy.getOption("tolerance")) {
+
+# Function -------------------------------------------------------------------
+
+.normalize01_num <- function(x, tolerance = hy.getOption("tolerance")) {
   x <- x - min(x)
 
   m <- max(x)
@@ -54,17 +54,26 @@ setMethod("normalize01", signature(x = "numeric"), function(x, tolerance = hy.ge
   } else {
     x / m
   }
-})
-
+}
 
 #' @rdname normalize01
 #' @export
 #'
-setMethod(normalize01, signature(x = "hyperSpec"), function(x, ...) {
+setMethod("normalize01", signature(x = "numeric"), .normalize01_num)
+
+
+# Function -------------------------------------------------------------------
+
+.normalize01_hy <- function(x, ...) {
   validObject(x)
   x@data$spc <- normalize01(unclass(x@data$spc), ...)
   x
-})
+}
+
+#' @rdname normalize01
+#' @export
+#'
+setMethod(normalize01, signature(x = "hyperSpec"), .normalize01_hy)
 
 
 # Unit tests -----------------------------------------------------------------

--- a/hyperSpec/R/plot.R
+++ b/hyperSpec/R/plot.R
@@ -76,6 +76,12 @@ setGeneric("plot")
   )
 }
 
+.plot_hy_miss <- function(x, y, ...) {
+  plotspc(x, ...)
+}
+
+
+
 #' Plotting `hyperSpec` objects
 #'
 #' @description
@@ -85,8 +91,6 @@ setGeneric("plot")
 #'
 #'
 #' @details
-#'
-#'
 #' Supported values for `y` are:
 #'
 #' \describe{
@@ -167,20 +171,12 @@ setGeneric("plot")
 #' plot(spc, "spcmeansd")
 #'
 #' ### Use plotspc() as a default plot function.
-setMethod(
-  "plot",
-  signature(x = "hyperSpec", y = "missing"),
-  function(x, y, ...) plotspc(x, ...)
-)
+setMethod("plot", signature(x = "hyperSpec", y = "missing"), .plot_hy_miss)
 
 ### allow choice of plot type by second argument:
 #' @rdname plot
 #' @export
-setMethod(
-  "plot",
-  signature(x = "hyperSpec", y = "character"),
-  .plot
-)
+setMethod("plot", signature(x = "hyperSpec", y = "character"), .plot)
 
 
 

--- a/hyperSpec/R/plot.R
+++ b/hyperSpec/R/plot.R
@@ -76,7 +76,7 @@ setGeneric("plot")
   )
 }
 
-.plot_hy_miss <- function(x, y, ...) {
+.plot_h_ <- function(x, y, ...) {
   plotspc(x, ...)
 }
 
@@ -171,7 +171,7 @@ setGeneric("plot")
 #' plot(spc, "spcmeansd")
 #'
 #' ### Use plotspc() as a default plot function.
-setMethod("plot", signature(x = "hyperSpec", y = "missing"), .plot_hy_miss)
+setMethod("plot", signature(x = "hyperSpec", y = "missing"), .plot_h_)
 
 ### allow choice of plot type by second argument:
 #' @rdname plot

--- a/hyperSpec/R/plot.R
+++ b/hyperSpec/R/plot.R
@@ -1,12 +1,19 @@
-### -----------------------------------------------------------------------------
+### -------------------------------------------------------------------------~
 ###
 ###  plot methods
 ###
+### -------------------------------------------------------------------------~
 
-### -----------------------------------------------------------------------------
-###
-### .plot: main switchyard for plotting functions
-###
+# Set generic ----------------------------------------------------------------
+#' @noRd
+#' @export
+setGeneric("plot")
+
+
+# Functions ------------------------------------------------------------------
+
+# .plot: main switchyard for plotting functions
+
 #' @importFrom utils modifyList
 .plot <- function(x, y, ...) {
   ##    'spc'        ... spectra
@@ -18,12 +25,15 @@
   ##    'depth'      ... concentration or time series
   ##    'spcmeansd'  ... mean spectrum +- 1 standard deviation
   ##    'spcprctile' ... median spectrum , 16th and 84th percentile
-  ##    'spcprctl5'  ... spcprctile plus 5th and 95th percentile
+  ##    'spcprctl5'  ... 'spcprctile' plus 5th and 95th percentile
 
   dots <- list(...) # to allow optional argument checks
 
   if (missing(y)) {
-    stop("second argument to plot is missing. Should be a character indicating the type of plot.")
+    stop(
+      "second argument to plot is missing. ",
+      "Should be a character indicating the type of plot."
+    )
     y <- "spc"
   }
 
@@ -66,51 +76,51 @@
   )
 }
 
-#' @noRd
-#' @export
-setGeneric("plot")
-
 #' Plotting `hyperSpec` objects
 #'
+#' @description
 #' The `plot` method for `hyperSpec` objects is a switchyard to [plotspc()],
-#' [plotmap()], and [plotc()].
+#' [plotmap()], and [plotc()]. The function also supplies some convenient
+#' abbreviations for frequently used plots (see 'Details').
 #'
-#' It also supplies some convenient abbrevations for much used plots.
 #'
-#' If `y` is missing, `plot` behaves like `plot(x, y = "spc")`.
+#' @details
+#'
 #'
 #' Supported values for `y` are:
 #'
 #' \describe{
 #'
-#' \item{"spc"}{calls [plotspc()] to produce a spectra plot.}
+#'    \item{"spc" or nothing}{calls [plotspc()] to produce a spectra plot.}
 #'
-#' \item{"spcmeansd"}{plots mean spectrum +/- one standard deviation}
+#'    \item{"spcmeansd"}{plots mean spectrum +/- one standard deviation}
 #'
-#' \item{"spcprctile"}{plots 16th, 50th, and 84th percentile spectre. If the
-#' distributions of the intensities at all wavelengths were normal, this would
-#' correspond to `"spcmeansd"`. However, this is frequently not the case.
-#' Then `"spcprctile"` gives a better impression of the spectral data set.}
+#'    \item{"spcprctile"}{plots 16th, 50th, and 84th percentile spectra. If the
+#'    distributions of the intensities at all wavelengths were normal, this
+#'    would correspond to `"spcmeansd"`. However, this is frequently not the
+#'    case.
+#'    Then `"spcprctile"` gives a better impression of the spectral data set.}
 #'
-#' \item{"spcprctl5"}{like `"spcprctile"`, but additionally the 5th and
-#' 95th percentile spectra are plotted.}
+#'    \item{"spcprctl5"}{like `"spcprctile"`, but additionally the 5th and
+#'    95th percentile spectra are plotted.}
 #'
-#' \item{"map"}{calls [plotmap()] to produce a map plot.}
+#'    \item{"map"}{calls [plotmap()] to produce a map plot.}
 #'
-#' \item{"voronoi"}{calls [plotvoronoi()] to produce a Voronoi plot (tesselated
-#' plot, like "map" for hyperSpec objects with uneven/non-rectangular grid).}
+#'    \item{"voronoi"}{calls [plotvoronoi()] to produce a Voronoi plot
+#'    (tessellated plot, like "map" for hyperSpec objects with
+#'    uneven/non-rectangular grid).}
 #'
-#' \item{"mat"}{calls [plotmat()] to produce a plot of the spectra matrix (not
-#' to be confused with [graphics::matplot()]).}
+#'    \item{"mat"}{calls [plotmat()] to produce a plot of the spectra matrix
+#'    (not to be confused with [graphics::matplot()]).}
 #'
-#' \item{"c"}{calls [plotc()] to produce a calibration (or time series,
-#'  depth-profile, or the like).}
+#'    \item{"c"}{calls [plotc()] to produce a calibration (or time series,
+#'     depth-profile, or the like).}
 #'
-#' \item{"ts"}{plots a time series: abbrevation for
-#' [`plotc(x, use.c = "t")`][`plotc()`].}
+#'    \item{"ts"}{plots a time series: abbreviation for
+#'    [`plotc(x, use.c = "t")`][`plotc()`].}
 #'
-#' \item{"depth"}{plots a depth profile:
-#'  abbrevation for [`plotc(x, use.c = "z")`][`plotc()`].}
+#'    \item{"depth"}{plots a depth profile:
+#'     abbreviation for [`plotc(x, use.c = "z")`][`plotc()`].}
 #' }
 #'
 #' @name plot-methods
@@ -118,11 +128,17 @@ setGeneric("plot")
 #' @aliases plot plot,ANY,ANY-method plot,hyperSpec,character-method
 #'   plot,hyperSpec,missing-method
 #' @docType methods
-#' @param x the `hyperSpec` object
-#' @param y selects what plot should be produced
-#' @param ... arguments passed to the respective plot function
+#'
+#' @param x `hyperSpec` object.
+#' @param y String (`"spc"`, `"map"`, etc.) to select what type of plot should
+#'       be produced. See section 'Details' for available values.
+#'       If `y` is missing, `plot(x)` behaves like `plot(x, y = "spc")`.
+#' @param ... Arguments passed to the respective plot function
+#'
 #' @author C. Beleites
-#' @seealso [plotspc()] for spectra plots (intensity over wavelength),
+#'
+#' @seealso
+#' [plotspc()] for spectra plots (intensity over wavelength),
 #'
 #' [plotmap()] for plotting maps, i.e. color coded summary value on two
 #' (usually spatial) dimensions.
@@ -150,14 +166,14 @@ setGeneric("plot")
 #' plot(spc, "spcprctile")
 #' plot(spc, "spcmeansd")
 #'
-#' ### use plotspc as default plot function
+#' ### Use plotspc() as a default plot function.
 setMethod(
   "plot",
   signature(x = "hyperSpec", y = "missing"),
   function(x, y, ...) plotspc(x, ...)
 )
 
-### allow choice of spectral or map plot by second argument
+### allow choice of plot type by second argument:
 #' @rdname plot
 #' @export
 setMethod(
@@ -165,6 +181,7 @@ setMethod(
   signature(x = "hyperSpec", y = "character"),
   .plot
 )
+
 
 
 # Unit tests -----------------------------------------------------------------
@@ -250,16 +267,16 @@ hySpc.testthat::test(.plot) <- function() {
 
 
     # Preparation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    plot_1 <- function() plot(hy_spectra)
-    plot_spc <- function() plot(hy_spectra, "spc")
-    plot_spcmeansd <- function() plot(hy_spectra, "spcmeansd")
-    plot_spcprctile <- function() plot(hy_spectra, "spcprctile")
-    plot_spcprctl5 <- function() plot(hy_spectra, "spcprctl5")
-    plot_mat <- function() plot(hy_spectra, "mat")
+    plot_1           <- function() plot(hy_spectra)
+    plot_spc         <- function() plot(hy_spectra, "spc")
+    plot_spcmeansd   <- function() plot(hy_spectra, "spcmeansd")
+    plot_spcprctile  <- function() plot(hy_spectra, "spcprctile")
+    plot_spcprctl5   <- function() plot(hy_spectra, "spcprctl5")
+    plot_mat         <- function() plot(hy_spectra, "mat")
     plot_mat_contour <- function() plot(hy_spectra, "mat", contour = TRUE)
 
-    plot_1_rev <- function() plot(hy_spectra, wl.reverse = TRUE)
-    plot_1_fill <- function() plot(hy_spectra, fill = TRUE)
+    plot_1_rev       <- function() plot(hy_spectra, wl.reverse = TRUE)
+    plot_1_fill      <- function() plot(hy_spectra, fill = TRUE)
 
 
     # Perform tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hyperSpec/R/quantile.R
+++ b/hyperSpec/R/quantile.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 .quantile <- function(x, probs = seq(0, 1, 0.5), na.rm = TRUE, names = "num", ...) {
   x <- apply(x, 2, quantile,
     probs = probs, na.rm = na.rm, names = FALSE, ...,
@@ -21,18 +23,21 @@
 }
 
 #' @rdname mean_sd
-#' @return For `hyperSpec` object, `quantile()` returns a `hyperSpec` object
-#' containing the respective quantile spectra.
+#'
 #' @param probs the quantiles, see [stats::quantile()]
 #' @param names `"pretty"` results in percentages (like [stats::quantile()]'s
 #' `names = TRUE`), `"num"` results in the row names being `as.character(probs)`
 #' (good for ggplot2 getting the order of the quantiles right). Otherwise, no
 #' names are assigned.
-#' @seealso  [stats::quantile()]
-#' @export
+#'
+#' @return For `hyperSpec` object, `quantile()` returns a `hyperSpec` object
+#' containing the respective quantile spectra.
 #'
 #' @concept stats
 #' @concept manipulation
+#'
+#' @seealso  [stats::quantile()]
+#' @export
 #'
 #' @examples
 #'

--- a/hyperSpec/R/replace.R
+++ b/hyperSpec/R/replace.R
@@ -1,4 +1,6 @@
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Function -------------------------------------------------------------------
+
 .replace <- function(x, i, j, ..., value) {
   validObject(x)
 
@@ -19,18 +21,20 @@
 
 #' @rdname extractreplace
 #' @name [<-
+#' @aliases [<-,hyperSpec-method
+#'
 #' @usage
 #'
 #' \S4method{[}{hyperSpec}(x, i, j, \dots) <- value
 #'
-#' @aliases [<-,hyperSpec-method
 #' @param value the replacement value
+#'
+#' @concept manipulation
+#'
 #' @include wl2i.R
 #' @include paste_row.R
 #'
 #' @export
-#'
-#' @concept manipulation
 #'
 #' @examples
 #' ## replacement functions
@@ -41,12 +45,14 @@
 #' spc[, "c"] <- 16:11
 #' ## be careful:
 #' plot(spc)
-#' spc [] <- 6:1
+#' spc[] <- 6:1
 #' spc$..
 #' plot(spc)
 setReplaceMethod("[", signature = signature(x = "hyperSpec"), .replace)
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Function -------------------------------------------------------------------
+
 .replace2 <- function(x, i, j, l, wl.index = FALSE, ..., value) {
   validObject(x)
 
@@ -73,7 +79,7 @@ setReplaceMethod("[", signature = signature(x = "hyperSpec"), .replace)
         "or a n by 2 matrix."
       )
     }
-  } else {# index by row and columns
+  } else { # index by row and columns
     if (!missing(j)) {
       stop(
         "The spectra matrix may only be indexed by i (spectra) and l",
@@ -95,20 +101,21 @@ setReplaceMethod("[", signature = signature(x = "hyperSpec"), .replace)
 
 
 #' @rdname extractreplace
+#' @name [[<-
+#' @aliases [[<-,hyperSpec-method
+#'
 #' @usage
 #'
 #' \S4method{[[}{hyperSpec}(x, i, j, l, wl.index = FALSE, \dots) <- value
 #'
-#' @aliases [[<-,hyperSpec-method
-#' @name [[<-
-#'
-#' @export
 #'
 #' @concept manipulation
 #'
 #' @include wl2i.R
+#' @export
+#'
 #' @examples
-#' spc <- flu [, , 405 ~ 410]
+#' spc <- flu[, , 405 ~ 410]
 #' spc[[]]
 #' spc[[3]] <- -spc[[3]]
 #' spc[[]]
@@ -117,7 +124,7 @@ setReplaceMethod("[", signature = signature(x = "hyperSpec"), .replace)
 #' spc[[, , 405 ~ 410]] <- -spc[[, , 405 ~ 410]]
 #'
 #' ## indexing with logical matrix
-#' spc <- flu [, , min ~ 410]
+#' spc <- flu[, , min ~ 410]
 #' spc < 125
 #' spc[[spc < 125]] <- NA
 #' spc[[]]
@@ -135,7 +142,8 @@ setReplaceMethod("[", signature = signature(x = "hyperSpec"), .replace)
 setReplaceMethod("[[", signature = signature(x = "hyperSpec"), .replace2)
 
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Function -------------------------------------------------------------------
+
 .replace_dollar <- function(x, name, value) {
   validObject(x)
 
@@ -173,15 +181,16 @@ setReplaceMethod("[[", signature = signature(x = "hyperSpec"), .replace2)
 
 
 #' @rdname extractreplace
+#' @name $<-
+#' @aliases $<-,hyperSpec-method
+#'
 #' @usage
 #'
 #' \S4method{$}{hyperSpec}(x, name) <- value
 #'
-#' @aliases $<-,hyperSpec-method
-#' @name $<-
-#' @export
-#'
 #' @concept manipulation
+#'
+#' @export
 #'
 #' @examples
 #' spc$.
@@ -192,6 +201,7 @@ setReplaceMethod("$", signature = signature(x = "hyperSpec"), .replace_dollar)
 
 
 # Unit tests -----------------------------------------------------------------
+
 hySpc.testthat::test(.replace) <- function() {
   ## replacement functions
   context("replace")
@@ -254,12 +264,11 @@ hySpc.testthat::test(.replace) <- function() {
     spc <- spc0
     expect_silent(spc$z <- list(1:6, "z / a.u."))
     expect_equal(labels(spc, "z"),   "z / a.u.")
-    expect_true("z" %in%  colnames(spc))
+    expect_true("z" %in% colnames(spc))
 
     spc <- spc0
     expect_silent(spc$.. <- NULL)
     expect_equal(ncol(spc$..), 0) # empty data frame.
     expect_equal(ncol(spc),    1) # only "spc" column is left.
   })
-
 }

--- a/hyperSpec/R/sample.R
+++ b/hyperSpec/R/sample.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 .sample <- function(x, size, replace = FALSE, prob = NULL) {
   validObject(x)
 
@@ -7,6 +9,9 @@
 
   x[s]
 }
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.sample) <- function() {
   context(".sample")
@@ -33,7 +38,7 @@ hySpc.testthat::test(.sample) <- function() {
 }
 
 
-
+# Function -------------------------------------------------------------------
 
 #' Random samples and permutations
 #'
@@ -42,22 +47,25 @@ hySpc.testthat::test(.sample) <- function() {
 #'
 #' @rdname sample
 #' @docType methods
+#'
 #' @param x The hyperSpec object, data.frame or matrix to sample fromto sample from
 #' @param size positive integer giving the number of spectra (rows) to choose.
 #' @param replace Should sampling be with replacement?
 #' @param prob A vector of probability weights for obtaining the elements of
-#'   the vector being sampled.
+#'        the vector being sampled.
+#'
 #' @return a hyperSpec object, data.frame or matrix with `size` rows for
 #'        `sample`, and an integer vector for `isample` that is suitable for
 #'        indexing (into the spectra) of x.
-#' @author C. Beleites
-#' @seealso [base::sample()]
 #'
-#' @export
+#' @author C. Beleites
 #'
 #' @keywords methods distribution
 #' @concept stats
 #'
+#' @export
+#'
+#' @seealso [base::sample()]
 #' @examples
 #'
 #' sample(flu, 3)
@@ -71,6 +79,11 @@ hySpc.testthat::test(.sample) <- function() {
 #'   lines.args = list(lwd = 2)
 #' )
 setMethod("sample", signature = signature(x = "hyperSpec"), .sample)
+
+
+
+
+# Function -------------------------------------------------------------------
 
 #' `isample()` returns an vector of indices, `sample()` returns the
 #' corresponding hyperSpec object.
@@ -91,6 +104,9 @@ isample <- function(x, size = nrow(x), replace = FALSE, prob = NULL) {
 
   sample.int(nrow(x), size = size, replace = replace, prob = prob)
 }
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(isample) <- function() {
   context("isample")
@@ -115,6 +131,10 @@ hySpc.testthat::test(isample) <- function() {
   })
 }
 
+
+# Function -------------------------------------------------------------------
+
+
 .sample.data.frame <- function(x, size, replace = FALSE, prob = NULL, drop = FALSE) {
   if (missing(size)) size <- nrow(x)
   x[sample.int(nrow(x), size = size, replace = replace, prob = prob), , drop = drop]
@@ -129,6 +149,9 @@ hySpc.testthat::test(isample) <- function() {
 #' @examples
 #' sample(cars, 2)
 setMethod("sample", signature = signature(x = "data.frame"), .sample.data.frame)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.sample.data.frame) <- function() {
   context("sample data.frame")
@@ -158,6 +181,7 @@ hySpc.testthat::test(.sample.data.frame) <- function() {
 }
 
 
+# Function -------------------------------------------------------------------
 
 .sample.matrix <- function(x, size, replace = FALSE, prob = NULL, drop = FALSE) {
   if (missing(size)) size <- nrow(x)
@@ -172,6 +196,9 @@ hySpc.testthat::test(.sample.data.frame) <- function() {
 #' @examples
 #' sample(matrix(1:24, 6), 2)
 setMethod("sample", signature = signature(x = "matrix"), .sample.matrix)
+
+
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(.sample.matrix) <- function() {
   context(".sample.matrix")

--- a/hyperSpec/R/scale.R
+++ b/hyperSpec/R/scale.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 .scale <- function(x, center = TRUE, scale = TRUE) {
   validObject(x)
 
@@ -19,6 +21,7 @@
 #' @rdname scale
 #' @aliases scale scale-methods scale,hyperSpec-method
 #' @docType methods
+#'
 #' @param x the `hyperSpec` object
 #' @param center if `TRUE`, the data is centered to `colMeans(x)`, `FALSE`
 #' suppresses centering. Alternatively, an object that can be converted to numeric of length
@@ -28,6 +31,8 @@
 #' `FALSE` suppresses scaling. Alternatively, an object that can be converted to numeric of
 #' length `nwl(x)` by [base::as.matrix()] (e.g. hyperSpec object containing 1 spectrum)
 #' can specify the center spectrum.
+#'
+#'
 #' @return the centered & scaled `hyperSpec` object
 #' @author C. Beleites
 #' @seealso [base::scale()]
@@ -60,6 +65,7 @@ setMethod("scale", signature = signature(x = "hyperSpec"), .scale)
 
 
 # Unit tests -----------------------------------------------------------------
+
 hySpc.testthat::test(.scale) <- function() {
   context("scale")
 

--- a/hyperSpec/R/split.R
+++ b/hyperSpec/R/split.R
@@ -1,3 +1,6 @@
+
+# Function -------------------------------------------------------------------
+
 .split <- function(x, f, drop = TRUE) {
   validObject(x)
 
@@ -22,12 +25,14 @@
 #' @rdname split
 #' @aliases split split-methods split,ANY-method split,hyperSpec-method
 #' @docType methods
+#'
 #' @param x the `hyperSpec` object
 #' @param f a factor giving the grouping (or a variable that can be converted
-#'   into a factor by `as.factor`)
-#' @param drop if `TRUE`, levels of`f` that do not occur are
-#'   dropped.
+#'        into a factor by `as.factor`)
+#' @param drop if `TRUE`, levels of`f` that do not occur are dropped.
+#'
 #' @return A list of `hyperSpec` objects.
+#'
 #' @author C. Beleites
 #' @seealso [base::split()]
 #'

--- a/hyperSpec/R/subset.R
+++ b/hyperSpec/R/subset.R
@@ -1,3 +1,4 @@
+# Function -------------------------------------------------------------------
 
 .subset <- function(x, ...) {
   validObject(x)
@@ -11,12 +12,16 @@
 #' Subset `hyperSpec` object
 #'
 #' @name subset
+#' @aliases subset subset,hyperSpec-method
+#' @docType methods
+#'
 #' @param x `hyperSpec` object
 #' @param ... handed to [base::subset()] (data.frame method)
-#' @docType methods
-#' @aliases subset subset,hyperSpec-method
+#'
 #' @return `hyperSpec` object containing the respective subset of spectra.
+#'
 #' @author Claudia Beleites
+#'
 #' @seealso [base::subset()]
 #'
 #' @export
@@ -24,3 +29,8 @@
 #' @concept manipulation
 #'
 setMethod("subset", signature = signature(x = "hyperSpec"), .subset)
+
+
+# Unit tests -----------------------------------------------------------------
+
+# TODO: add unit tests

--- a/hyperSpec/R/sweep.R
+++ b/hyperSpec/R/sweep.R
@@ -1,3 +1,5 @@
+# Function -------------------------------------------------------------------
+
 .sweep <- function(x, MARGIN, STATS, FUN = "-",
                    check.margin = TRUE, ...) {
   validObject(x)
@@ -21,9 +23,10 @@
 #'
 #' [base::sweep()] for `hyperSpec` objects.
 #'
+#'
 #' Calls [base::sweep()] for the spectra matrix.
 #'
-#' `sweep` is useful for some spectra pre-processing, like offset
+#' `sweep()` is useful for some spectra pre-processing, like offset
 #' correction, subtraction of background spectra, and normalization of the
 #' spectra.
 #'
@@ -31,13 +34,14 @@
 #' @rdname sweep
 #' @aliases sweep-methods sweep,hyperSpec-method
 #' @docType methods
+#'
 #' @param x a `hyperSpec object.`
 #' @param MARGIN direction of the spectra matrix that `STATS` goees
-#'   along.
+#'        along.
 #' @param STATS the summary statistic to sweep out. Either a vector or a
-#'   `hyperSpec` object.
+#'        `hyperSpec` object.
 #'
-#' hyperSpec offers a non-standard convenience function: if `STATS` is a
+#' \pkg{hyperSpec} offers a non-standard convenience function: if `STATS` is a
 #'   function, this function is applied first (with the same `MARGIN`) to
 #'   compute the statistic. However, no further arguments to the apply
 #'   function can be given.  See the examples.
@@ -47,7 +51,9 @@
 #'   `x`.  Set to `FALSE` for a small speed gain when you
 #'   *know* that dimensions match.
 #' @param ... further arguments for `FUN`
+#'
 #' @return A `hyperSpec` object.
+#'
 #' @author C. Beleites
 #' @seealso [base::sweep()]
 #'

--- a/hyperSpec/R/vandermonde.R
+++ b/hyperSpec/R/vandermonde.R
@@ -1,23 +1,25 @@
+# Function -------------------------------------------------------------------
+
 #' Function evaluation on `hyperSpec` objects
 #'
-#' `vandermonde()` generates Vandermonde matrices, the `hyperSpec` method
-#' generates a `hyperSpec` object containing the Vandermonde matrix of the
-#' wavelengths of a `hyperSpec` object.
+#' Function `vanderMonde()` generates Vandermonde matrices, the `hyperSpec`
+#' method generates a `hyperSpec` object containing the Vandermonde matrix
+#' of the wavelengths of a `hyperSpec` object.
 #'
 #' It is often numerically preferable to map `wl(x)` to \[0, 1\], see the
 #' example.
 #'
+#' @name vanderMonde
+#' @rdname vanderMonde
+#' @concept data generation
+#'
 #' @param x object to evaluate the polynomial on
 #' @param order of the polynomial
 #'
-#' @rdname vanderMonde
 #' @return Vandermonde matrix
 #' @author C. Beleites
 #'
 #' @export
-#'
-#' @concept data generation
-#'
 
 vanderMonde <- function(x, order, ...) {
   if (nargs() > 2) {
@@ -27,39 +29,54 @@ vanderMonde <- function(x, order, ...) {
   outer(x, 0:order, `^`)
 }
 
+# Set generic ----------------------------------------------------------------
+
 #' @noRd
 setGeneric("vanderMonde")
 
-#' @param normalize.wl function to transform the wavelengths before evaluating the polynomial (or
-#' other function). [hyperSpec::normalize01()] maps the wavelength range to the interval
-#' \[0, 1\]. Use [base::I()] to turn off.
-#' @param ... hyperSpec method: further arguments to [hyperSpec::decomposition()]
-#' @return hyperSpec method: hyperSpec object containing Vandermonde matrix as spectra and an additional column `$.vdm.order$ giving the order of each spectrum (term).
+
+# Function -------------------------------------------------------------------
+
+.vanderMonde <- function(x, order, ..., normalize.wl = normalize01) {
+  validObject(x)
+
+  wl <- normalize.wl(x@wavelength)
+
+  x <- decomposition(x, t(vanderMonde(wl, order)),
+    scores = FALSE, ...
+  )
+  x$.vdm.order <- 0:order
+  x
+}
+
 #' @rdname vanderMonde
-#' @seealso [hyperSpec::wl_eval()] for calculating arbitrary functions of the wavelength,
+#'
+#' @param normalize.wl function to transform the wavelengths before evaluating
+#'        the polynomial (or other function). [hyperSpec::normalize01()] maps
+#'        the wavelength range to the interval \[0, 1\]. Use [base::I()] to
+#'        turn off.
+#' @param ... hyperSpec method: further arguments to [hyperSpec::decomposition()]
+#'
+#' @return `hyperSpec` method: hyperSpec object containing Vandermonde matrix
+#'         as spectra and an additional column `$.vdm.order` giving the order
+#'         of each spectrum (term).
+#'
+#' @seealso
+#' [hyperSpec::wl_eval()] for calculating arbitrary functions of the wavelength
 #'
 #' [hyperSpec::normalize01()]
-#' @export
 #'
 #' @concept data generation
+#'
+#' @export
 #'
 #' @examples
 #' plot(vanderMonde(flu, 2))
 #' plot(vanderMonde(flu, 2, normalize.wl = I))
-setMethod("vanderMonde",
-  signature = signature(x = "hyperSpec"),
-  function(x, order, ..., normalize.wl = normalize01) {
-    validObject(x)
+setMethod("vanderMonde", signature = signature(x = "hyperSpec"), .vanderMonde)
 
-    wl <- normalize.wl(x@wavelength)
 
-    x <- decomposition(x, t(vanderMonde(wl, order)),
-      scores = FALSE, ...
-    )
-    x$.vdm.order <- 0:order
-    x
-  }
-)
+# Unit tests -----------------------------------------------------------------
 
 hySpc.testthat::test(vanderMonde) <- function() {
   context("vanderMonde")
@@ -85,8 +102,7 @@ hySpc.testthat::test(vanderMonde) <- function() {
 
     tmp <- vanderMonde(paracetamol, 3, normalize.wl = normalize01)
     dimnames(tmp$spc) <- NULL
-    expect_equal(tmp[[]], t(vanderMonde(normalize01(
-      wl(paracetamol)
-    ), 3)))
+    expect_equal(tmp[[]], t(vanderMonde(normalize01(wl(paracetamol)), 3))
+    )
   })
 }

--- a/hyperSpec/R/vandermonde.R
+++ b/hyperSpec/R/vandermonde.R
@@ -1,4 +1,4 @@
-# Function -------------------------------------------------------------------
+# Set generic ----------------------------------------------------------------
 
 #' Function evaluation on `hyperSpec` objects
 #'
@@ -17,6 +17,7 @@
 #' @param order of the polynomial
 #'
 #' @return Vandermonde matrix
+#'
 #' @author C. Beleites
 #'
 #' @export
@@ -28,8 +29,6 @@ vanderMonde <- function(x, order, ...) {
 
   outer(x, 0:order, `^`)
 }
-
-# Set generic ----------------------------------------------------------------
 
 #' @noRd
 setGeneric("vanderMonde")


### PR DESCRIPTION
**UPDATED**

In this PR:

1. **MAIN.** Anonymous functions (in `setMethod()` and `setReplaceMethod()`) are converted into hidden functions (so the lines of code re-arranged accordingly so that functions were documented properly). Closes #238
2. **ADDITIONAL.** Some documentation style updates are also introduced in the files that were touched. E.g.:
    a. the position of some lines of code were switched;
    b. some lines in documentation re-indented;
    c. some typos were fixed;
    d. sections "Set generic", "Function" and "Unit tests" were  added so that it was easier to navigate files in RStudio; 
    e. Most of the parts of code rearranged to meet this order:
                - setGeneric() statement
                - definition of hidden function
                - setMethod() or set RepaceMethod() statement
                - unit tests
    f. in some places, where unit sets are missing, **`# TODO`** comments were added to indicate this. These comments have to be solved in future PRs.
    


